### PR TITLE
Feature/NT-12 role based authorization

### DIFF
--- a/src/NextTurn.API/Controllers/AuthController.cs
+++ b/src/NextTurn.API/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using NextTurn.API.Models.Auth;
@@ -47,6 +48,7 @@ public sealed class AuthController : ControllerBase
     ///   422 — input validation failed (e.g. missing field, weak password)
     /// </remarks>
     [HttpPost("register")]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
@@ -80,6 +82,7 @@ public sealed class AuthController : ControllerBase
     ///   429 — rate limit exceeded
     /// </remarks>
     [HttpPost("login")]
+    [AllowAnonymous]
     [EnableRateLimiting("login")]
     [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/NextTurn.API/Controllers/RoleProbeController.cs
+++ b/src/NextTurn.API/Controllers/RoleProbeController.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace NextTurn.API.Controllers;
+
+/// <summary>
+/// SCAFFOLDING ONLY — remove or gate behind a feature flag before production.
+///
+/// Provides four lightweight endpoints whose sole purpose is to verify that the
+/// authorization policy matrix is enforced correctly. Each endpoint is guarded by
+/// one of the four named policies defined in Program.cs and returns the caller's
+/// role so integration tests can confirm both the HTTP status and the identity.
+///
+/// These endpoints have no business logic and carry no sensitive data.
+/// They exist to give integration tests (NT-12-4) a stable, purpose-built surface
+/// without coupling authorization tests to domain feature endpoints (Sprint 2+).
+/// </summary>
+[ApiController]
+[Route("api/probe")]
+public sealed class RoleProbeController : ControllerBase
+{
+    /// <summary>
+    /// Accessible by any authenticated user (User, Staff, OrgAdmin, SystemAdmin).
+    /// </summary>
+    [HttpGet("user")]
+    [Authorize(Policy = "IsUser")]
+    [ProducesResponseType(typeof(ProbeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IActionResult UserProbe()
+        => Ok(new ProbeResponse(CallerRole()));
+
+    /// <summary>
+    /// Accessible by Staff, OrgAdmin, and SystemAdmin.
+    /// </summary>
+    [HttpGet("staff")]
+    [Authorize(Policy = "IsStaff")]
+    [ProducesResponseType(typeof(ProbeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IActionResult StaffProbe()
+        => Ok(new ProbeResponse(CallerRole()));
+
+    /// <summary>
+    /// Accessible by OrgAdmin and SystemAdmin.
+    /// </summary>
+    [HttpGet("org-admin")]
+    [Authorize(Policy = "IsOrgAdmin")]
+    [ProducesResponseType(typeof(ProbeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IActionResult OrgAdminProbe()
+        => Ok(new ProbeResponse(CallerRole()));
+
+    /// <summary>
+    /// Accessible by SystemAdmin only.
+    /// </summary>
+    [HttpGet("system-admin")]
+    [Authorize(Policy = "IsSystemAdmin")]
+    [ProducesResponseType(typeof(ProbeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IActionResult SystemAdminProbe()
+        => Ok(new ProbeResponse(CallerRole()));
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private string CallerRole()
+        => User.FindFirstValue("role") ?? "unknown";
+}
+
+/// <summary>Response body returned by all probe endpoints.</summary>
+public sealed record ProbeResponse(string Role);

--- a/src/NextTurn.API/Middleware/TenantMiddleware.cs
+++ b/src/NextTurn.API/Middleware/TenantMiddleware.cs
@@ -55,6 +55,17 @@ public sealed class TenantMiddleware
         // ── 3. Reject if unresolved ───────────────────────────────────────────
         if (tenantId == null)
         {
+            // If the user has no valid identity (no token / invalid token), pass the
+            // request through so UseAuthorization() can return the correct 401.
+            // Returning 400 here would mask the authentication failure.
+            if (context.User.Identity?.IsAuthenticated != true)
+            {
+                await _next(context);
+                return;
+            }
+
+            // Authenticated user with a token that lacks a 'tid' claim — that means
+            // a malformed token slipped through, which is a bad request (not a 401).
             _logger.LogWarning(
                 "Request to {Method} {Path} rejected: TenantId could not be resolved " +
                 "from JWT claim '{Claim}' or header '{Header}'.",

--- a/src/NextTurn.API/Program.cs
+++ b/src/NextTurn.API/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using NextTurn.API.Middleware;
@@ -32,6 +33,11 @@ builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
+        // Disable ASP.NET Core's default claim-type renaming so the raw JWT claim
+        // names (e.g. "role", "sub") are preserved. Without this, "role" gets
+        // remapped to the long WS-Federation claim URI, breaking RequireClaim("role").
+        options.MapInboundClaims = false;
+
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer           = true,
@@ -46,6 +52,39 @@ builder.Services
             ClockSkew                = TimeSpan.Zero, // no grace period — tokens expire exactly at 'exp'
         };
     });
+
+// ── Authorization policies ──────────────────────────────────────────────────────
+// Named policies backed by the "role" JWT claim (preserved as-is via MapInboundClaims = false).
+// Hierarchy: SystemAdmin ⊃ OrgAdmin ⊃ Staff ⊃ User.
+// A global FallbackPolicy requires every endpoint to be authenticated unless
+// explicitly decorated with [AllowAnonymous] (register, login).
+builder.Services.AddAuthorization(options =>
+{
+    // Any authenticated user
+    options.AddPolicy("IsUser", policy =>
+        policy.RequireAuthenticatedUser()
+              .RequireClaim("role", "User", "Staff", "OrgAdmin", "SystemAdmin"));
+
+    // Staff and above
+    options.AddPolicy("IsStaff", policy =>
+        policy.RequireAuthenticatedUser()
+              .RequireClaim("role", "Staff", "OrgAdmin", "SystemAdmin"));
+
+    // Org admins and above
+    options.AddPolicy("IsOrgAdmin", policy =>
+        policy.RequireAuthenticatedUser()
+              .RequireClaim("role", "OrgAdmin", "SystemAdmin"));
+
+    // Platform-wide admin only
+    options.AddPolicy("IsSystemAdmin", policy =>
+        policy.RequireAuthenticatedUser()
+              .RequireClaim("role", "SystemAdmin"));
+
+    // Global fallback: every endpoint requires a valid JWT unless [AllowAnonymous] is present.
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+});
 
 // ── Rate limiting ─────────────────────────────────────────────────────────────
 // Sliding window: max 10 requests per 60-second window per client IP.

--- a/src/NextTurn.API/Program.cs
+++ b/src/NextTurn.API/Program.cs
@@ -120,11 +120,13 @@ app.UseHttpsRedirection();
 app.UseMiddleware<DomainExceptionMiddleware>();
 app.UseMiddleware<ValidationExceptionMiddleware>();
 
+app.UseAuthentication();
+
 // Resolve TenantId from JWT claim 'tid' or X-Tenant-Id header.
-// Placed after exception middlewares so tenant errors are also caught properly.
+// Must run AFTER UseAuthentication() so context.User is populated from the JWT
+// before TenantMiddleware attempts to read the 'tid' claim.
 app.UseMiddleware<TenantMiddleware>();
 
-app.UseAuthentication();
 app.UseAuthorization();
 app.UseRateLimiter();
 app.MapControllers();

--- a/src/NextTurn.Infrastructure/Auth/HttpTenantContext.cs
+++ b/src/NextTurn.Infrastructure/Auth/HttpTenantContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
 using NextTurn.Infrastructure.Common;
 
 namespace NextTurn.Infrastructure.Auth;
@@ -52,9 +53,8 @@ public sealed class HttpTenantContext : ITenantContext
                 return tenantId;
             }
 
-            throw new InvalidOperationException(
-                "TenantId has not been set. Ensure TenantMiddleware is registered " +
-                "in the request pipeline before any endpoint that requires a tenant context.");
+            throw new DomainException(
+                "A valid tenant identifier must be provided via the 'X-Tenant-Id' header or a JWT 'tid' claim.");
         }
     }
 }

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -2,18 +2,34 @@
  * App — root router.
  *
  * Routes:
- *  /                    → WelcomePage (landing)
- *  /register/:tenantId  → RegisterPage
- *  /login/:tenantId     → LoginPage       (NT-59)
- *  /dashboard/:tenantId → ProtectedRoute → DashboardPage  (NT-60)
- *  *                    → redirect to /
+ *  /                       → WelcomePage (landing)
+ *  /register/:tenantId     → RegisterPage
+ *  /login/:tenantId        → LoginPage
+ *  /dashboard/:tenantId    → ProtectedRoute (any role)  → DashboardPage
+ *  /staff/:tenantId        → ProtectedRoute (Staff+)    → stub
+ *  /admin/:tenantId        → ProtectedRoute (OrgAdmin+) → stub
+ *  /system/:tenantId       → ProtectedRoute (SystemAdmin) → stub
+ *  /access-denied          → AccessDeniedPage
+ *  *                       → redirect to /
+ *
+ * The /staff, /admin, /system routes are stubs (NT-12-66) — they exist solely
+ * to prove the role guards work in tests and during the sprint demo.
+ * Real feature pages will replace the stubs in Sprint 2+.
  */
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { WelcomePage } from './pages/Welcome'
 import { RegisterPage } from './pages/Register'
 import { LoginPage } from './pages/Login'
 import { DashboardPage } from './pages/Dashboard'
+import { AccessDeniedPage } from './pages/AccessDenied'
 import { ProtectedRoute } from './components/ProtectedRoute'
+
+// ── Role-restricted stub pages ────────────────────────────────────────────────
+// Temporary placeholders so the route guards have real targets during NT-12
+// testing and the sprint demo. Replace with real feature pages in Sprint 2+.
+const StaffStub     = () => <main style={{ padding: '2rem' }}><h1>Staff Area — Sprint 2</h1></main>
+const OrgAdminStub  = () => <main style={{ padding: '2rem' }}><h1>Admin Area — Sprint 2</h1></main>
+const SystemAdminStub = () => <main style={{ padding: '2rem' }}><h1>System Area — Sprint 2</h1></main>
 
 function App() {
   return (
@@ -21,6 +37,8 @@ function App() {
       <Route path="/" element={<WelcomePage />} />
       <Route path="/register/:tenantId" element={<RegisterPage />} />
       <Route path="/login/:tenantId" element={<LoginPage />} />
+
+      {/* Any authenticated user */}
       <Route
         path="/dashboard/:tenantId"
         element={
@@ -29,6 +47,38 @@ function App() {
           </ProtectedRoute>
         }
       />
+
+      {/* Staff and above */}
+      <Route
+        path="/staff/:tenantId"
+        element={
+          <ProtectedRoute allowedRoles={['Staff', 'OrgAdmin', 'SystemAdmin']}>
+            <StaffStub />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* OrgAdmin and above */}
+      <Route
+        path="/admin/:tenantId"
+        element={
+          <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
+            <OrgAdminStub />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* SystemAdmin only */}
+      <Route
+        path="/system/:tenantId"
+        element={
+          <ProtectedRoute allowedRoles={['SystemAdmin']}>
+            <SystemAdminStub />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route path="/access-denied" element={<AccessDeniedPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/src/web/src/api/__tests__/apiClient.test.ts
+++ b/src/web/src/api/__tests__/apiClient.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the 401 interceptor in client.ts (NT-12-68).
+ *
+ * Strategy:
+ *  - Import the real apiClient so the interceptor is live
+ *  - Replace the axios adapter with a per-test fake that returns controlled responses
+ *  - Spy on window.location.replace to assert redirects
+ *  - Mock clearToken and getTokenPayload from authToken
+ *
+ * Coverage:
+ *  1. 401 response → clearToken() is called
+ *  2. 401 with tid in token → redirects to /login/:tid?reason=session_expired
+ *  3. 401 with no token payload → redirects to /?reason=session_expired
+ *  4. 403 response → NOT redirected, error propagates
+ *  5. 200 response → passes through, no redirect
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { InternalAxiosRequestConfig, AxiosResponse } from 'axios'
+
+// ---------------------------------------------------------------------------
+// Mock authToken BEFORE importing client so the interceptor captures the mocks
+// ---------------------------------------------------------------------------
+vi.mock('../../utils/authToken', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/authToken')>()
+  return { ...actual, clearToken: vi.fn(), getTokenPayload: vi.fn() }
+})
+
+import * as authToken from '../../utils/authToken'
+import { apiClient } from '../client'
+import type { TokenPayload } from '../../utils/authToken'
+
+const mockClearToken      = vi.mocked(authToken.clearToken)
+const mockGetTokenPayload = vi.mocked(authToken.getTokenPayload)
+
+const TENANT = 'aabbccdd-0000-0000-0000-000000000001'
+
+const BASE_PAYLOAD: TokenPayload = {
+  sub: 'user-1', email: 'alice@example.com', name: 'Alice Smith',
+  role: 'User', tid: TENANT, exp: 9999999999, iat: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Replace the apiClient adapter with one that resolves or rejects synchronously. */
+function fakeAdapter(status: number) {
+  apiClient.defaults.adapter = async (
+    config: InternalAxiosRequestConfig
+  ): Promise<AxiosResponse> => {
+    if (status >= 200 && status < 300) {
+      return {
+        data: { ok: true },
+        status,
+        statusText: 'OK',
+        headers: {},
+        config,
+      }
+    }
+    // Simulate an AxiosError for non-2xx
+    const err = Object.assign(new Error(`Request failed with status ${status}`), {
+      isAxiosError: true,
+      response: {
+        data: {},
+        status,
+        statusText: status === 401 ? 'Unauthorized' : status === 403 ? 'Forbidden' : 'Error',
+        headers: {},
+        config,
+      },
+      config,
+    })
+    return Promise.reject(err)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// window.location.replace spy
+// ---------------------------------------------------------------------------
+// jsdom does not allow direct assignment of window.location, so we use
+// Object.defineProperty to replace `replace` with a spy.
+let replaceSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  replaceSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { ...window.location, replace: replaceSpy },
+  })
+  mockGetTokenPayload.mockReturnValue(BASE_PAYLOAD)
+})
+
+afterEach(() => {
+  // Restore the real adapter
+  apiClient.defaults.adapter = undefined
+})
+
+// ---------------------------------------------------------------------------
+// 401 — intercept and redirect
+// ---------------------------------------------------------------------------
+describe('apiClient — 401 interceptor', () => {
+  it('calls clearToken when a 401 response is received', async () => {
+    fakeAdapter(401)
+    await apiClient.get('/test').catch(() => {})
+    expect(mockClearToken).toHaveBeenCalledOnce()
+  })
+
+  it('redirects to /login/:tid?reason=session_expired when tid is in the token', async () => {
+    fakeAdapter(401)
+    await apiClient.get('/test').catch(() => {})
+    expect(replaceSpy).toHaveBeenCalledWith(`/login/${TENANT}?reason=session_expired`)
+  })
+
+  it('redirects to /?reason=session_expired when token payload is null', async () => {
+    mockGetTokenPayload.mockReturnValue(null)
+    fakeAdapter(401)
+    await apiClient.get('/test').catch(() => {})
+    expect(replaceSpy).toHaveBeenCalledWith('/?reason=session_expired')
+  })
+
+  it('still rejects the promise after redirecting', async () => {
+    fakeAdapter(401)
+    await expect(apiClient.get('/test')).rejects.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Non-401 — pass through
+// ---------------------------------------------------------------------------
+describe('apiClient — non-401 errors', () => {
+  it('does NOT call clearToken on a 403 response', async () => {
+    fakeAdapter(403)
+    await apiClient.get('/test').catch(() => {})
+    expect(mockClearToken).not.toHaveBeenCalled()
+  })
+
+  it('does NOT redirect on a 403 response', async () => {
+    fakeAdapter(403)
+    await apiClient.get('/test').catch(() => {})
+    expect(replaceSpy).not.toHaveBeenCalled()
+  })
+
+  it('propagates the 403 error to the caller', async () => {
+    fakeAdapter(403)
+    await expect(apiClient.get('/test')).rejects.toMatchObject({
+      response: { status: 403 },
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 200 — happy path
+// ---------------------------------------------------------------------------
+describe('apiClient — 2xx responses', () => {
+  it('returns the response on a 200 response without redirecting', async () => {
+    fakeAdapter(200)
+    const result = await apiClient.get('/test')
+    expect(result.status).toBe(200)
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(mockClearToken).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -2,10 +2,19 @@
  * Axios instance — base URL from environment variable.
  * The Vite dev-server proxy rewrites /api → http://localhost:5000/api
  * so this works identically in dev and production.
+ *
+ * Global 401 interceptor (NT-12-68):
+ *   A 401 from any API call means the token has expired or been tampered with.
+ *   The interceptor clears the token and hard-navigates to the login page with
+ *   ?reason=session_expired so LoginPage can show an informational banner.
+ *   window.location.replace() is used intentionally — we're outside React's
+ *   component tree here, and a full navigation ensures stale in-memory state
+ *   is wiped before the login page mounts.
  */
 import axios from 'axios'
 import type { AxiosError } from 'axios'
 import type { ApiError, ProblemDetails } from '../types/api'
+import { clearToken, getTokenPayload } from '../utils/authToken'
 
 export const apiClient = axios.create({
   baseURL: '/api',
@@ -14,6 +23,33 @@ export const apiClient = axios.create({
   },
   timeout: 15_000,
 })
+
+// ── Global 401 interceptor ───────────────────────────────────────────────────
+// Catches 401 responses from any endpoint, clears the stored token, and
+// redirects to the appropriate login page with ?reason=session_expired.
+// 403 responses are intentionally NOT handled here — they are caught by
+// individual call sites (or propagate as ApiError to the ProtectedRoute guard).
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      // Try to get the tenant from the (now-invalid) token so we redirect to
+      // the right organisation's login page. Fall back to '/' if not available.
+      const payload = getTokenPayload()
+      const tid = payload?.tid
+
+      clearToken()
+
+      const loginPath = tid
+        ? `/login/${tid}?reason=session_expired`
+        : `/?reason=session_expired`
+
+      // Hard navigation — clears React state, ensures a clean login mount.
+      window.location.replace(loginPath)
+    }
+    return Promise.reject(error)
+  }
+)
 
 /**
  * Extracts a friendly ApiError from any Axios error.

--- a/src/web/src/components/ProtectedRoute.tsx
+++ b/src/web/src/components/ProtectedRoute.tsx
@@ -1,45 +1,62 @@
 /**
- * ProtectedRoute — wraps any route that requires authentication.
+ * ProtectedRoute — wraps any route that requires authentication and optionally
+ * a specific role.
  *
  * Usage in App.tsx:
- *   <Route
- *     path="/dashboard/:tenantId"
- *     element={
- *       <ProtectedRoute>
- *         <DashboardPage />
- *       </ProtectedRoute>
- *     }
- *   />
+ *   // Any authenticated user
+ *   <ProtectedRoute><DashboardPage /></ProtectedRoute>
  *
- * If the user is NOT authenticated:
- *   → Navigate to /login/:tenantId (preserving the tenantId from the URL so
- *     the user lands on the correct organisation's login page after logging in)
+ *   // Staff or higher only
+ *   <ProtectedRoute allowedRoles={['Staff', 'OrgAdmin', 'SystemAdmin']}>
+ *     <StaffPage />
+ *   </ProtectedRoute>
  *
- * Why useParams here works:
- *   ProtectedRoute is the *element* of a Route that declares :tenantId, so it
- *   is rendered inside that route's context and useParams() can see the param.
+ * Guard logic (in order):
+ *   1. Not authenticated (missing / expired token)
+ *      → Navigate to /login/:tenantId
+ *   2. Authenticated but role not in allowedRoles
+ *      → Navigate to /access-denied
+ *   3. Authenticated + role allowed (or no restriction)
+ *      → Render children
+ *
+ * Why useParams works here:
+ *   ProtectedRoute is the element of a Route that declares :tenantId, so it
+ *   is rendered inside that route's context and useParams() can read the param.
  *
  * Sprint 2 hardening (NT-XX):
- *   - Add `returnTo` state to the Navigate so the user is redirected back to
- *     their original destination after a successful login.
+ *   - Add `returnTo` state to the Navigate so the user is redirected back after login.
  *   - Move token storage from localStorage to in-memory + httpOnly cookie.
  */
 import { Navigate, useParams } from 'react-router-dom'
 import type { ReactNode } from 'react'
 import { isAuthenticated } from '../utils/authGuard'
+import { getTokenPayload } from '../utils/authToken'
 
 interface ProtectedRouteProps {
   children: ReactNode
+  /**
+   * When provided, the authenticated user's role must be one of these values.
+   * If omitted, any authenticated user is allowed through.
+   */
+  allowedRoles?: string[]
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
+export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
   const { tenantId } = useParams<{ tenantId: string }>()
 
+  // Step 1 — authentication check
   if (!isAuthenticated()) {
-    // Redirect to the correct tenant's login page.
-    // If tenantId is somehow absent (mis-wired route), fall back to /.
     const loginPath = tenantId ? `/login/${tenantId}` : '/'
     return <Navigate to={loginPath} replace />
+  }
+
+  // Step 2 — role check (only when allowedRoles is specified)
+  if (allowedRoles && allowedRoles.length > 0) {
+    const payload = getTokenPayload()
+    const role = payload?.role ?? ''
+    if (!allowedRoles.includes(role)) {
+      return <Navigate to="/access-denied" replace />
+    }
   }
 
   return <>{children}</>

--- a/src/web/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/src/web/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for ProtectedRoute (NT-12-66).
+ *
+ * Strategy:
+ *  - Mock isAuthenticated() and getTokenPayload() to control gate conditions
+ *  - Render inside MemoryRouter with a route that declares :tenantId so
+ *    useParams() resolves correctly inside the component
+ *  - Assert navigation destinations via MemoryRouter route matching
+ *
+ * Coverage:
+ *  1. Unauthenticated (no token) → redirects to /login/:tenantId
+ *  2. Unauthenticated (no tenantId in URL) → redirects to /
+ *  3. Authenticated, no allowedRoles → renders children
+ *  4. Authenticated, role in allowedRoles → renders children
+ *  5. Authenticated, role NOT in allowedRoles → redirects to /access-denied
+ *  6. Authenticated, empty allowedRoles array → renders children (no restriction)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+import { ProtectedRoute } from '../ProtectedRoute'
+import * as authGuard from '../../utils/authGuard'
+import * as authToken from '../../utils/authToken'
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock('../../utils/authGuard', () => ({ isAuthenticated: vi.fn() }))
+vi.mock('../../utils/authToken', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/authToken')>()
+  return { ...actual, getTokenPayload: vi.fn() }
+})
+
+const mockIsAuthenticated = vi.mocked(authGuard.isAuthenticated)
+const mockGetTokenPayload = vi.mocked(authToken.getTokenPayload)
+
+const TENANT = 'aabbccdd-0000-0000-0000-000000000000'
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+function renderGuard(
+  initialPath: string,
+  allowedRoles?: string[]
+) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        {/* Route that ProtectedRoute will be nested inside */}
+        <Route
+          path="/dashboard/:tenantId"
+          element={
+            <ProtectedRoute allowedRoles={allowedRoles}>
+              <div>Protected Content</div>
+            </ProtectedRoute>
+          }
+        />
+        {/* Staff route to test role restriction */}
+        <Route
+          path="/staff/:tenantId"
+          element={
+            <ProtectedRoute allowedRoles={['Staff', 'OrgAdmin', 'SystemAdmin']}>
+              <div>Staff Content</div>
+            </ProtectedRoute>
+          }
+        />
+        {/* Destinations — render text so we can assert navigation happened */}
+        <Route path="/login/:tenantId" element={<div>Login Page</div>} />
+        <Route path="/" element={<div>Welcome Page</div>} />
+        <Route path="/access-denied" element={<div>Access Denied Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// 1. Unauthenticated → redirects to /login/:tenantId
+// ---------------------------------------------------------------------------
+describe('ProtectedRoute — unauthenticated', () => {
+  beforeEach(() => {
+    mockIsAuthenticated.mockReturnValue(false)
+    mockGetTokenPayload.mockReturnValue(null)
+  })
+
+  it('redirects to /login/:tenantId when no token is present', () => {
+    renderGuard(`/dashboard/${TENANT}`)
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+
+  it('redirects to / when tenantId is absent from the URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          {/* Route without :tenantId — useParams returns undefined */}
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <div>Protected Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/" element={<div>Welcome Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(screen.getByText('Welcome Page')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. Authenticated, no role restriction → renders children
+// ---------------------------------------------------------------------------
+describe('ProtectedRoute — authenticated, no allowedRoles', () => {
+  beforeEach(() => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockGetTokenPayload.mockReturnValue({
+      sub: '1', email: 'a@b.com', name: 'Alice', role: 'User',
+      tid: TENANT, exp: 9999999999, iat: 0,
+    })
+  })
+
+  it('renders children when no allowedRoles restriction is set', () => {
+    renderGuard(`/dashboard/${TENANT}`)
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+  })
+
+  it('renders children when allowedRoles is an empty array', () => {
+    renderGuard(`/dashboard/${TENANT}`, [])
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Authenticated, role IN allowedRoles → renders children
+// ---------------------------------------------------------------------------
+describe('ProtectedRoute — authenticated, role allowed', () => {
+  it.each([
+    ['Staff',       ['Staff', 'OrgAdmin', 'SystemAdmin']],
+    ['OrgAdmin',    ['Staff', 'OrgAdmin', 'SystemAdmin']],
+    ['SystemAdmin', ['Staff', 'OrgAdmin', 'SystemAdmin']],
+  ])('renders children for role %s', (role, allowedRoles) => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockGetTokenPayload.mockReturnValue({
+      sub: '1', email: 'a@b.com', name: 'A', role,
+      tid: TENANT, exp: 9999999999, iat: 0,
+    })
+    renderGuard(`/dashboard/${TENANT}`, allowedRoles)
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Authenticated, role NOT in allowedRoles → redirects to /access-denied
+// ---------------------------------------------------------------------------
+describe('ProtectedRoute — authenticated, role denied', () => {
+  it('redirects User to /access-denied when Staff+ is required', () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockGetTokenPayload.mockReturnValue({
+      sub: '1', email: 'a@b.com', name: 'Alice', role: 'User',
+      tid: TENANT, exp: 9999999999, iat: 0,
+    })
+
+    render(
+      <MemoryRouter initialEntries={[`/staff/${TENANT}`]}>
+        <Routes>
+          <Route
+            path="/staff/:tenantId"
+            element={
+              <ProtectedRoute allowedRoles={['Staff', 'OrgAdmin', 'SystemAdmin']}>
+                <div>Staff Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/access-denied" element={<div>Access Denied Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Access Denied Page')).toBeInTheDocument()
+    expect(screen.queryByText('Staff Content')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['User',  ['OrgAdmin', 'SystemAdmin']],
+    ['Staff', ['OrgAdmin', 'SystemAdmin']],
+    ['User',  ['SystemAdmin']],
+    ['Staff', ['SystemAdmin']],
+    ['OrgAdmin', ['SystemAdmin']],
+  ])('redirects role %s to /access-denied for restricted route', (role, allowedRoles) => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockGetTokenPayload.mockReturnValue({
+      sub: '1', email: 'a@b.com', name: 'A', role,
+      tid: TENANT, exp: 9999999999, iat: 0,
+    })
+    renderGuard(`/dashboard/${TENANT}`, allowedRoles)
+    expect(screen.getByText('Access Denied Page')).toBeInTheDocument()
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+})

--- a/src/web/src/pages/AccessDenied/AccessDeniedPage.module.css
+++ b/src/web/src/pages/AccessDenied/AccessDeniedPage.module.css
@@ -1,0 +1,113 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg, #f5f5f5);
+  padding: 1.5rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.1);
+  padding: 3rem 2.5rem;
+  max-width: 440px;
+  width: 100%;
+  text-align: center;
+}
+
+.iconWrap {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #fff1f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.5rem;
+  color: #ef4444;
+}
+
+.iconWrap svg {
+  width: 32px;
+  height: 32px;
+}
+
+.heading {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text, #1a1a1a);
+  margin: 0 0 0.75rem;
+}
+
+.message {
+  font-size: 1rem;
+  color: var(--color-text-muted, #666);
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+}
+
+.roleChip {
+  display: inline-block;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 20px;
+  padding: 0.35rem 1rem;
+  font-size: 0.875rem;
+  color: #166534;
+  margin-bottom: 2rem;
+}
+
+.roleChip strong {
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.primaryBtn {
+  padding: 0.75rem 1.5rem;
+  background: var(--color-primary, #237227);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.primaryBtn:hover {
+  background: var(--color-primary-dark, #1a5c1e);
+}
+
+.secondaryBtn {
+  padding: 0.75rem 1.5rem;
+  background: transparent;
+  color: var(--color-text-muted, #666);
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.secondaryBtn:hover {
+  border-color: #9ca3af;
+  color: var(--color-text, #1a1a1a);
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 2rem 1.5rem;
+  }
+
+  .heading {
+    font-size: 1.5rem;
+  }
+}

--- a/src/web/src/pages/AccessDenied/AccessDeniedPage.tsx
+++ b/src/web/src/pages/AccessDenied/AccessDeniedPage.tsx
@@ -1,0 +1,78 @@
+/**
+ * AccessDeniedPage — shown when an authenticated user tries to access a route
+ * that requires a higher role than they hold (NT-12-6).
+ *
+ * Displays:
+ *  - The user's current role so they know who they're signed in as
+ *  - A "Go to Dashboard" button (safe landing zone)
+ *  - A "Sign Out" button (clears token, returns to welcome page)
+ */
+import { useNavigate, useParams } from 'react-router-dom'
+import { clearToken } from '../../utils/authToken'
+import { getTokenPayload } from '../../utils/authToken'
+import styles from './AccessDeniedPage.module.css'
+
+export function AccessDeniedPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const role = payload?.role ?? 'Unknown'
+
+  function handleDashboard() {
+    // Navigate back to the dashboard for the current tenant if known,
+    // otherwise fall back to the welcome page.
+    const dest = tenantId
+      ? `/dashboard/${tenantId}`
+      : payload?.tid
+        ? `/dashboard/${payload.tid}`
+        : '/'
+    navigate(dest, { replace: true })
+  }
+
+  function handleSignOut() {
+    clearToken()
+    navigate('/', { replace: true })
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        {/* Icon */}
+        <div className={styles.iconWrap} aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
+          </svg>
+        </div>
+
+        <h1 className={styles.heading}>Access Denied</h1>
+
+        <p className={styles.message}>
+          You don't have permission to view that page.
+        </p>
+
+        <div className={styles.roleChip}>
+          Signed in as <strong>{role}</strong>
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.primaryBtn}
+            onClick={handleDashboard}
+          >
+            Go to Dashboard
+          </button>
+          <button
+            type="button"
+            className={styles.secondaryBtn}
+            onClick={handleSignOut}
+          >
+            Sign Out
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/web/src/pages/AccessDenied/__tests__/AccessDeniedPage.test.tsx
+++ b/src/web/src/pages/AccessDenied/__tests__/AccessDeniedPage.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Tests for AccessDeniedPage (/access-denied) (NT-12-67).
+ *
+ * Strategy:
+ *  - Mock getTokenPayload to control role display
+ *  - Mock clearToken and useNavigate to assert side-effects
+ *  - Render directly — no ProtectedRoute wrapper needed
+ *
+ * Coverage:
+ *  1. Renders "Access Denied" heading
+ *  2. Displays the user's current role from the token
+ *  3. Shows "Unknown" role when token payload is null
+ *  4. "Go to Dashboard" navigates to /dashboard/:tenantId when tenantId is in URL
+ *  5. "Go to Dashboard" falls back to /dashboard/:tid from token when no URL tenantId
+ *  6. "Go to Dashboard" falls back to / when no tenantId anywhere
+ *  7. "Sign Out" calls clearToken and navigates to /
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+import { AccessDeniedPage } from '../AccessDeniedPage'
+import * as authToken from '../../../utils/authToken'
+import type { TokenPayload } from '../../../utils/authToken'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+vi.mock('../../../utils/authToken', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/authToken')>()
+  return { ...actual, getTokenPayload: vi.fn(), clearToken: vi.fn() }
+})
+const mockGetTokenPayload = vi.mocked(authToken.getTokenPayload)
+const mockClearToken      = vi.mocked(authToken.clearToken)
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const TENANT = 'aabbccdd-0000-0000-0000-000000000000'
+
+const BASE_PAYLOAD: TokenPayload = {
+  sub: 'user-1', email: 'alice@example.com', name: 'Alice Smith',
+  role: 'User', tid: TENANT, exp: 9999999999, iat: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function renderWithTenant(tenantId?: string) {
+  const path = tenantId ? `/access-denied/${tenantId}` : '/access-denied'
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/access-denied/:tenantId" element={<AccessDeniedPage />} />
+        <Route path="/access-denied" element={<AccessDeniedPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  mockGetTokenPayload.mockReturnValue(BASE_PAYLOAD)
+})
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+describe('AccessDeniedPage — rendering', () => {
+  it('renders the "Access Denied" heading', () => {
+    renderWithTenant()
+    expect(screen.getByRole('heading', { name: /access denied/i })).toBeInTheDocument()
+  })
+
+  it('displays the permission-denied message', () => {
+    renderWithTenant()
+    expect(screen.getByText(/don't have permission/i)).toBeInTheDocument()
+  })
+
+  it('displays the user\'s role from the token', () => {
+    renderWithTenant()
+    expect(screen.getByText('User')).toBeInTheDocument()
+  })
+
+  it('displays "Unknown" when token payload is null', () => {
+    mockGetTokenPayload.mockReturnValue(null)
+    renderWithTenant()
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+
+  it('renders "Go to Dashboard" and "Sign Out" buttons', () => {
+    renderWithTenant()
+    expect(screen.getByRole('button', { name: /go to dashboard/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
+  })
+
+  it('renders the role for Staff users', () => {
+    mockGetTokenPayload.mockReturnValue({ ...BASE_PAYLOAD, role: 'Staff' })
+    renderWithTenant()
+    expect(screen.getByText('Staff')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// "Go to Dashboard" navigation
+// ---------------------------------------------------------------------------
+describe('AccessDeniedPage — Go to Dashboard', () => {
+  it('navigates to /dashboard/:tenantId when tenantId is in the token tid', async () => {
+    const user = userEvent.setup()
+    renderWithTenant()
+    await user.click(screen.getByRole('button', { name: /go to dashboard/i }))
+    expect(mockNavigate).toHaveBeenCalledWith(`/dashboard/${TENANT}`, { replace: true })
+  })
+
+  it('navigates to / when token payload is null', async () => {
+    mockGetTokenPayload.mockReturnValue(null)
+    const user = userEvent.setup()
+    renderWithTenant()
+    await user.click(screen.getByRole('button', { name: /go to dashboard/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// "Sign Out"
+// ---------------------------------------------------------------------------
+describe('AccessDeniedPage — Sign Out', () => {
+  it('calls clearToken and navigates to / on sign out', async () => {
+    const user = userEvent.setup()
+    renderWithTenant()
+    await user.click(screen.getByRole('button', { name: /sign out/i }))
+    expect(mockClearToken).toHaveBeenCalledOnce()
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+})

--- a/src/web/src/pages/AccessDenied/index.ts
+++ b/src/web/src/pages/AccessDenied/index.ts
@@ -1,0 +1,1 @@
+export { AccessDeniedPage } from './AccessDeniedPage'

--- a/src/web/src/pages/Login/LoginPage.module.css
+++ b/src/web/src/pages/Login/LoginPage.module.css
@@ -161,7 +161,8 @@
    ============================================================ */
 .bannerError,
 .bannerLockout,
-.bannerRateLimit {
+.bannerRateLimit,
+.bannerSession {
   display: flex;
   align-items: flex-start;
   gap: var(--space-3);
@@ -196,6 +197,14 @@
   border: 1px solid #bfdbfe;
   border-left: 4px solid #3b82f6;
   color: #1e40af;
+}
+
+/* session expired — teal/info */
+.bannerSession {
+  background-color: #f0fdfa;
+  border: 1px solid #99f6e4;
+  border-left: 4px solid #14b8a6;
+  color: #115e59;
 }
 
 /* Form layout */

--- a/src/web/src/pages/Login/LoginPage.tsx
+++ b/src/web/src/pages/Login/LoginPage.tsx
@@ -17,7 +17,7 @@
  */
 import { useForm, type SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useState } from 'react'
 
 import { loginSchema } from '../../schemas/loginSchema'
@@ -34,12 +34,21 @@ import { Button } from '../../components/ui/Button'
 import logoImg from '../../assets/nextTurn-logo.png'
 import styles from './LoginPage.module.css'
 
-type BannerKind = 'error' | 'lockout' | 'ratelimit'
+type BannerKind = 'error' | 'lockout' | 'ratelimit' | 'session'
 
 export function LoginPage() {
   const { tenantId } = useParams<{ tenantId: string }>()
   const navigate = useNavigate()
-  const [banner, setBanner] = useState<{ kind: BannerKind; message: string } | null>(null)
+  const [searchParams] = useSearchParams()
+
+  // Show a soft info banner when the user was redirected here because their
+  // session expired (401 interceptor in client.ts sets ?reason=session_expired).
+  const sessionExpired = searchParams.get('reason') === 'session_expired'
+  const [banner, setBanner] = useState<{ kind: BannerKind; message: string } | null>(
+    sessionExpired
+      ? { kind: 'session', message: 'Your session has expired. Please sign in again.' }
+      : null
+  )
 
   const {
     register,
@@ -121,12 +130,13 @@ export function LoginPage() {
             </p>
           </div>
 
-          {/* Banner — error / lockout / rate-limit */}
+          {/* Banner — error / lockout / rate-limit / session-expired */}
           {banner && (
             <div
               className={
                 banner.kind === 'lockout'   ? styles.bannerLockout
                 : banner.kind === 'ratelimit' ? styles.bannerRateLimit
+                : banner.kind === 'session'   ? styles.bannerSession
                 : styles.bannerError
               }
               role="alert"
@@ -135,7 +145,9 @@ export function LoginPage() {
                 ? <LockIcon />
                 : banner.kind === 'ratelimit'
                   ? <ClockIcon />
-                  : <ErrorIcon />}
+                  : banner.kind === 'session'
+                    ? <InfoIcon />
+                    : <ErrorIcon />}
               <span>{banner.message}</span>
             </div>
           )}
@@ -305,6 +317,18 @@ function LockIcon() {
       style={{ flexShrink: 0 }}>
       <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
       <path d="M7 11V7a5 5 0 0110 0v4"/>
+    </svg>
+  )
+}
+
+function InfoIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      style={{ flexShrink: 0 }}>
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="12" y1="16" x2="12" y2="12"/>
+      <line x1="12" y1="8" x2="12.01" y2="8"/>
     </svg>
   )
 }

--- a/src/web/src/pages/Login/__tests__/LoginPage.test.tsx
+++ b/src/web/src/pages/Login/__tests__/LoginPage.test.tsx
@@ -301,3 +301,32 @@ describe('LoginPage — loading state', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// 15: Session-expired banner (NT-12-7)
+// ---------------------------------------------------------------------------
+describe('LoginPage — session expired banner', () => {
+  it('shows a session-expired info banner when redirected with ?reason=session_expired', () => {
+    render(
+      <MemoryRouter initialEntries={[`/login/${TENANT_ID}?reason=session_expired`]}>
+        <Routes>
+          <Route path="/login/:tenantId" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    // The banner should be present immediately (no user interaction needed)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/your session has expired/i)).toBeInTheDocument()
+  })
+
+  it('does NOT show the session-expired banner when no reason param is present', () => {
+    render(
+      <MemoryRouter initialEntries={[`/login/${TENANT_ID}`]}>
+        <Routes>
+          <Route path="/login/:tenantId" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/tests/NextTurn.IntegrationTests/Auth/RoleAccessIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Auth/RoleAccessIntegrationTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NextTurn.Domain.Auth;
+
+namespace NextTurn.IntegrationTests.Auth;
+
+/// <summary>
+/// Integration tests for NT-12 role-based access control.
+///
+/// Verifies the full role × policy matrix by calling the four probe endpoints
+/// (/api/probe/user, /api/probe/staff, /api/probe/org-admin, /api/probe/system-admin)
+/// with tokens minted directly via NextTurnWebApplicationFactory.CreateTokenForRole,
+/// avoiding any dependency on the login endpoint.
+///
+/// Coverage:
+///   AC1 — No token                    → 401 on any protected endpoint
+///   AC1 — Expired token               → 401
+///   AC1 — Tampered token              → 401
+///   AC2 — User   → staff endpoint     → 403
+///   AC2 — User   → org-admin endpoint → 403
+///   AC2 — User   → system-admin       → 403
+///   AC3 — Staff  → org-admin          → 403
+///   AC3 — Staff  → system-admin       → 403
+///   AC4 — OrgAdmin → system-admin     → 403
+///   AC5 — SystemAdmin → all four      → 200
+///   AC6 — Register + login are [AllowAnonymous] → no token needed → not 401
+///   Role body — response carries the caller's role string
+/// </summary>
+[Collection("Integration")]
+public sealed class RoleAccessIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public RoleAccessIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync() => await _factory.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ── AC1: 401 when there is no valid token ─────────────────────────────────
+
+    [Theory]
+    [InlineData("/api/probe/user")]
+    [InlineData("/api/probe/staff")]
+    [InlineData("/api/probe/org-admin")]
+    [InlineData("/api/probe/system-admin")]
+    public async Task NoToken_Returns401(string endpoint)
+    {
+        var client = _factory.CreateClient();    // no Authorization header
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            because: "every protected endpoint must reject requests with no token");
+    }
+
+    [Theory]
+    [InlineData("/api/probe/user")]
+    [InlineData("/api/probe/staff")]
+    [InlineData("/api/probe/org-admin")]
+    [InlineData("/api/probe/system-admin")]
+    public async Task ExpiredToken_Returns401(string endpoint)
+    {
+        // Mint a token with a negative expiry (already past)
+        var token = _factory.CreateTokenForRole(UserRole.SystemAdmin, expiryMinutes: -1);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            because: "an expired token must be rejected");
+    }
+
+    [Theory]
+    [InlineData("/api/probe/user")]
+    [InlineData("/api/probe/staff")]
+    [InlineData("/api/probe/org-admin")]
+    [InlineData("/api/probe/system-admin")]
+    public async Task TamperedToken_Returns401(string endpoint)
+    {
+        // Take a valid token and corrupt the signature segment
+        var valid  = _factory.CreateTokenForRole(UserRole.SystemAdmin);
+        var parts  = valid.Split('.');
+        var tampered = $"{parts[0]}.{parts[1]}.invalidsignatureXXXX";
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", tampered);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            because: "a token with an invalid signature must be rejected");
+    }
+
+    // ── AC2: User role is denied staff/admin endpoints ────────────────────────
+
+    [Theory]
+    [InlineData("/api/probe/staff")]
+    [InlineData("/api/probe/org-admin")]
+    [InlineData("/api/probe/system-admin")]
+    public async Task UserRole_DeniedHigherProbeEndpoints_Returns403(string endpoint)
+    {
+        var client = _factory.CreateClientForRole(UserRole.User, tenantId: TenantA);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            because: $"a User does not have the role required for {endpoint}");
+    }
+
+    [Fact]
+    public async Task UserRole_CanAccessUserProbeEndpoint_Returns200()
+    {
+        var client = _factory.CreateClientForRole(UserRole.User, tenantId: TenantA);
+
+        var response = await client.GetAsync("/api/probe/user");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── AC3: Staff role is denied org-admin/system-admin endpoints ────────────
+
+    [Theory]
+    [InlineData("/api/probe/org-admin")]
+    [InlineData("/api/probe/system-admin")]
+    public async Task StaffRole_DeniedAdminProbeEndpoints_Returns403(string endpoint)
+    {
+        var client = _factory.CreateClientForRole(UserRole.Staff, tenantId: TenantA);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            because: $"a Staff member does not have the role required for {endpoint}");
+    }
+
+    [Theory]
+    [InlineData("/api/probe/user")]
+    [InlineData("/api/probe/staff")]
+    public async Task StaffRole_CanAccessUserAndStaffProbeEndpoints_Returns200(string endpoint)
+    {
+        var client = _factory.CreateClientForRole(UserRole.Staff, tenantId: TenantA);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── AC4: OrgAdmin is denied system-admin endpoint ─────────────────────────
+
+    [Fact]
+    public async Task OrgAdminRole_DeniedSystemAdminEndpoint_Returns403()
+    {
+        var client = _factory.CreateClientForRole(UserRole.OrgAdmin, tenantId: TenantA);
+
+        var response = await client.GetAsync("/api/probe/system-admin");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            because: "an OrgAdmin must not access the SystemAdmin endpoint");
+    }
+
+    [Theory]
+    [InlineData("/api/probe/user")]
+    [InlineData("/api/probe/staff")]
+    [InlineData("/api/probe/org-admin")]
+    public async Task OrgAdminRole_CanAccessUserStaffAndOrgAdminEndpoints_Returns200(string endpoint)
+    {
+        var client = _factory.CreateClientForRole(UserRole.OrgAdmin, tenantId: TenantA);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── AC5: SystemAdmin has full access ──────────────────────────────────────
+
+    [Theory]
+    [InlineData("/api/probe/user")]
+    [InlineData("/api/probe/staff")]
+    [InlineData("/api/probe/org-admin")]
+    [InlineData("/api/probe/system-admin")]
+    public async Task SystemAdminRole_CanAccessAllProbeEndpoints_Returns200(string endpoint)
+    {
+        var client = _factory.CreateClientForRole(UserRole.SystemAdmin, tenantId: TenantA);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            because: $"SystemAdmin should have full access to {endpoint}");
+    }
+
+    // ── AC6: Register and login are [AllowAnonymous] ──────────────────────────
+
+    [Fact]
+    public async Task RegisterEndpoint_WithNoToken_IsNotRejectedWith401()
+    {
+        // We're not submitting a valid payload — we just want to confirm the endpoint
+        // is reachable (not blocked by authentication). 422 (validation) or 400 is fine.
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/register", new { });
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized,
+            because: "POST /api/auth/register must be publicly accessible");
+    }
+
+    [Fact]
+    public async Task LoginEndpoint_WithNoToken_IsNotRejectedWith401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new { });
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized,
+            because: "POST /api/auth/login must be publicly accessible");
+    }
+
+    // ── Response body carries caller's role ───────────────────────────────────
+
+    [Theory]
+    [InlineData(UserRole.User,        "/api/probe/user",        "User")]
+    [InlineData(UserRole.Staff,       "/api/probe/staff",       "Staff")]
+    [InlineData(UserRole.OrgAdmin,    "/api/probe/org-admin",   "OrgAdmin")]
+    [InlineData(UserRole.SystemAdmin, "/api/probe/system-admin","SystemAdmin")]
+    public async Task ProbeEndpoint_Returns200WithCallerRole(
+        UserRole role, string endpoint, string expectedRole)
+    {
+        var client = _factory.CreateClientForRole(role, tenantId: TenantA);
+
+        var response = await client.GetAsync(endpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ProbeBody>();
+        body!.Role.Should().Be(expectedRole,
+            because: "the probe endpoint echoes the caller's role from the JWT claim");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private sealed record ProbeBody(string Role);
+}

--- a/tests/NextTurn.IntegrationTests/NextTurnWebApplicationFactory.cs
+++ b/tests/NextTurn.IntegrationTests/NextTurnWebApplicationFactory.cs
@@ -1,12 +1,17 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using NextTurn.Domain.Auth;
+using NextTurn.Infrastructure.Persistence;
 using Respawn;
 using Testcontainers.MsSql;
-using NextTurn.Infrastructure.Persistence;
 
 namespace NextTurn.IntegrationTests;
 
@@ -98,5 +103,71 @@ public sealed class NextTurnWebApplicationFactory
 
         // Use a dedicated test environment to suppress production-only behaviour.
         builder.UseEnvironment("Testing");
+    }
+
+    // ── Token factory ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Mints a signed JWT for the given role without going through the login endpoint.
+    /// Uses the same secret / issuer / audience injected by ConfigureWebHost so the
+    /// API's JwtBearer handler will accept the token as valid.
+    ///
+    /// Call this in integration tests that need a pre-authenticated client:
+    ///   _client.DefaultRequestHeaders.Authorization =
+    ///       new AuthenticationHeaderValue("Bearer", _factory.CreateTokenForRole(UserRole.Staff));
+    /// </summary>
+    public string CreateTokenForRole(
+        UserRole role,
+        Guid?    userId   = null,
+        Guid?    tenantId = null,
+        int      expiryMinutes = 60)
+    {
+        const string secret   = "integration-test-secret-32-chars!!";
+        const string issuer   = "https://localhost:5001";
+        const string audience = "NextTurnClient";
+
+        var key         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        // For already-expired tokens (expiryMinutes < 0), both notBefore and expires
+        // must be in the past. notBefore is set one minute before expires to keep the
+        // JwtSecurityToken constructor happy (expires must be after notBefore).
+        var expires   = DateTime.UtcNow.AddMinutes(expiryMinutes);
+        var notBefore = expiryMinutes < 0
+            ? expires.AddMinutes(-1)
+            : DateTime.UtcNow;
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub,   (userId   ?? Guid.NewGuid()).ToString()),
+            new Claim(JwtRegisteredClaimNames.Email, $"test-{role.ToString().ToLower()}@example.com"),
+            new Claim(JwtRegisteredClaimNames.Name,  $"Test {role}"),
+            new Claim("role",                        role.ToString()),
+            new Claim("tid",                         (tenantId ?? Guid.NewGuid()).ToString()),
+            new Claim(JwtRegisteredClaimNames.Jti,   Guid.NewGuid().ToString()),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer:             issuer,
+            audience:           audience,
+            claims:             claims,
+            notBefore:          notBefore,
+            expires:            expires,
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>
+    /// Convenience overload: creates an <see cref="HttpClient"/> pre-configured with
+    /// a Bearer token for the given role.
+    /// </summary>
+    public HttpClient CreateClientForRole(UserRole role, Guid? tenantId = null)
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                "Bearer", CreateTokenForRole(role, tenantId: tenantId));
+        return client;
     }
 }

--- a/tests/NextTurn.UnitTests/API/Auth/AuthorizationPolicyTests.cs
+++ b/tests/NextTurn.UnitTests/API/Auth/AuthorizationPolicyTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using System.Security.Claims;
+
+namespace NextTurn.UnitTests.API.Auth;
+
+/// <summary>
+/// Unit tests for the four named authorization policies and the FallbackPolicy
+/// defined in Program.cs (NT-12-1).
+///
+/// Tests build an isolated IAuthorizationService via ServiceCollection — no HTTP server,
+/// no database, no JWT library. The policies are mirrored here exactly as registered in
+/// Program.cs so any drift between the two will immediately surface as a failing test.
+///
+/// Coverage:
+///   - Full 4-role × 4-policy matrix (16 combinations)
+///   - All four policies deny unauthenticated principals
+///   - FallbackPolicy denies unauthenticated, allows any authenticated role
+/// </summary>
+public sealed class AuthorizationPolicyTests
+{
+    private readonly IAuthorizationService _authService;
+
+    public AuthorizationPolicyTests()
+    {
+        // Mirror the exact policy configuration from Program.cs.
+        // If the policies change there, these tests must be updated to match.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy("IsUser", policy =>
+                policy.RequireAuthenticatedUser()
+                      .RequireClaim("role", "User", "Staff", "OrgAdmin", "SystemAdmin"));
+
+            options.AddPolicy("IsStaff", policy =>
+                policy.RequireAuthenticatedUser()
+                      .RequireClaim("role", "Staff", "OrgAdmin", "SystemAdmin"));
+
+            options.AddPolicy("IsOrgAdmin", policy =>
+                policy.RequireAuthenticatedUser()
+                      .RequireClaim("role", "OrgAdmin", "SystemAdmin"));
+
+            options.AddPolicy("IsSystemAdmin", policy =>
+                policy.RequireAuthenticatedUser()
+                      .RequireClaim("role", "SystemAdmin"));
+
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
+        });
+
+        _authService = services.BuildServiceProvider()
+                                .GetRequiredService<IAuthorizationService>();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns an authenticated ClaimsPrincipal carrying the specified role claim.
+    /// A non-empty authenticationType makes the identity report IsAuthenticated = true.
+    /// </summary>
+    private static ClaimsPrincipal Principal(string role)
+    {
+        var identity = new ClaimsIdentity(
+            claims: [new Claim("role", role)],
+            authenticationType: "TestAuth");   // non-empty → IsAuthenticated = true
+        return new ClaimsPrincipal(identity);
+    }
+
+    /// <summary>
+    /// Returns an unauthenticated ClaimsPrincipal (no claims, no auth type).
+    /// </summary>
+    private static ClaimsPrincipal Unauthenticated()
+        => new(new ClaimsIdentity());          // empty authenticationType → IsAuthenticated = false
+
+    // ── Policy matrix ─────────────────────────────────────────────────────────
+    //
+    //              IsUser  IsStaff  IsOrgAdmin  IsSystemAdmin
+    // User           ✅      ❌        ❌           ❌
+    // Staff          ✅      ✅        ❌           ❌
+    // OrgAdmin       ✅      ✅        ✅           ❌
+    // SystemAdmin    ✅      ✅        ✅           ✅
+
+    public static TheoryData<string, string, bool> PolicyMatrix => new()
+    {
+        // ── User ────────────────────────────────────────────────────────
+        { "User",        "IsUser",        true  },
+        { "User",        "IsStaff",       false },
+        { "User",        "IsOrgAdmin",    false },
+        { "User",        "IsSystemAdmin", false },
+        // ── Staff ───────────────────────────────────────────────────────
+        { "Staff",       "IsUser",        true  },
+        { "Staff",       "IsStaff",       true  },
+        { "Staff",       "IsOrgAdmin",    false },
+        { "Staff",       "IsSystemAdmin", false },
+        // ── OrgAdmin ────────────────────────────────────────────────────
+        { "OrgAdmin",    "IsUser",        true  },
+        { "OrgAdmin",    "IsStaff",       true  },
+        { "OrgAdmin",    "IsOrgAdmin",    true  },
+        { "OrgAdmin",    "IsSystemAdmin", false },
+        // ── SystemAdmin ─────────────────────────────────────────────────
+        { "SystemAdmin", "IsUser",        true  },
+        { "SystemAdmin", "IsStaff",       true  },
+        { "SystemAdmin", "IsOrgAdmin",    true  },
+        { "SystemAdmin", "IsSystemAdmin", true  },
+    };
+
+    [Theory]
+    [MemberData(nameof(PolicyMatrix))]
+    public async Task Policy_EnforcesRoleHierarchy(string role, string policy, bool shouldSucceed)
+    {
+        var result = await _authService.AuthorizeAsync(Principal(role), resource: null, policy);
+
+        if (shouldSucceed)
+            result.Succeeded.Should().BeTrue(
+                because: $"role '{role}' should satisfy policy '{policy}'");
+        else
+            result.Succeeded.Should().BeFalse(
+                because: $"role '{role}' should be denied by policy '{policy}'");
+    }
+
+    // ── Unauthenticated principal is denied by every policy ───────────────────
+
+    [Theory]
+    [InlineData("IsUser")]
+    [InlineData("IsStaff")]
+    [InlineData("IsOrgAdmin")]
+    [InlineData("IsSystemAdmin")]
+    public async Task AllPolicies_DenyUnauthenticatedPrincipal(string policy)
+    {
+        var result = await _authService.AuthorizeAsync(Unauthenticated(), resource: null, policy);
+
+        result.Succeeded.Should().BeFalse(
+            because: $"an unauthenticated user must always be denied by policy '{policy}'");
+    }
+
+    // ── FallbackPolicy ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FallbackPolicy_DeniesUnauthenticatedUser()
+    {
+        var fallback = new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .Build();
+
+        var result = await _authService.AuthorizeAsync(Unauthenticated(), resource: null, fallback);
+
+        result.Succeeded.Should().BeFalse(
+            because: "the FallbackPolicy must deny requests with no valid identity");
+    }
+
+    [Theory]
+    [InlineData("User")]
+    [InlineData("Staff")]
+    [InlineData("OrgAdmin")]
+    [InlineData("SystemAdmin")]
+    public async Task FallbackPolicy_AllowsAnyAuthenticatedRole(string role)
+    {
+        var fallback = new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .Build();
+
+        var result = await _authService.AuthorizeAsync(Principal(role), resource: null, fallback);
+
+        result.Succeeded.Should().BeTrue(
+            because: $"any authenticated user (role: '{role}') must satisfy the FallbackPolicy");
+    }
+}

--- a/tests/NextTurn.UnitTests/NextTurn.UnitTests.csproj
+++ b/tests/NextTurn.UnitTests/NextTurn.UnitTests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />


### PR DESCRIPTION
## NT-12 - Role-Based Access Control (API + UI)

### Summary

Implements full role-based access control across the API and frontend, enforcing the role hierarchy introduced in NT-11. Unauthenticated and under-privileged requests are blocked at both the ASP.NET Core authorization layer and the React route guard layer. A global Axios interceptor handles mid-session token expiry with a clean redirect and informational banner.


### Changes

#### Backend

**`Program.cs`**
- Added `MapInboundClaims = false` on `AddJwtBearer` so the raw `"role"` claim name is
  preserved (without this, the JWT middleware remaps it to the long MSTS claim URI and
  `RequireClaim("role", ...)` never matches).
- Registered four named authorization policies using `RequireClaim("role", ...)` with
  cumulative role lists matching the hierarchy:
  - `IsUser` — User, Staff, OrgAdmin, SystemAdmin
  - `IsStaff` — Staff, OrgAdmin, SystemAdmin
  - `IsOrgAdmin` — OrgAdmin, SystemAdmin
  - `IsSystemAdmin` — SystemAdmin
- Set `FallbackPolicy` to `RequireAuthenticatedUser()` so every endpoint requires a valid
  JWT unless explicitly opted out.
- **Fixed middleware order**: `UseAuthentication()` was executing after
  `UseMiddleware<TenantMiddleware>()`, meaning `context.User` was always unauthenticated
  inside the middleware. Swapped to the correct order:
  `UseAuthentication → TenantMiddleware → UseAuthorization`.

**`AuthController.cs`**
- Added `[AllowAnonymous]` to `Register` and `Login` actions (required because
  `FallbackPolicy` now covers all endpoints by default).

**`TenantMiddleware.cs`**
- Added an early-exit guard: if the request is not authenticated and no tenant header is
  present, pass through to the next middleware instead of returning 400. This lets
  unauthenticated requests reach `UseAuthorization()` and receive the correct 401.

**`HttpTenantContext.cs`**
- Changed the unresolved-tenant throw from `InvalidOperationException` (unhandled → 500)
  to `DomainException` (caught by `DomainExceptionMiddleware` → 400).

**`RoleProbeController.cs`** *(new — scaffolding only, remove before production)*
- Four endpoints (`GET /api/probe/user|staff|org-admin|system-admin`), each guarded by
  the corresponding named policy, used to drive integration tests without real feature
  endpoints.

#### Backend Tests

**`AuthorizationPolicyTests.cs`** *(new — unit)*
- Builds the authorization service in isolation using `ServiceCollection`.
- 16-combination role × policy matrix (`TheoryData`) — every `(role, policy)` pair
  asserted as allowed or denied.
- 4 unauthenticated-denial tests, 1 `FallbackPolicy` deny, 4 `FallbackPolicy` allow.
- **100 unit tests passing** (was 75 before NT-12).

**`RoleAccessIntegrationTests.cs`** *(new — integration)*
- Uses `CreateTokenForRole()` / `CreateClientForRole()` helpers added to
  `NextTurnWebApplicationFactory` to mint tokens directly without hitting the login
  endpoint.
- 34 scenarios covering:
  - No token → 401 × 4 endpoints
  - Expired token → 401 × 4 endpoints
  - Tampered (corrupted signature) token → 401 × 4 endpoints
  - Role × endpoint matrix (User, Staff, OrgAdmin, SystemAdmin against all 4 probe
    endpoints) — 403 or 200 as expected
  - `[AllowAnonymous]` endpoints (register, login) return non-401 without a token
  - Role claim echoed correctly in response body
- **51 integration tests passing** (was 17 before NT-12).

#### Frontend

**`ProtectedRoute.tsx`**
- Added optional `allowedRoles?: string[]` prop.
- If the user is authenticated but their `role` claim is not in `allowedRoles`, they are
  redirected to `/access-denied` (no network call made).

**`AccessDeniedPage.tsx`** *(new)*
- Displays the user's current role (from `getTokenPayload()`), a "Go to Dashboard" button
  (navigates to `/dashboard/:tid`), and a "Sign Out" button (`clearToken()` + navigate to
  `/`).
- Routed at `/access-denied` in `App.tsx`.

**`client.ts`**
- Added a global Axios response interceptor.
- On any 401: calls `clearToken()`, reads `tid` from the (now-invalid) token payload, and
  hard-navigates to `/login/:tid?reason=session_expired` (or `/?reason=session_expired`
  if no tenant is recoverable). `window.location.replace()` is used intentionally to
  wipe in-memory React state.
- 403 responses are **not** intercepted — they propagate to individual call sites.

**`LoginPage.tsx`**
- Reads `?reason=session_expired` from search params on mount.
- Renders a teal informational banner ("Your session has expired. Please sign in again.")
  when the param is present.

**`App.tsx`**
- Added stub routes for `/staff/:tenantId`, `/admin/:tenantId`, `/system/:tenantId` (each
  wrapped in `ProtectedRoute` with appropriate `allowedRoles`) to enable frontend
  role-guard testing and future page wiring.
- Added `/access-denied` route.

#### Frontend Tests

- **`ProtectedRoute.test.tsx`** *(new)*: 13 tests covering unauthenticated redirect,
  no-restriction pass-through, allowed role pass-through, and denied role redirect.
- **`AccessDeniedPage.test.tsx`** *(new)*: 9 tests covering heading render, role display,
  null-payload fallback, dashboard navigation, and sign-out behaviour.
- **`apiClient.test.ts`** *(new)*: 8 tests covering the 401 interceptor — `clearToken`
  called, redirect with/without `tid`, 403 not intercepted, 200 passes through.
- **`LoginPage.test.tsx`** *(extended)*: 2 new tests — session-expired banner shown with
  `?reason=session_expired`, not shown without it.
- **130 frontend tests passing** (was 98 before NT-12).


### Test Summary

| Suite | Before | After |
|---|---|---|
| Unit (backend) | 75 | 100 |
| Integration (backend) | 17 | 51 |
| Frontend | 98 | 130 |
| **Total** | **190** | **281** |


### Acceptance Criteria Coverage

| AC | Description | Covered by |
|---|---|---|
| AC1 | Unauthenticated → 401 | `RoleAccessIntegrationTests` (no-token, expired, tampered) |
| AC2 | User accessing Staff+ → 403 | `RoleAccessIntegrationTests` |
| AC3 | Staff accessing OrgAdmin+ → 403 | `RoleAccessIntegrationTests` |
| AC4 | OrgAdmin accessing SystemAdmin → 403 | `RoleAccessIntegrationTests` |
| AC5 | SystemAdmin → 200 everywhere | `RoleAccessIntegrationTests` |
| AC6 | Register/login publicly accessible | `RoleAccessIntegrationTests` |
| AC7 | Frontend role mismatch → `/access-denied` | `ProtectedRoute.test.tsx` |
| AC8 | No/expired token → `/login/:tenantId` | `ProtectedRoute.test.tsx` |
| AC9 | 401 API response → redirect + `clearToken` | `apiClient.test.ts` |
| AC10 | Session-expired banner on LoginPage | `LoginPage.test.tsx` |
| AC11 | AccessDeniedPage usable | `AccessDeniedPage.test.tsx` |


### Out of Scope (Sprint 2+)

- Actual staff / org-admin / system-admin feature endpoints
- Row-level security (staff restricted to their own organization's data)
- Fine-grained permission claims / scopes
- Admin UI for role assignment