### PR TITLE
feat(NT-31): production deployment pipeline — Azure & Vercel

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD (Deploy to Azure)
+name: CD (Deploy to Azure + Vercel)
 
 on:
   push:
@@ -8,7 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  deploy-backend:
+    name: Backend → Azure App Service
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +27,22 @@ jobs:
       - name: Build
         run: dotnet build ./src/NextTurn.API/NextTurn.API.csproj -c Release --no-restore
 
+      - name: Install EF Tools
+        run: dotnet tool install --global dotnet-ef
+
+      - name: Generate migration script
+        run: |
+          dotnet ef migrations script --idempotent \
+            --project src/NextTurn.Infrastructure \
+            --startup-project src/NextTurn.API \
+            -o migrate.sql
+
+      - name: Apply migrations to Azure SQL
+        uses: azure/sql-action@v2
+        with:
+          connection-string: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+          path: migrate.sql
+
       - name: Publish
         run: dotnet publish ./src/NextTurn.API/NextTurn.API.csproj -c Release -o publish
 
@@ -41,3 +58,35 @@ jobs:
           app-name: nextturn
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: ./publish.zip
+
+  deploy-frontend:
+    name: Frontend → Vercel
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        working-directory: src/web
+        run: npm ci
+
+      - name: Build
+        working-directory: src/web
+        run: npm run build
+        env:
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: src/web
+          vercel-args: "--prod"

--- a/src/NextTurn.API/Program.cs
+++ b/src/NextTurn.API/Program.cs
@@ -102,6 +102,23 @@ builder.Services.AddAuthorization(options =>
         .Build();
 });
 
+// ── CORS ─────────────────────────────────────────────────────────────────────
+// Allowed origins are read from config so they can be overridden per environment.
+// Development: http://localhost:5173 (Vite dev server)
+// Production:  set AllowedOrigins__0 in Azure App Service env vars (e.g. https://next-turn.vercel.app)
+string[] allowedOrigins = builder.Configuration
+    .GetSection("AllowedOrigins")
+    .Get<string[]>() ?? ["http://localhost:5173"];
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("Frontend", policy =>
+        policy.WithOrigins(allowedOrigins)
+              .AllowAnyHeader()
+              .AllowAnyMethod()
+              .AllowCredentials());
+});
+
 // ── Rate limiting ─────────────────────────────────────────────────────────────
 // Sliding window: max 10 requests per 60-second window per client IP.
 // Applied selectively via [EnableRateLimiting("login")] on the login endpoint only.
@@ -139,6 +156,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors("Frontend");
 
 // Exception handlers — must be early so they wrap all downstream middleware.
 // DomainException (400) wraps ValidationException (422) because domain errors

--- a/src/web/.gitignore
+++ b/src/web/.gitignore
@@ -18,6 +18,9 @@ coverage
 # Vite internal cache
 .vite
 
+# Vercel CLI local config (contains project/org IDs — not secrets, but no need to commit)
+.vercel
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/web/src/api/client.ts
+++ b/src/web/src/api/client.ts
@@ -16,8 +16,12 @@ import type { AxiosError } from 'axios'
 import type { ApiError, ProblemDetails } from '../types/api'
 import { clearToken, getTokenPayload } from '../utils/authToken'
 
+// In production (Vercel), VITE_API_URL is set to the full Azure API base URL
+// e.g. https://nextturn.azurewebsites.net/api
+// In development, it is undefined and falls back to '/api' which the Vite
+// dev-server proxy rewrites to http://localhost:5258/api.
 export const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL: import.meta.env.VITE_API_URL ?? '/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/web/src/vite-env.d.ts
+++ b/src/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## feat(NT-31): production deployment pipeline — Azure & Vercel

Implements the full production deployment pipeline for both the backend (Azure App Service) and frontend (Vercel).

### Backend (Azure)
- Added EF Core migration step to `cd.yml` — generates an idempotent SQL script and applies it to Azure SQL before deploying, ensuring the database schema is always in sync
- Added CORS policy (`"Frontend"`) to `Program.cs` — allowed origins are config-driven via `AllowedOrigins` section, overridable per environment via Azure App Service env vars

### Frontend (Vercel)
- Added `deploy-frontend` job to `cd.yml` — builds the React app and deploys to Vercel on push to `qa`
- `VITE_API_URL` injected at build time so the frontend points to the Azure backend in production
- `client.ts` updated — `baseURL` uses `VITE_API_URL` env var in production, falls back to `/api` (Vite dev proxy) in development
- Created `vite-env.d.ts` — types `VITE_API_URL` for TypeScript
- Added `.vercel` to `src/web/.gitignore`

### Secrets required
- **GitHub:** `AZURE_SQL_CONNECTION_STRING`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VITE_API_URL`
- **Azure App Service:** `ConnectionStrings__DefaultConnection`, `JwtSettings__Secret`, `JwtSettings__Issuer`, `AllowedOrigins__0`