### PR TITLE
feat(ci-cd): restructure GitHub Actions pipelines across develop/qa/main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD (Deploy to Azure + Vercel)
 
 on:
   push:
-    branches: ["qa"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,13 +1,14 @@
-name: CI (.NET)
+name: QA (Full Test Suite)
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "qa" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "qa" ]
 
 jobs:
-  build-and-test:
+  test:
+    name: Unit + Integration Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +28,6 @@ jobs:
 
       # ── Unit tests with coverlet XPlat coverage ───────────────────────────
       # Coverage is scoped to Domain + Application only (see coverlet.runsettings).
-      # Infrastructure and API are covered by the integration test suite.
       - name: Run unit tests with coverage
         run: |
           dotnet test tests/NextTurn.UnitTests/NextTurn.UnitTests.csproj \
@@ -89,3 +89,26 @@ jobs:
 
           print("Coverage threshold met")
           EOF
+
+      # ── Integration tests ─────────────────────────────────────────────────
+      # ubuntu-latest has Docker pre-installed.
+      # Testcontainers.MsSql spins up mcr.microsoft.com/mssql/server:2022-latest
+      # automatically — no manual container setup required here.
+      - name: Run integration tests
+        run: |
+          dotnet test tests/NextTurn.IntegrationTests/NextTurn.IntegrationTests.csproj \
+            --configuration Release \
+            --no-build \
+            --logger "trx;LogFileName=integration-tests.trx"
+
+      # ── Newman contract tests (Sprint 2 stretch) ──────────────────────────
+      # Only runs when a Postman collection is present in tests/postman/.
+      - name: Setup Node
+        if: hashFiles('tests/postman/*.json') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run Newman contract tests
+        if: hashFiles('tests/postman/*.json') != ''
+        run: npx newman run tests/postman/NextTurn.postman_collection.json


### PR DESCRIPTION
## Summary

Restructures the CI/CD pipeline from a two-workflow model into a three-stage
promotion pipeline — each branch has a single, clearly scoped responsibility.
No deployment can reach production without passing the full test suite on qa first.

## Changes

### `.github/workflows/ci.yml` — modified
- **Removed** the integration test step (`NextTurn.IntegrationTests`)
- `develop` is now a pure build gate: restore → build → unit tests → coverage gate → artifact upload
- Integration tests belong to `qa`; running them on every feature branch push was
  slow, Docker-dependent, and inconsistent with the branch's purpose

### `.github/workflows/qa.yml` — created
Triggers on push + PR to `qa`. Full test suite, no deployment.

Steps:
1. Restore + Build (Release)
2. Unit tests with coverlet (`coverlet.runsettings`) — same ≥80% line & branch gate as `develop`
3. ReportGenerator → coverage HTML report + GitHub job summary
4. Upload coverage artifact
5. Coverage gate (Python inline script parsing `Cobertura.xml`)
6. Integration tests (`NextTurn.IntegrationTests`) — Testcontainers spins up
   `mcr.microsoft.com/mssql/server:2022-latest` automatically; no manual Docker setup needed
7. Newman contract tests — **guarded** by `if: hashFiles('tests/postman/*.json') != ''`;
   activates automatically when a Postman collection is committed to `tests/postman/`

### `.github/workflows/cd.yml` — modified
- **Changed trigger branch** from `qa` → `main`
- All deployment steps preserved exactly as-is:
  - Idempotent EF Core migration script → applied to Azure SQL via `azure/sql-action@v2`
  - `dotnet publish` → zip → deploy to Azure App Service (`nextturn`) via `azure/webapps-deploy@v3`
  - `npm ci` + `npm run build` (with `VITE_API_URL`) → deploy to Vercel `--prod` via `amondnet/vercel-action@v25`

## Pipeline flow
feature → PR → develop [ci.yml](vscode-file://vscode-app/d:/coding%20apps/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) : build + unit tests + ≥80% coverage gate
↓
PR → qa qa.yml : same gate + integration tests + Newman (when ready)
↓
PR → main [cd.yml](vscode-file://vscode-app/d:/coding%20apps/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) : EF migration → Azure App Service + Vercel


## No secrets hardcoded

All credentials injected via GitHub Actions secrets:
`AZURE_SQL_CONNECTION_STRING`, `AZURE_WEBAPP_PUBLISH_PROFILE`, `VITE_API_URL`,
`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`

## Recommended branch protection rules (to be configured in GitHub settings)

| Branch | Required check | Direct push |
|--------|---------------|-------------|
| `develop` | `ci.yml` / `build-and-test` | Blocked (PR only) |
| `qa` | `qa.yml` / `test` | Blocked (PR only) |
| `main` | `qa.yml` / `test` | Blocked (PR only) |

## Testing

- Push to `develop` → `ci.yml` passes; integration tests do NOT run
- Push to `qa` → `qa.yml` passes; Testcontainers SQL Server container starts and integration tests pass; nothing deployed
- Push to `main` → `cd.yml` deploys to Azure App Service and Vercel

## Related

Closes NT-29 - Sprint 2: CI/CD pipeline restructure (DevOps)