### PR TITLE
Feature/NT-18 leave queue

### DIFF
--- a/src/NextTurn.API/Controllers/QueuesController.cs
+++ b/src/NextTurn.API/Controllers/QueuesController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using NextTurn.API.Models.Queues;
 using NextTurn.Application.Queue.Commands.CreateQueue;
 using NextTurn.Application.Queue.Commands.JoinQueue;
+using NextTurn.Application.Queue.Commands.LeaveQueue;
 using NextTurn.Application.Queue.Queries.GetMyQueues;
 using NextTurn.Application.Queue.Queries.GetQueueStatus;
 using NextTurn.Application.Queue.Queries.ListOrgQueues;
@@ -82,6 +83,43 @@ public sealed class QueuesController : ControllerBase
         var result  = await _sender.Send(command, cancellationToken);
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Leave (cancel entry in) a queue.
+    /// </summary>
+    /// <remarks>
+    /// Requires a valid JWT (Authorization: Bearer {token}) and an X-Tenant-Id header.
+    ///
+    /// The authenticated user's ID is extracted from the JWT <c>sub</c> claim.
+    /// The user may only cancel their own entry.
+    ///
+    /// Success response: 204 No Content
+    ///
+    /// Error responses:
+    ///   400 — queue not found, or user is not in this queue
+    ///   401 — missing or invalid JWT
+    ///   422 — validation failed (malformed queueId GUID)
+    /// </remarks>
+    [HttpPost("{queueId:guid}/leave")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> LeaveQueue(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                       ?? User.FindFirstValue("sub");
+
+        if (!Guid.TryParse(userIdClaim, out var userId))
+            return Unauthorized();
+
+        var command = new LeaveQueueCommand(queueId, userId);
+        await _sender.Send(command, cancellationToken);
+
+        return NoContent();
     }
 
     /// <summary>

--- a/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommand.cs
+++ b/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommand.cs
@@ -1,0 +1,23 @@
+using MediatR;
+
+namespace NextTurn.Application.Queue.Commands.LeaveQueue;
+
+/// <summary>
+/// Command representing the intent of a user to leave (cancel their entry in) a specific queue.
+///
+/// <para>
+/// <b>QueueId</b> — parsed from the URL route parameter <c>/api/queues/{queueId}/leave</c>.
+/// </para>
+/// <para>
+/// <b>UserId</b> — extracted from the authenticated user's JWT <c>sub</c> claim by the
+/// controller and injected here. The handler never reads ClaimsPrincipal directly,
+/// keeping it testable without an HttpContext.
+/// </para>
+///
+/// Input validation (non-empty GUIDs) runs automatically via ValidationBehavior before
+/// the handler is invoked.
+/// </summary>
+public record LeaveQueueCommand(
+    Guid QueueId,
+    Guid UserId
+) : IRequest;

--- a/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandHandler.cs
@@ -12,13 +12,12 @@ namespace NextTurn.Application.Queue.Commands.LeaveQueue;
 /// this handler is invoked.
 ///
 /// 4-step flow:
-///   1. Fetch the user's active entry in the queue — DomainException if not found
-///   2. Call Cancel() on the entry to transition it to Cancelled status
-///   3. Persist the mutation
+///   1. Cancel the user's active entry in the queue — DomainException if not found
+///   2. Persist the mutation
 ///   4. Return (implicit success)
 ///
-/// The entry is loaded by user and queue ID, ensuring the user can only cancel
-/// their own entry and cannot access other users' entries.
+/// The repository operation is scoped by user and queue ID, ensuring the user can
+/// only cancel their own entry and cannot access other users' entries.
 /// </summary>
 public class LeaveQueueCommandHandler : IRequestHandler<LeaveQueueCommand>
 {
@@ -37,19 +36,14 @@ public class LeaveQueueCommandHandler : IRequestHandler<LeaveQueueCommand>
         LeaveQueueCommand command,
         CancellationToken cancellationToken)
     {
-        // Step 1 — load the user's active entry (Waiting or Serving) in this queue
-        var entry = await _queueRepository.GetUserActiveEntryAsync(
+        // Step 1 — cancel the user's active entry (Waiting or Serving) in this queue
+        bool cancelled = await _queueRepository.CancelEntryAsync(
             command.QueueId, command.UserId, cancellationToken);
 
-        if (entry is null)
+        if (!cancelled)
             throw new DomainException("You are not in this queue.");
 
-        // Step 2 — cancel the entry
-        // The Cancel() method enforces the invariant that only Waiting or Serving entries
-        // may be cancelled — it will raise InvalidOperationException if violated.
-        entry.Cancel();
-
-        // Step 3 — persist the state transition
+        // Step 2 — persist the state transition
         await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandHandler.cs
@@ -1,0 +1,55 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+
+namespace NextTurn.Application.Queue.Commands.LeaveQueue;
+
+/// <summary>
+/// Handles the LeaveQueueCommand — orchestrates the full queue-leave (cancel entry) flow.
+///
+/// Input validation (non-empty GUIDs) runs automatically via ValidationBehavior before
+/// this handler is invoked.
+///
+/// 4-step flow:
+///   1. Fetch the user's active entry in the queue — DomainException if not found
+///   2. Call Cancel() on the entry to transition it to Cancelled status
+///   3. Persist the mutation
+///   4. Return (implicit success)
+///
+/// The entry is loaded by user and queue ID, ensuring the user can only cancel
+/// their own entry and cannot access other users' entries.
+/// </summary>
+public class LeaveQueueCommandHandler : IRequestHandler<LeaveQueueCommand>
+{
+    private readonly IQueueRepository _queueRepository;
+    private readonly IApplicationDbContext _context;
+
+    public LeaveQueueCommandHandler(
+        IQueueRepository queueRepository,
+        IApplicationDbContext context)
+    {
+        _queueRepository = queueRepository;
+        _context = context;
+    }
+
+    public async Task Handle(
+        LeaveQueueCommand command,
+        CancellationToken cancellationToken)
+    {
+        // Step 1 — load the user's active entry (Waiting or Serving) in this queue
+        var entry = await _queueRepository.GetUserActiveEntryAsync(
+            command.QueueId, command.UserId, cancellationToken);
+
+        if (entry is null)
+            throw new DomainException("You are not in this queue.");
+
+        // Step 2 — cancel the entry
+        // The Cancel() method enforces the invariant that only Waiting or Serving entries
+        // may be cancelled — it will raise InvalidOperationException if violated.
+        entry.Cancel();
+
+        // Step 3 — persist the state transition
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandValidator.cs
+++ b/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Commands.LeaveQueue;
+
+/// <summary>
+/// Validates a LeaveQueueCommand before the handler processes it.
+///
+/// Intentionally minimal — only structural field validation belongs here.
+/// Business rules (queue exists, user has active entry) live in the handler
+/// because they require async I/O that FluentValidation should not perform.
+/// </summary>
+public class LeaveQueueCommandValidator : AbstractValidator<LeaveQueueCommand>
+{
+    public LeaveQueueCommandValidator()
+    {
+        RuleFor(x => x.QueueId)
+            .NotEmpty().WithMessage("Queue ID is required.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/NextTurn.Domain/Queue/Entities/QueueEntry.cs
+++ b/src/NextTurn.Domain/Queue/Entities/QueueEntry.cs
@@ -1,4 +1,5 @@
 using NextTurn.Domain.Queue.Enums;
+using NextTurn.Domain.Common;
 
 namespace NextTurn.Domain.Queue.Entities;
 
@@ -78,14 +79,13 @@ public class QueueEntry
     /// Invariant: The entry must be in <see cref="QueueEntryStatus.Waiting"/> or
     /// <see cref="QueueEntryStatus.Serving"/> status to be cancellable.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="DomainException">
     /// Thrown if the entry is already in a terminal state (Served, Cancelled, NoShow).
     /// </exception>
     public void Cancel()
     {
         if (Status != QueueEntryStatus.Waiting && Status != QueueEntryStatus.Serving)
-            throw new InvalidOperationException(
-                $"Cannot cancel a queue entry in {Status} status. Only Waiting or Serving entries may be cancelled.");
+            throw new DomainException("Queue entry is already in a terminal state and cannot be cancelled.");
 
         Status = QueueEntryStatus.Cancelled;
     }

--- a/src/NextTurn.Domain/Queue/Entities/QueueEntry.cs
+++ b/src/NextTurn.Domain/Queue/Entities/QueueEntry.cs
@@ -70,4 +70,23 @@ public class QueueEntry
             status:       QueueEntryStatus.Waiting,
             joinedAt:     DateTimeOffset.UtcNow);
     }
+
+    /// <summary>
+    /// Transitions the entry to <see cref="QueueEntryStatus.Cancelled"/> status.
+    /// Represents a user voluntarily leaving the queue.
+    /// 
+    /// Invariant: The entry must be in <see cref="QueueEntryStatus.Waiting"/> or
+    /// <see cref="QueueEntryStatus.Serving"/> status to be cancellable.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the entry is already in a terminal state (Served, Cancelled, NoShow).
+    /// </exception>
+    public void Cancel()
+    {
+        if (Status != QueueEntryStatus.Waiting && Status != QueueEntryStatus.Serving)
+            throw new InvalidOperationException(
+                $"Cannot cancel a queue entry in {Status} status. Only Waiting or Serving entries may be cancelled.");
+
+        Status = QueueEntryStatus.Cancelled;
+    }
 }

--- a/src/NextTurn.Domain/Queue/Repositories/IQueueRepository.cs
+++ b/src/NextTurn.Domain/Queue/Repositories/IQueueRepository.cs
@@ -48,6 +48,14 @@ public interface IQueueRepository
     Task AddEntryAsync(QueueEntry entry, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Cancels the user's active entry (<see cref="QueueEntryStatus.Waiting"/> or
+    /// <see cref="QueueEntryStatus.Serving"/>) in the specified queue.
+    /// Returns <c>true</c> when an active entry was found and cancelled; otherwise <c>false</c>.
+    /// The caller is responsible for committing the unit of work (SaveChangesAsync).
+    /// </summary>
+    Task<bool> CancelEntryAsync(Guid queueId, Guid userId, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Returns <c>true</c> if the user already has an active entry
     /// (<see cref="QueueEntryStatus.Waiting"/> or <see cref="QueueEntryStatus.Serving"/>)
     /// in the specified queue.

--- a/src/NextTurn.Infrastructure/Queue/QueueRepository.cs
+++ b/src/NextTurn.Infrastructure/Queue/QueueRepository.cs
@@ -71,6 +71,26 @@ public sealed class QueueRepository : IQueueRepository
     }
 
     /// <inheritdoc/>
+    public async Task<bool> CancelEntryAsync(
+        Guid queueId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var entry = await _context.QueueEntries
+            .FirstOrDefaultAsync(
+                e => e.QueueId == queueId &&
+                     e.UserId   == userId  &&
+                     (e.Status == QueueEntryStatus.Waiting || e.Status == QueueEntryStatus.Serving),
+                cancellationToken);
+
+        if (entry is null)
+            return false;
+
+        entry.Cancel();
+        return true;
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> HasActiveEntryAsync(
         Guid queueId,
         Guid userId,

--- a/src/web/src/api/queues.ts
+++ b/src/web/src/api/queues.ts
@@ -229,3 +229,35 @@ export async function getMyQueues(): Promise<MyQueueEntry[]> {
     throw parseApiError(err)
   }
 }
+
+/**
+ * POST /api/queues/{queueId}/leave
+ *
+ * Cancels the authenticated user's active entry in a queue.
+ * The API extracts the userId from the JWT sub claim server-side.
+ *
+ * @throws ApiError on:
+ *   400 — queue not found, or user is not in this queue
+ *   401 — missing or invalid JWT
+ *   422 — validation failed (malformed queueId GUID)
+ */
+export async function leaveQueue(
+  queueId: string,
+  tenantId: string,
+): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.post(
+      `/queues/${queueId}/leave`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      }
+    )
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}

--- a/src/web/src/pages/Queue/QueuePage.module.css
+++ b/src/web/src/pages/Queue/QueuePage.module.css
@@ -409,3 +409,126 @@
 .closedBanner    { composes: alertBanner alertClosed; }
 .youreNext       { composes: alertBanner alertNext; }
 .body            { composes: idleBody; }
+
+/* ── Leave Queue Button ──────────────────────────────────────── */
+
+.leaveBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-4);
+  border: 1.5px solid #ef5350;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: transparent;
+  color: #ef5350;
+  transition: background 0.15s, color 0.15s;
+  width: 100%;
+  margin-top: var(--space-3);
+}
+
+.leaveBtn:hover:not(:disabled) {
+  background: rgba(239, 83, 80, 0.08);
+}
+
+.leaveBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ── Modal Overlay & Box ─────────────────────────────────────── */
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  z-index: 200;
+  padding: var(--space-4);
+}
+
+.modal {
+  background: var(--color-white);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Modal Header ────────────────────────────────────────────── */
+
+.modalHeader {
+  background: linear-gradient(135deg, #1b5e20 0%, var(--color-primary) 100%);
+  padding: var(--space-6) var(--space-6) var(--space-4);
+  color: var(--color-white);
+}
+
+.modalTitle {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+/* ── Modal Body ──────────────────────────────────────────────── */
+
+.modalBody {
+  padding: var(--space-6);
+  flex: 1;
+}
+
+.modalBody p {
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--color-text);
+  margin: 0 0 var(--space-3);
+}
+
+.modalBody p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Modal Footer ────────────────────────────────────────────── */
+
+.modalFooter {
+  padding: var(--space-4) var(--space-6) var(--space-6);
+  display: flex;
+  gap: var(--space-3);
+  flex-direction: column;
+}
+
+.modalFooter button {
+  flex: 1;
+}
+
+/* ── Danger Button ───────────────────────────────────────────── */
+
+.joinBtnDanger {
+  background: #ef5350;
+  color: var(--color-white);
+  border: none;
+}
+
+.joinBtnDanger:hover:not(:disabled) {
+  background: #e53935;
+}
+

--- a/src/web/src/pages/Queue/QueuePage.tsx
+++ b/src/web/src/pages/Queue/QueuePage.tsx
@@ -20,7 +20,7 @@
  */
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { joinQueue, getQueueStatus, type QueueStatusResult } from '../../api/queues'
+import { joinQueue, getQueueStatus, leaveQueue, type QueueStatusResult } from '../../api/queues'
 import { getTokenPayload } from '../../utils/authToken'
 import type { ApiError } from '../../types/api'
 import logoImg from '../../assets/nextTurn-logo.png'
@@ -34,6 +34,7 @@ type PageState =
   | { status: 'alreadyIn' }
   | { status: 'full' }
   | { status: 'error'; detail: string }
+  | { status: 'left' }
 
 function formatEta(seconds: number): string {
   if (seconds < 60) return `${seconds}s`
@@ -63,6 +64,8 @@ export function QueuePage() {
   const navigate = useNavigate()
   const [state, setState] = useState<PageState>({ status: 'loading' })
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [showLeaveModal, setShowLeaveModal] = useState(false)
+  const [isLeavingQueue, setIsLeavingQueue] = useState(false)
   const payload = getTokenPayload()
 
   // ── On mount: check if user already has an active ticket ─────────────
@@ -126,6 +129,27 @@ export function QueuePage() {
         setState({ status: 'error', detail: apiErr.detail ?? 'Something went wrong.' })
       }
     }
+  }
+
+  async function handleConfirmLeave() {
+    if (!tenantId || !queueId) return
+    setIsLeavingQueue(true)
+
+    try {
+      await leaveQueue(queueId, tenantId)
+      setShowLeaveModal(false)
+      setState({ status: 'left' })
+    } catch (err) {
+      const apiErr = err as ApiError
+      setState({ status: 'error', detail: apiErr.detail ?? 'Failed to leave queue.' })
+      setShowLeaveModal(false)
+    } finally {
+      setIsLeavingQueue(false)
+    }
+  }
+
+  function handleCancelLeave() {
+    setShowLeaveModal(false)
   }
 
   function handleBackToDashboard() {
@@ -268,6 +292,13 @@ export function QueuePage() {
               <p className={styles.ticketNote}>
                 Please stay nearby. You'll be called when it's your turn.
               </p>
+              <button
+                className={`${styles.leaveBtn}`}
+                onClick={() => setShowLeaveModal(true)}
+                type="button"
+              >
+                Leave Queue
+              </button>
             </div>
           </div>
         )}
@@ -331,7 +362,58 @@ export function QueuePage() {
           </div>
         )}
 
+        {/* ── Left queue ── */}
+        {state.status === 'left' && (
+          <div className={styles.idleCard} data-testid="left-block">
+            <div className={styles.idleIcon}>
+              <CheckIcon />
+            </div>
+            <h1 className={styles.idleHeading}>You've left the queue</h1>
+            <p className={styles.idleBody}>Your ticket has been cancelled.</p>
+            <button
+              className={`${styles.joinBtn} ${styles.joinBtnSecondary}`}
+              onClick={handleBackToDashboard}
+              type="button"
+            >
+              Back to Dashboard
+            </button>
+          </div>
+        )}
+
       </main>
+
+      {/* Leave queue confirmation modal */}
+      {showLeaveModal && (
+        <div className={styles.modalOverlay} onClick={handleCancelLeave} role="presentation">
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2 className={styles.modalTitle}>Leave Queue?</h2>
+            </div>
+            <div className={styles.modalBody}>
+              <p>Your ticket will be cancelled and you'll lose your place in the queue.</p>
+              <p>Are you sure you want to leave?</p>
+            </div>
+            <div className={styles.modalFooter}>
+              <button
+                className={`${styles.joinBtn} ${styles.joinBtnSecondary}`}
+                onClick={handleCancelLeave}
+                type="button"
+                disabled={isLeavingQueue}
+              >
+                Keep Waiting
+              </button>
+              <button
+                className={`${styles.joinBtn} ${styles.joinBtnDanger}`}
+                onClick={handleConfirmLeave}
+                type="button"
+                disabled={isLeavingQueue}
+              >
+                {isLeavingQueue ? 'Leaving...' : 'Leave Queue'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -394,6 +476,15 @@ function BackIcon() {
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
       stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="15 18 9 12 15 6"/>
+    </svg>
+  )
+}
+function CheckIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10"/>
+      <polyline points="16 12 12 8 8 12"/>
     </svg>
   )
 }

--- a/tests/NextTurn.IntegrationTests/Queue/LeaveQueueIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Queue/LeaveQueueIntegrationTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using FluentAssertions;
+using NextTurn.Domain.Auth;
+using NextTurn.IntegrationTests;
+
+namespace NextTurn.IntegrationTests.Queue;
+
+/// <summary>
+/// Integration tests for POST /api/queues/{queueId}/leave.
+///
+/// Each test resets the database via Respawn and starts from a known state
+/// built by <see cref="NextTurnWebApplicationFactory.SeedQueueAsync"/>.
+///
+/// Covered scenarios:
+///   1. Authenticated user leaves a valid queue they're in → 204 No Content
+///   2. No JWT → 401 Unauthorized
+///   3. Queue not found (unknown GUID) → 400 "Queue not found." (no, actually the user not in queue error)
+///   4. User not in queue → 400 "You are not in this queue."
+///   5. Malformed queueId GUID in route → 422 Unprocessable Entity
+///   6. Leave same queue twice → 400 on second attempt (user no longer in queue)
+/// </summary>
+[Collection("Integration")]
+public sealed class LeaveQueueIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    // These are set in InitializeAsync, after the database is seeded.
+    private Guid _tenantId;
+    private Guid _queueId;
+
+    // A stable userId embedded in the JWT so the handler can identify the caller.
+    private static readonly Guid TestUserId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    public LeaveQueueIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _queueId) = await _factory.SeedQueueAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ── 1. Happy path ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LeaveQueue_WithValidRequest_Returns204NoContent()
+    {
+        // Pre-condition: User must be in the queue first
+        await PostJoinAsync(_queueId, TestUserId, _tenantId);
+
+        var response = await PostLeaveAsync(_queueId, TestUserId, _tenantId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task LeaveQueue_WithValidRequest_RemovesUserFromQueue()
+    {
+        // Pre-condition: User joins
+        var joinResponse = await PostJoinAsync(_queueId, TestUserId, _tenantId);
+        joinResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // User leaves
+        var leaveResponse = await PostLeaveAsync(_queueId, TestUserId, _tenantId);
+        leaveResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Attempt to get status — should fail because user is no longer in queue
+        var statusResponse = await GetStatusAsync(_queueId, TestUserId, _tenantId);
+        statusResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── 2. No JWT → 401 ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LeaveQueue_WithoutJwt_Returns401()
+    {
+        // Create a plain (unauthenticated) client.
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", _tenantId.ToString());
+
+        var response = await client.PostAsync($"/api/queues/{_queueId}/leave", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── 3. User not in queue → 400 ────────────────────────────────────────────
+
+    [Fact]
+    public async Task LeaveQueue_WhenUserNotInQueue_Returns400()
+    {
+        var differentUserId = Guid.NewGuid();
+
+        var response = await PostLeaveAsync(_queueId, differentUserId, _tenantId);
+        var body = await ReadBodyAsync(response);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body["detail"].GetString().Should().Be("You are not in this queue.");
+    }
+
+    // ── 4. Leave twice → 400 on second attempt ────────────────────────────────
+
+    [Fact]
+    public async Task LeaveQueue_WhenUserLeavesTowice_SecondReturns400()
+    {
+        // Precondition: User joins
+        var joinResponse = await PostJoinAsync(_queueId, TestUserId, _tenantId);
+        joinResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // First leave should succeed
+        var firstLeave = await PostLeaveAsync(_queueId, TestUserId, _tenantId);
+        firstLeave.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Second leave for the same user should fail — user no longer in queue
+        var secondLeave = await PostLeaveAsync(_queueId, TestUserId, _tenantId);
+        var body = await ReadBodyAsync(secondLeave);
+
+        secondLeave.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body["detail"].GetString().Should().Be("You are not in this queue.");
+    }
+
+    // ── 5. Empty GUID → 422 (FluentValidation) ────────────────────────────────
+
+    [Fact]
+    public async Task LeaveQueue_WithEmptyGuidQueueId_Returns422()
+    {
+        var response = await PostLeaveAsync(Guid.Empty, TestUserId, _tenantId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Posts to the leave endpoint with a freshly minted JWT for the given user.
+    /// </summary>
+    private Task<HttpResponseMessage> PostLeaveAsync(
+        Guid queueId,
+        Guid userId,
+        Guid tenantId)
+    {
+        var client = AuthenticatedClient(userId, tenantId);
+        return client.PostAsync($"/api/queues/{queueId}/leave", null);
+    }
+
+    /// <summary>
+    /// Gets the queue status with a freshly minted JWT for the given user.
+    /// </summary>
+    private Task<HttpResponseMessage> GetStatusAsync(
+        Guid queueId,
+        Guid userId,
+        Guid tenantId)
+    {
+        var client = AuthenticatedClient(userId, tenantId);
+        return client.GetAsync($"/api/queues/{queueId}/status");
+    }
+
+    /// <summary>
+    /// Posts to the join endpoint with a freshly minted JWT for the given user.
+    /// </summary>
+    private Task<HttpResponseMessage> PostJoinAsync(
+        Guid queueId,
+        Guid userId,
+        Guid tenantId)
+    {
+        var client = AuthenticatedClient(userId, tenantId);
+        return client.PostAsync($"/api/queues/{queueId}/join", null);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> bearing a signed JWT for the given userId/tenantId
+    /// and adds the required X-Tenant-Id header.
+    /// </summary>
+    private HttpClient AuthenticatedClient(Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(UserRole.User, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private static async Task<Dictionary<string, JsonElement>> ReadBodyAsync(
+        HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    }
+}

--- a/tests/NextTurn.IntegrationTests/Queue/LeaveQueueIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Queue/LeaveQueueIntegrationTests.cs
@@ -2,8 +2,12 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using NextTurn.Domain.Auth;
+using NextTurn.Domain.Queue.Enums;
 using NextTurn.IntegrationTests;
+using NextTurn.Infrastructure.Persistence;
 
 namespace NextTurn.IntegrationTests.Queue;
 
@@ -15,11 +19,12 @@ namespace NextTurn.IntegrationTests.Queue;
 ///
 /// Covered scenarios:
 ///   1. Authenticated user leaves a valid queue they're in → 204 No Content
-///   2. No JWT → 401 Unauthorized
-///   3. Queue not found (unknown GUID) → 400 "Queue not found." (no, actually the user not in queue error)
-///   4. User not in queue → 400 "You are not in this queue."
-///   5. Malformed queueId GUID in route → 422 Unprocessable Entity
-///   6. Leave same queue twice → 400 on second attempt (user no longer in queue)
+///   2. Entry status persists as Cancelled in the database
+///   3. Global consumer (TenantId = Guid.Empty) can leave queues too
+///   4. No JWT → 401 Unauthorized
+///   5. User not in queue → 400 "You are not in this queue."
+///   6. Malformed queueId GUID in route → 422 Unprocessable Entity
+///   7. Leave same queue twice → 400 on second attempt (user no longer in queue)
 /// </summary>
 [Collection("Integration")]
 public sealed class LeaveQueueIntegrationTests
@@ -61,7 +66,7 @@ public sealed class LeaveQueueIntegrationTests
     }
 
     [Fact]
-    public async Task LeaveQueue_WithValidRequest_RemovesUserFromQueue()
+    public async Task LeaveQueue_WithValidRequest_PersistsCancelledStatusInDatabase()
     {
         // Pre-condition: User joins
         var joinResponse = await PostJoinAsync(_queueId, TestUserId, _tenantId);
@@ -74,6 +79,34 @@ public sealed class LeaveQueueIntegrationTests
         // Attempt to get status — should fail because user is no longer in queue
         var statusResponse = await GetStatusAsync(_queueId, TestUserId, _tenantId);
         statusResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var entry = await db.QueueEntries
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(e => e.QueueId == _queueId && e.UserId == TestUserId);
+
+        entry.Should().NotBeNull();
+        entry!.Status.Should().Be(QueueEntryStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task LeaveQueue_WithGlobalConsumerUser_Returns204NoContent()
+    {
+        var consumerUserId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+        // Consumer JWT carries tid = Guid.Empty while X-Tenant-Id scopes the queue request.
+        var client = _factory.CreateClient();
+        var token = _factory.CreateTokenForRole(UserRole.User, userId: consumerUserId, tenantId: Guid.Empty);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", _tenantId.ToString());
+
+        var join = await client.PostAsync($"/api/queues/{_queueId}/join", null);
+        join.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var leave = await client.PostAsync($"/api/queues/{_queueId}/leave", null);
+        leave.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     // ── 2. No JWT → 401 ───────────────────────────────────────────────────────
@@ -107,7 +140,7 @@ public sealed class LeaveQueueIntegrationTests
     // ── 4. Leave twice → 400 on second attempt ────────────────────────────────
 
     [Fact]
-    public async Task LeaveQueue_WhenUserLeavesTowice_SecondReturns400()
+    public async Task LeaveQueue_WhenUserLeavesTwice_SecondReturns400()
     {
         // Precondition: User joins
         var joinResponse = await PostJoinAsync(_queueId, TestUserId, _tenantId);

--- a/tests/NextTurn.UnitTests/Application/Queue/LeaveQueueCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/LeaveQueueCommandHandlerTests.cs
@@ -4,7 +4,6 @@ using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.LeaveQueue;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
-using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
 
 namespace NextTurn.UnitTests.Application.Queue;
 
@@ -16,7 +15,8 @@ namespace NextTurn.UnitTests.Application.Queue;
 ///
 /// Key invariants exercised:
 ///   - User not in queue → DomainException "You are not in this queue."
-///   - Happy path: entry is cancelled (GetUserActiveEntryAsync returns a valid entry)
+///   - Happy path: CancelEntryAsync returns true and SaveChangesAsync is called once
+///   - Wrong-user guard: if repository cannot cancel for this queue/user pair, command fails
 ///   - SaveChangesAsync called exactly once per successful leave
 /// </summary>
 public sealed class LeaveQueueCommandHandlerTests
@@ -32,14 +32,12 @@ public sealed class LeaveQueueCommandHandlerTests
 
     private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static readonly Guid UserId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
-    private static readonly Guid OrgId = Guid.NewGuid();
-
     public LeaveQueueCommandHandlerTests()
     {
-        // Default: user has an active entry in the queue
+        // Default: user has an active entry in the queue and cancellation succeeds
         _queueRepositoryMock
-            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(BuildQueueEntry());
+            .Setup(r => r.CancelEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _contextMock
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
@@ -61,27 +59,13 @@ public sealed class LeaveQueueCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CallsGetUserActiveEntryAsyncWithCorrectParameters()
+    public async Task Handle_CallsCancelEntryAsyncWithCorrectParameters()
     {
         await _handler.Handle(ValidCommand(), CancellationToken.None);
 
         _queueRepositoryMock.Verify(
-            r => r.GetUserActiveEntryAsync(QueueId, UserId, It.IsAny<CancellationToken>()),
+            r => r.CancelEntryAsync(QueueId, UserId, It.IsAny<CancellationToken>()),
             Times.Once);
-    }
-
-    [Fact]
-    public async Task Handle_CancelsTheEntry()
-    {
-        var entry = BuildQueueEntry();
-        _queueRepositoryMock
-            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(entry);
-
-        await _handler.Handle(ValidCommand(), CancellationToken.None);
-
-        // Verify the entry's status is now Cancelled
-        entry.Status.Should().Be(NextTurn.Domain.Queue.Enums.QueueEntryStatus.Cancelled);
     }
 
     [Fact]
@@ -97,11 +81,11 @@ public sealed class LeaveQueueCommandHandlerTests
     // ── User not in queue (step 1) ────────────────────────────────────────────
 
     [Fact]
-    public async Task Handle_WhenUserNotInQueue_ThrowsDomainException()
+    public async Task Handle_WhenCancelEntryReturnsFalse_ThrowsDomainException()
     {
         _queueRepositoryMock
-            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((QueueEntry?)null);
+            .Setup(r => r.CancelEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
         var act = async () => await _handler.Handle(ValidCommand(), CancellationToken.None);
 
@@ -110,11 +94,11 @@ public sealed class LeaveQueueCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenUserNotInQueue_DoesNotCallSaveChangesAsync()
+    public async Task Handle_WhenCancelEntryReturnsFalse_DoesNotCallSaveChangesAsync()
     {
         _queueRepositoryMock
-            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((QueueEntry?)null);
+            .Setup(r => r.CancelEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
         try { await _handler.Handle(ValidCommand(), CancellationToken.None); } catch { /* expected */ }
 
@@ -123,11 +107,24 @@ public sealed class LeaveQueueCommandHandlerTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task Handle_WhenWrongUserAttemptsLeave_ThrowsDomainException()
+    {
+        var wrongUserId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var command = new LeaveQueueCommand(QueueId, wrongUserId);
+
+        _queueRepositoryMock
+            .Setup(r => r.CancelEntryAsync(QueueId, wrongUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("You are not in this queue.");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static LeaveQueueCommand ValidCommand() =>
         new(QueueId: QueueId, UserId: UserId);
-
-    private static QueueEntry BuildQueueEntry() =>
-        QueueEntry.Create(QueueId, UserId, ticketNumber: 1);
 }

--- a/tests/NextTurn.UnitTests/Application/Queue/LeaveQueueCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/LeaveQueueCommandHandlerTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.LeaveQueue;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+/// <summary>
+/// Unit tests for LeaveQueueCommandHandler.
+///
+/// All dependencies are Moq doubles — no database, no EF Core, no HTTP context.
+/// Tests verify the handler's 4-step orchestration logic in isolation.
+///
+/// Key invariants exercised:
+///   - User not in queue → DomainException "You are not in this queue."
+///   - Happy path: entry is cancelled (GetUserActiveEntryAsync returns a valid entry)
+///   - SaveChangesAsync called exactly once per successful leave
+/// </summary>
+public sealed class LeaveQueueCommandHandlerTests
+{
+    // ── Shared doubles ────────────────────────────────────────────────────────
+
+    private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly LeaveQueueCommandHandler _handler;
+
+    // ── Shared test data ──────────────────────────────────────────────────────
+
+    private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid UserId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid OrgId = Guid.NewGuid();
+
+    public LeaveQueueCommandHandlerTests()
+    {
+        // Default: user has an active entry in the queue
+        _queueRepositoryMock
+            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildQueueEntry());
+
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new LeaveQueueCommandHandler(
+            _queueRepositoryMock.Object,
+            _contextMock.Object);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WithValidCommand_Succeeds()
+    {
+        var act = async () => await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_CallsGetUserActiveEntryAsyncWithCorrectParameters()
+    {
+        await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        _queueRepositoryMock.Verify(
+            r => r.GetUserActiveEntryAsync(QueueId, UserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CancelsTheEntry()
+    {
+        var entry = BuildQueueEntry();
+        _queueRepositoryMock
+            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entry);
+
+        await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        // Verify the entry's status is now Cancelled
+        entry.Status.Should().Be(NextTurn.Domain.Queue.Enums.QueueEntryStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task Handle_CallsSaveChangesAsyncExactlyOnce()
+    {
+        await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        _contextMock.Verify(
+            c => c.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── User not in queue (step 1) ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenUserNotInQueue_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        var act = async () => await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+                 .WithMessage("You are not in this queue.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserNotInQueue_DoesNotCallSaveChangesAsync()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetUserActiveEntryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        try { await _handler.Handle(ValidCommand(), CancellationToken.None); } catch { /* expected */ }
+
+        _contextMock.Verify(
+            c => c.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static LeaveQueueCommand ValidCommand() =>
+        new(QueueId: QueueId, UserId: UserId);
+
+    private static QueueEntry BuildQueueEntry() =>
+        QueueEntry.Create(QueueId, UserId, ticketNumber: 1);
+}

--- a/tests/NextTurn.UnitTests/Domain/Queue/QueueEntryTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Queue/QueueEntryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Entities;
 using NextTurn.Domain.Queue.Enums;
 
@@ -84,5 +85,50 @@ public sealed class QueueEntryTests
         var act = () => QueueEntry.Create(ValidQueueId, ValidUserId, ticketNumber: 1);
 
         act.Should().NotThrow();
+    }
+
+    // ── QueueEntry.Cancel behaviour ──────────────────────────────────────────
+
+    [Fact]
+    public void Cancel_WhenEntryIsWaiting_SetsStatusToCancelled()
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+
+        entry.Cancel();
+
+        entry.Status.Should().Be(QueueEntryStatus.Cancelled);
+    }
+
+    [Fact]
+    public void Cancel_WhenEntryAlreadyCancelled_ThrowsDomainException()
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        entry.Cancel();
+
+        var act = () => entry.Cancel();
+
+        act.Should().Throw<DomainException>()
+           .WithMessage("Queue entry is already in a terminal state and cannot be cancelled.");
+    }
+
+    [Theory]
+    [InlineData(QueueEntryStatus.Served)]
+    [InlineData(QueueEntryStatus.NoShow)]
+    public void Cancel_WhenEntryInOtherTerminalState_ThrowsDomainException(QueueEntryStatus terminalStatus)
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        SetStatus(entry, terminalStatus);
+
+        var act = () => entry.Cancel();
+
+        act.Should().Throw<DomainException>()
+           .WithMessage("Queue entry is already in a terminal state and cannot be cancelled.");
+    }
+
+    private static void SetStatus(QueueEntry entry, QueueEntryStatus status)
+    {
+        typeof(QueueEntry)
+            .GetProperty(nameof(QueueEntry.Status))!
+            .SetValue(entry, status);
     }
 }


### PR DESCRIPTION
## PR Title
NT-18 Leave Queue: End-to-end implementation (API, Application, Domain, Infrastructure, UI, and tests)

## PR Description

### Summary
This PR implements NT-18 (Leave Queue) end-to-end in NextTurn.  
Users can now leave a queue safely through a confirmation flow in the frontend, and the backend performs a soft removal by setting queue entry status to Cancelled (record preserved for analytics).

This also includes hardening updates to fully align with story requirements:
- domain-level terminal-state guard semantics
- explicit repository cancel contract
- stronger unit test coverage for guard paths
- integration tests that verify persisted Cancelled status in the database

### What was implemented

#### Backend
- Added LeaveQueue command flow in Application:
  - LeaveQueueCommand
  - LeaveQueueCommandValidator
  - LeaveQueueCommandHandler
- Added API endpoint:
  - POST /api/queues/{queueId}/leave on QueuesController with Authorize
  - Returns 204 No Content on success
- Updated domain behavior:
  - QueueEntry.Cancel now enforces terminal-state guard
  - Throws DomainException when trying to cancel an entry already in terminal state
- Added repository contract and implementation:
  - IQueueRepository.CancelEntryAsync(queueId, userId, cancellationToken)
  - QueueRepository implementation performs scoped active-entry lookup and cancellation

#### Frontend
- Added leaveQueue API call
- Updated QueuePage:
  - Leave Queue action in joined state
  - Confirmation modal to prevent accidental leave
  - Leaving and left UI states
- Added CSS styling for:
  - leave button
  - confirmation modal
  - danger action style

### Tests

#### Unit tests
- Added/updated tests for:
  - happy path leave
  - wrong-user guard
  - no-active-entry guard
  - domain terminal-state cancellation guard
- Result: Unit tests pass locally (362 passed, 0 failed)

#### Integration tests
- Added/updated tests for:
  - successful leave response
  - DB assertion: queue entry status is persisted as Cancelled
  - global consumer user flow (TenantId = Guid.Empty) can leave queue
  - unauthorized and validation scenarios
- Note: local integration execution is currently blocked in this environment due to Docker/Testcontainers availability, but tests are implemented and ready for CI/docker-capable execution.

### Acceptance Criteria coverage
- Queue entry status updated to Cancelled in DB (soft removal): Completed
- User cannot leave Served, Cancelled, or NoShow entries: Completed
- Remaining users position/ETA update via SQL-derived counts: Preserved
- Confirmation prompt in UI: Completed
- Consumer users can leave queues: Completed and covered in integration tests

### Commits included
- 58e3ccb
- fbac61b
- 032ed00
- b0f3b77
- 1890e41
- caae152
- 156a41d
- d3d7d80