### PR TITLE
Feature/NT-21 cancel appointment

### DIFF
--- a/src/NextTurn.API/Controllers/AppointmentsController.cs
+++ b/src/NextTurn.API/Controllers/AppointmentsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NextTurn.API.Models.Appointments;
 using NextTurn.Application.Appointment.Commands.BookAppointment;
+using NextTurn.Application.Appointment.Commands.CancelAppointment;
 using NextTurn.Application.Appointment.Commands.RescheduleAppointment;
 using NextTurn.Application.Appointment.Queries.GetAvailableSlots;
 
@@ -85,6 +86,27 @@ public sealed class AppointmentsController : ControllerBase
             request.NewSlotEnd);
 
         var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPost("{appointmentId:guid}/cancel")]
+    [ProducesResponseType(typeof(CancelAppointmentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> CancelAppointment(
+        Guid appointmentId,
+        CancellationToken cancellationToken)
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                       ?? User.FindFirstValue("sub");
+
+        if (!Guid.TryParse(userIdClaim, out var userId))
+            return Unauthorized();
+
+        var command = new CancelAppointmentCommand(appointmentId, userId);
+        var result = await _sender.Send(command, cancellationToken);
+
         return Ok(result);
     }
 }

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotification.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotification.cs
@@ -1,0 +1,14 @@
+using MediatR;
+
+namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
+
+/// <summary>
+/// In-process event published after an appointment is cancelled.
+/// </summary>
+public sealed record AppointmentCancelledNotification(
+    Guid AppointmentId,
+    Guid UserId,
+    Guid OrganisationId,
+    DateTimeOffset SlotStart,
+    DateTimeOffset SlotEnd,
+    bool LateCancellation) : INotification;

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotificationHandler.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
+
+/// <summary>
+/// Stub notification handler for appointment cancellation events.
+/// </summary>
+public sealed class AppointmentCancelledNotificationHandler
+    : INotificationHandler<AppointmentCancelledNotification>
+{
+    private readonly ILogger<AppointmentCancelledNotificationHandler> _logger;
+
+    public AppointmentCancelledNotificationHandler(
+        ILogger<AppointmentCancelledNotificationHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task Handle(
+        AppointmentCancelledNotification notification,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Appointment cancelled. AppointmentId: {AppointmentId}, UserId: {UserId}, OrgId: {OrgId}, Slot: {SlotStart}->{SlotEnd}, LateCancellation: {LateCancellation}.",
+            notification.AppointmentId,
+            notification.UserId,
+            notification.OrganisationId,
+            notification.SlotStart,
+            notification.SlotEnd,
+            notification.LateCancellation);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentCommand.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
+
+/// <summary>
+/// Command to cancel an appointment owned by the authenticated user.
+/// </summary>
+public sealed record CancelAppointmentCommand(
+    Guid AppointmentId,
+    Guid UserId) : IRequest<CancelAppointmentResult>;

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentCommandHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentCommandHandler.cs
@@ -1,0 +1,61 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Appointment.Repositories;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
+
+/// <summary>
+/// Handles appointment cancellation.
+/// </summary>
+public sealed class CancelAppointmentCommandHandler
+    : IRequestHandler<CancelAppointmentCommand, CancelAppointmentResult>
+{
+    private readonly IAppointmentRepository _appointmentRepository;
+    private readonly IApplicationDbContext _context;
+    private readonly IPublisher _publisher;
+
+    public CancelAppointmentCommandHandler(
+        IAppointmentRepository appointmentRepository,
+        IApplicationDbContext context,
+        IPublisher publisher)
+    {
+        _appointmentRepository = appointmentRepository;
+        _context = context;
+        _publisher = publisher;
+    }
+
+    public async Task<CancelAppointmentResult> Handle(
+        CancelAppointmentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var appointment = await _appointmentRepository.GetByIdAsync(
+            request.AppointmentId,
+            cancellationToken);
+
+        if (appointment is null)
+            throw new DomainException("Appointment not found.");
+
+        if (appointment.UserId != request.UserId)
+            throw new DomainException("You can only cancel your own appointment.");
+
+        appointment.Cancel();
+
+        await _appointmentRepository.UpdateAsync(appointment, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await _publisher.Publish(
+            new AppointmentCancelledNotification(
+                AppointmentId: appointment.Id,
+                UserId: appointment.UserId,
+                OrganisationId: appointment.OrganisationId,
+                SlotStart: appointment.SlotStart,
+                SlotEnd: appointment.SlotEnd,
+                LateCancellation: appointment.LateCancellation),
+            cancellationToken);
+
+        return new CancelAppointmentResult(
+            appointment.Id,
+            appointment.LateCancellation);
+    }
+}

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentCommandValidator.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
+
+public sealed class CancelAppointmentCommandValidator : AbstractValidator<CancelAppointmentCommand>
+{
+    public CancelAppointmentCommandValidator()
+    {
+        RuleFor(x => x.AppointmentId)
+            .NotEmpty().WithMessage("Appointment ID is required.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentResult.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/CancelAppointmentResult.cs
@@ -1,0 +1,8 @@
+namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
+
+/// <summary>
+/// Result returned after a successful cancellation.
+/// </summary>
+public sealed record CancelAppointmentResult(
+    Guid AppointmentId,
+    bool LateCancellation);

--- a/src/NextTurn.Domain/Appointment/Entities/Appointment.cs
+++ b/src/NextTurn.Domain/Appointment/Entities/Appointment.cs
@@ -14,6 +14,7 @@ public class Appointment
     public DateTimeOffset SlotStart { get; private set; }
     public DateTimeOffset SlotEnd { get; private set; }
     public AppointmentStatus Status { get; private set; }
+    public bool LateCancellation { get; private set; }
 
     protected Appointment()
     {
@@ -25,7 +26,8 @@ public class Appointment
         Guid userId,
         DateTimeOffset slotStart,
         DateTimeOffset slotEnd,
-        AppointmentStatus status)
+        AppointmentStatus status,
+        bool lateCancellation)
     {
         Id = id;
         OrganisationId = organisationId;
@@ -33,6 +35,7 @@ public class Appointment
         SlotStart = slotStart;
         SlotEnd = slotEnd;
         Status = status;
+        LateCancellation = lateCancellation;
     }
 
     public static Appointment Create(
@@ -56,7 +59,8 @@ public class Appointment
             userId: userId,
             slotStart: slotStart,
             slotEnd: slotEnd,
-            status: AppointmentStatus.Confirmed);
+            status: AppointmentStatus.Confirmed,
+            lateCancellation: false);
     }
 
     public bool Overlaps(DateTimeOffset slotStart, DateTimeOffset slotEnd)
@@ -66,8 +70,19 @@ public class Appointment
 
     public void Cancel()
     {
+        var now = DateTimeOffset.UtcNow;
+
         if (Status == AppointmentStatus.Cancelled)
-            return;
+            throw new DomainException("Appointment is already cancelled.");
+
+        if (SlotStart <= now)
+            throw new DomainException("Past appointments cannot be cancelled.");
+
+        if (Status != AppointmentStatus.Confirmed && Status != AppointmentStatus.Pending)
+            throw new DomainException("Only active appointments can be cancelled.");
+
+        // Cancellation inside 24 hours is allowed, but flagged for reporting.
+        LateCancellation = SlotStart <= now.AddHours(24);
 
         Status = AppointmentStatus.Cancelled;
     }

--- a/src/NextTurn.Infrastructure/Migrations/20260315022842_AddLateCancellationToAppointments.Designer.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260315022842_AddLateCancellationToAppointments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NextTurn.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using NextTurn.Infrastructure.Persistence;
 namespace NextTurn.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260315022842_AddLateCancellationToAppointments")]
+    partial class AddLateCancellationToAppointments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NextTurn.Infrastructure/Migrations/20260315022842_AddLateCancellationToAppointments.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260315022842_AddLateCancellationToAppointments.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NextTurn.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLateCancellationToAppointments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "LateCancellation",
+                table: "Appointments",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LateCancellation",
+                table: "Appointments");
+        }
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Appointment/AppointmentConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Appointment/AppointmentConfiguration.cs
@@ -34,6 +34,10 @@ public sealed class AppointmentConfiguration : IEntityTypeConfiguration<Appointm
             .HasConversion<string>()
             .HasDefaultValue(AppointmentStatus.Confirmed);
 
+        builder.Property(a => a.LateCancellation)
+            .IsRequired()
+            .HasDefaultValue(false);
+
         builder.HasIndex(a => new { a.OrganisationId, a.SlotStart })
             .HasDatabaseName("IX_Appointments_OrganisationId_SlotStart");
 

--- a/src/web/src/api/appointments.ts
+++ b/src/web/src/api/appointments.ts
@@ -16,6 +16,11 @@ export interface RescheduleAppointmentResult {
   slotEnd: string
 }
 
+export interface CancelAppointmentResult {
+  appointmentId: string
+  lateCancellation: boolean
+}
+
 export interface BookAppointmentBody {
   organisationId: string
   slotStart: string
@@ -71,6 +76,29 @@ export async function rescheduleAppointment(
     const { data } = await apiClient.put<RescheduleAppointmentResult>(
       `/appointments/${appointmentId}/reschedule`,
       body,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': organisationId,
+        },
+      }
+    )
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function cancelAppointment(
+  appointmentId: string,
+  organisationId: string,
+): Promise<CancelAppointmentResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<CancelAppointmentResult>(
+      `/appointments/${appointmentId}/cancel`,
+      null,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/web/src/pages/Appointment/AppointmentPage.module.css
+++ b/src/web/src/pages/Appointment/AppointmentPage.module.css
@@ -140,6 +140,20 @@
   margin-top: var(--space-2);
 }
 
+.cancelTriggerBtn {
+  margin-top: var(--space-3);
+  border: 1px solid rgba(192, 57, 43, 0.45);
+  background: var(--color-white);
+  color: var(--color-error);
+  border-radius: var(--radius-md);
+  padding: 0.55rem 0.85rem;
+  font-weight: var(--font-weight-semibold);
+}
+
+.cancelTriggerBtn:hover {
+  background: var(--color-error-bg);
+}
+
 .slotHeader h2 {
   font-size: var(--font-size-xl);
 }
@@ -223,6 +237,72 @@
   border-color: var(--color-error-border);
   background: var(--color-error-bg);
   color: var(--color-error);
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(19, 25, 21, 0.55);
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  z-index: 40;
+}
+
+.modalCard {
+  width: min(520px, 100%);
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-5);
+}
+
+.modalTitle {
+  font-size: var(--font-size-xl);
+  margin-bottom: var(--space-3);
+}
+
+.modalBody {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.modalBody + .modalBody {
+  margin-top: var(--space-2);
+}
+
+.modalActions {
+  margin-top: var(--space-5);
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.modalSecondaryBtn,
+.modalDangerBtn {
+  border-radius: var(--radius-md);
+  padding: 0.62rem 0.95rem;
+  font-weight: var(--font-weight-semibold);
+}
+
+.modalSecondaryBtn {
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  color: var(--color-text-primary);
+}
+
+.modalDangerBtn {
+  border: 1px solid rgba(192, 57, 43, 0.5);
+  background: var(--color-error);
+  color: var(--color-white);
+}
+
+.modalSecondaryBtn:disabled,
+.modalDangerBtn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
 }
 
 @media (max-width: 980px) {

--- a/src/web/src/pages/Appointment/AppointmentPage.tsx
+++ b/src/web/src/pages/Appointment/AppointmentPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import {
   getAvailableAppointmentSlots,
   bookAppointment,
+  cancelAppointment,
   rescheduleAppointment,
   type AvailableAppointmentSlot,
 } from '../../api/appointments'
@@ -71,6 +72,8 @@ export function AppointmentPage() {
   const [selectedSlot, setSelectedSlot] = useState<AvailableAppointmentSlot | null>(null)
   const [currentAppointment, setCurrentAppointment] = useState<CurrentAppointment | null>(null)
   const [booking, setBooking] = useState<BookingState>({ status: 'idle' })
+  const [showCancelModal, setShowCancelModal] = useState(false)
+  const [isCancelling, setIsCancelling] = useState(false)
 
   useEffect(() => {
     if (!isGuid(organisationId)) {
@@ -173,6 +176,51 @@ export function AppointmentPage() {
     }
   }
 
+  async function handleConfirmCancel() {
+    if (!currentAppointment || !isGuid(organisationId)) return
+
+    setIsCancelling(true)
+
+    try {
+      const result = await cancelAppointment(currentAppointment.appointmentId, organisationId)
+
+      if (toDateOnly(new Date(currentAppointment.slotStart)) === toDateOnly(selectedDate)) {
+        setSlots(prev => {
+          const exists = prev.some(
+            s => s.slotStart === currentAppointment.slotStart && s.slotEnd === currentAppointment.slotEnd,
+          )
+
+          if (exists) return prev
+
+          return [...prev, {
+            slotStart: currentAppointment.slotStart,
+            slotEnd: currentAppointment.slotEnd,
+          }].sort((a, b) => a.slotStart.localeCompare(b.slotStart))
+        })
+      }
+
+      setCurrentAppointment(null)
+      setSelectedSlot(null)
+      setShowCancelModal(false)
+
+      setBooking({
+        status: 'success',
+        appointmentId: result.appointmentId,
+        message: result.lateCancellation
+          ? 'Appointment cancelled (late cancellation recorded). ID:'
+          : 'Appointment cancelled. ID:',
+      })
+    } catch (err) {
+      const apiErr = err as ApiError
+      setBooking({
+        status: 'error',
+        detail: apiErr.detail ?? 'Could not cancel appointment.',
+      })
+    } finally {
+      setIsCancelling(false)
+    }
+  }
+
   const hasValidOrg = isGuid(organisationId)
   const isRescheduleMode = currentAppointment !== null
 
@@ -204,6 +252,7 @@ export function AppointmentPage() {
               setOrganisationId(e.target.value)
               setCurrentAppointment(null)
               setSelectedSlot(null)
+              setShowCancelModal(false)
               setBooking({ status: 'idle' })
             }}
             placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -238,6 +287,14 @@ export function AppointmentPage() {
               <p className={styles.currentAppointmentLine}>
                 Slot: <strong>{formatSlotRange(currentAppointment.slotStart, currentAppointment.slotEnd)}</strong>
               </p>
+              <button
+                type="button"
+                className={styles.cancelTriggerBtn}
+                onClick={() => setShowCancelModal(true)}
+                data-testid="open-cancel-modal-btn"
+              >
+                Cancel appointment
+              </button>
             </div>
           )}
 
@@ -315,6 +372,39 @@ export function AppointmentPage() {
           )}
         </section>
       </main>
+
+      {showCancelModal && currentAppointment && (
+        <div className={styles.modalOverlay} onClick={() => setShowCancelModal(false)} role="presentation">
+          <div className={styles.modalCard} onClick={e => e.stopPropagation()}>
+            <h2 className={styles.modalTitle}>Cancel appointment?</h2>
+            <p className={styles.modalBody}>
+              This will free the slot for other users.
+            </p>
+            <p className={styles.modalBody}>
+              Slot: <strong>{formatSlotRange(currentAppointment.slotStart, currentAppointment.slotEnd)}</strong>
+            </p>
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalSecondaryBtn}
+                onClick={() => setShowCancelModal(false)}
+                disabled={isCancelling}
+              >
+                Keep appointment
+              </button>
+              <button
+                type="button"
+                className={styles.modalDangerBtn}
+                onClick={handleConfirmCancel}
+                disabled={isCancelling}
+                data-testid="confirm-cancel-btn"
+              >
+                {isCancelling ? 'Cancelling...' : 'Confirm cancellation'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/tests/NextTurn.IntegrationTests/Appointment/CancelAppointmentIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Appointment/CancelAppointmentIntegrationTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Domain.Appointment.Enums;
+using NextTurn.Domain.Auth;
+using NextTurn.Infrastructure.Persistence;
+
+namespace NextTurn.IntegrationTests.Appointment;
+
+[Collection("Integration")]
+public sealed class CancelAppointmentIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+
+    public CancelAppointmentIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _) = await _factory.SeedQueueAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CancelAppointment_ReleasesSlotAndPersistsCancelledStatus()
+    {
+        var ownerId = Guid.NewGuid();
+        var ownerClient = AuthenticatedClient(UserRole.User, ownerId, _tenantId);
+
+        var date = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(2));
+        var (slotStart, slotEnd) = SlotAt(date, 10, 0);
+
+        var booking = await ownerClient.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            slotStart,
+            slotEnd,
+        });
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        var cancel = await ownerClient.PostAsync($"/api/appointments/{booked!.AppointmentId}/cancel", null);
+        cancel.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var cancelled = await cancel.Content.ReadFromJsonAsync<CancelAppointmentApiResult>();
+        cancelled.Should().NotBeNull();
+        cancelled!.AppointmentId.Should().Be(booked.AppointmentId);
+        cancelled.LateCancellation.Should().BeFalse();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var persisted = await db.Appointments
+            .IgnoreQueryFilters()
+            .FirstAsync(a => a.Id == booked.AppointmentId);
+
+        persisted.Status.Should().Be(AppointmentStatus.Cancelled);
+        persisted.LateCancellation.Should().BeFalse();
+
+        var dateText = date.ToString("yyyy-MM-dd");
+        var slotsResponse = await ownerClient.GetAsync($"/api/appointments/slots?organisationId={_tenantId}&date={dateText}");
+        slotsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var slots = await slotsResponse.Content.ReadFromJsonAsync<List<SlotDto>>();
+        slots.Should().NotBeNull();
+        slots!.Should().Contain(s => s.SlotStart == slotStart && s.SlotEnd == slotEnd,
+            "cancelled slot should become available again");
+
+        var anotherUser = AuthenticatedClient(UserRole.User, Guid.NewGuid(), _tenantId);
+        var rebook = await anotherUser.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            slotStart,
+            slotEnd,
+        });
+
+        rebook.StatusCode.Should().Be(HttpStatusCode.OK,
+            "slot must be bookable after cancellation");
+    }
+
+    private HttpClient AuthenticatedClient(UserRole role, Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(role, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private static (DateTimeOffset SlotStart, DateTimeOffset SlotEnd) SlotAt(DateOnly date, int hour, int minute)
+    {
+        var slotStart = new DateTimeOffset(date.ToDateTime(new TimeOnly(hour, minute)), TimeSpan.Zero);
+        var slotEnd = slotStart.AddMinutes(30);
+        return (slotStart, slotEnd);
+    }
+
+    private sealed record BookAppointmentApiResult(Guid AppointmentId);
+
+    private sealed record CancelAppointmentApiResult(Guid AppointmentId, bool LateCancellation);
+
+    private sealed record SlotDto(DateTimeOffset SlotStart, DateTimeOffset SlotEnd);
+}

--- a/tests/NextTurn.UnitTests/Application/Appointment/CancelAppointmentCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/CancelAppointmentCommandHandlerTests.cs
@@ -1,0 +1,128 @@
+using FluentAssertions;
+using MediatR;
+using Moq;
+using NextTurn.Application.Appointment.Commands.CancelAppointment;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Appointment.Repositories;
+using NextTurn.Domain.Common;
+using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+
+namespace NextTurn.UnitTests.Application.Appointment;
+
+public sealed class CancelAppointmentCommandHandlerTests
+{
+    private readonly Mock<IAppointmentRepository> _appointmentRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<IPublisher> _publisherMock = new();
+
+    private readonly CancelAppointmentCommandHandler _handler;
+
+    private static readonly Guid AppointmentId = Guid.NewGuid();
+    private static readonly Guid OrganisationId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    public CancelAppointmentCommandHandlerTests()
+    {
+        var appointment = AppointmentEntity.Create(
+            OrganisationId,
+            UserId,
+            DateTimeOffset.UtcNow.AddHours(36),
+            DateTimeOffset.UtcNow.AddHours(36).AddMinutes(30));
+
+        _appointmentRepositoryMock
+            .Setup(r => r.GetByIdAsync(AppointmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(appointment);
+
+        _appointmentRepositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<AppointmentEntity>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _publisherMock
+            .Setup(p => p.Publish(It.IsAny<AppointmentCancelledNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new CancelAppointmentCommandHandler(
+            _appointmentRepositoryMock.Object,
+            _contextMock.Object,
+            _publisherMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CancelsAndPublishesNotification()
+    {
+        var result = await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        result.AppointmentId.Should().NotBeEmpty();
+        result.LateCancellation.Should().BeFalse();
+
+        _appointmentRepositoryMock.Verify(
+            r => r.UpdateAsync(
+                It.Is<AppointmentEntity>(a => a.Status == NextTurn.Domain.Appointment.Enums.AppointmentStatus.Cancelled),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _publisherMock.Verify(p => p.Publish(It.IsAny<AppointmentCancelledNotification>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenWrongUser_ThrowsDomainException()
+    {
+        var command = new CancelAppointmentCommand(AppointmentId, Guid.NewGuid());
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("You can only cancel your own appointment.");
+
+        _appointmentRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<AppointmentEntity>(), It.IsAny<CancellationToken>()), Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPastAppointment_ThrowsDomainException()
+    {
+        var past = AppointmentEntity.Create(
+            OrganisationId,
+            UserId,
+            DateTimeOffset.UtcNow.AddHours(-2),
+            DateTimeOffset.UtcNow.AddHours(-1));
+
+        _appointmentRepositoryMock
+            .Setup(r => r.GetByIdAsync(AppointmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(past);
+
+        var act = async () => await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Past appointments cannot be cancelled.");
+
+        _appointmentRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<AppointmentEntity>(), It.IsAny<CancellationToken>()), Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenWithin24Hours_ReturnsLateCancellationTrue()
+    {
+        var near = AppointmentEntity.Create(
+            OrganisationId,
+            UserId,
+            DateTimeOffset.UtcNow.AddHours(8),
+            DateTimeOffset.UtcNow.AddHours(8).AddMinutes(30));
+
+        _appointmentRepositoryMock
+            .Setup(r => r.GetByIdAsync(AppointmentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(near);
+
+        var result = await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        result.LateCancellation.Should().BeTrue();
+    }
+
+    private static CancelAppointmentCommand ValidCommand() =>
+        new(AppointmentId, UserId);
+}

--- a/tests/NextTurn.UnitTests/Domain/Appointment/AppointmentTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Appointment/AppointmentTests.cs
@@ -94,15 +94,64 @@ public sealed class AppointmentTests
     [Fact]
     public void Cancel_SetsStatusCancelled()
     {
+        var start = DateTimeOffset.UtcNow.AddHours(30);
         var appointment = AppointmentEntity.Create(
             OrgId,
             UserId,
-            new DateTimeOffset(2026, 3, 20, 10, 0, 0, TimeSpan.Zero),
-            new DateTimeOffset(2026, 3, 20, 10, 30, 0, TimeSpan.Zero));
+            start,
+            start.AddMinutes(30));
 
         appointment.Cancel();
 
         appointment.Status.Should().Be(AppointmentStatus.Cancelled);
+        appointment.LateCancellation.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Cancel_Within24Hours_SetsLateCancellationTrue()
+    {
+        var start = DateTimeOffset.UtcNow.AddHours(12);
+        var appointment = AppointmentEntity.Create(
+            OrgId,
+            UserId,
+            start,
+            start.AddMinutes(30));
+
+        appointment.Cancel();
+
+        appointment.Status.Should().Be(AppointmentStatus.Cancelled);
+        appointment.LateCancellation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Cancel_WhenPastAppointment_ThrowsDomainException()
+    {
+        var appointment = AppointmentEntity.Create(
+            OrgId,
+            UserId,
+            DateTimeOffset.UtcNow.AddHours(-2),
+            DateTimeOffset.UtcNow.AddHours(-1));
+
+        var act = () => appointment.Cancel();
+
+        act.Should().Throw<DomainException>().WithMessage("Past appointments cannot be cancelled.");
+    }
+
+    [Fact]
+    public void Cancel_WhenAlreadyCancelled_ThrowsDomainException()
+    {
+        var start = DateTimeOffset.UtcNow.AddHours(2);
+        var appointment = AppointmentEntity.Create(
+            OrgId,
+            UserId,
+            start,
+            start.AddMinutes(30));
+
+        appointment.Cancel();
+
+        var act = () => appointment.Cancel();
+
+        act.Should().Throw<DomainException>().WithMessage("Appointment is already cancelled.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
This PR implements NT-21: users can cancel their own appointments and free the slot for others.

Key behavior delivered:
- Appointment is marked Cancelled in DB
- Slot becomes available again for new bookings
- Only appointment owner can cancel
- Past appointments cannot be cancelled
- Cancellations within 24 hours are allowed and recorded via LateCancellation flag
- Cancellation event is published to a stub notification handler (log-only)

## Architecture
Implemented within the existing modular monolith Appointment module.

### Domain
- Added cancellation guards and late-cancel flag in Appointment.cs
  - Past appointment guard
  - Already-cancelled guard
  - Active-status guard
  - LateCancellation set when slot is within 24 hours

### Application
- Added command flow:
  - CancelAppointmentCommand.cs
  - CancelAppointmentCommandValidator.cs
  - CancelAppointmentCommandHandler.cs
  - CancelAppointmentResult.cs
- Added notification event + stub handler:
  - AppointmentCancelledNotification.cs
  - AppointmentCancelledNotificationHandler.cs

### Infrastructure
- Persisted LateCancellation via EF mapping:
  - AppointmentConfiguration.cs
- Added migration:
  - 20260315022842_AddLateCancellationToAppointments.cs

### API
- Added endpoint:
  - POST /api/appointments/{appointmentId}/cancel
- Controller update:
  - AppointmentsController.cs

### Frontend
- Added cancel API call:
  - appointments.ts
- Added cancellation UX in appointment detail view:
  - Cancel button
  - Confirmation modal
  - Success/error handling and UI state updates
- Files:
  - AppointmentPage.tsx
  - AppointmentPage.module.css

## Acceptance Criteria Mapping
- Mark Cancelled and slot becomes available:
  - Domain status transition + repository availability filtering + integration test rebook check
- Owner-only cancel:
  - Handler validates appointment.UserId against authenticated user ID
- Past appointments cannot be cancelled:
  - DomainException thrown by aggregate guard
- Late cancellation flag:
  - Computed in domain and persisted in DB via new column/mapping

## Tests
### Unit
- Domain cancellation behavior and guards:
  - AppointmentTests.cs
- Application handler behavior:
  - CancelAppointmentCommandHandlerTests.cs

### Integration
- Cancelling appointment persists status and frees slot for rebooking:
  - CancelAppointmentIntegrationTests.cs

## Validation
- Solution build: pass
- Frontend build: pass
- Appointment unit tests: pass
- Unit coverage (Domain + Application): Line 82.27%, Branch 85.29% (>=80%)
- Integration tests: implemented; execution requires Docker/Testcontainers runtime

## Commits (Granular)
- f680481 feat(domain): add cancel guards and LateCancellation flag
- 714cb35 feat(application): add CancelAppointment command and stub notification
- 29aa9ea feat(infrastructure): persist appointment late-cancellation flag
- 8755334 NT-21-feat(api): add appointment cancellation endpoint
- 9b99fc6 NT-21- feat(web): add appointment cancellation modal and action
- c53986b NT-21-test(appointments): add cancellation guards and slot-release tests

## Reviewer Notes
- Please focus review on:
  - Domain guard semantics for cancellation
  - LateCancellation persistence and mapping
  - Owner-check enforcement path
  - Slot release behavior (availability + rebook) in integration coverage