### PR TITLE
Feature/NT-23 staff dashboard

### DIFF
--- a/src/NextTurn.API/Controllers/QueuesController.cs
+++ b/src/NextTurn.API/Controllers/QueuesController.cs
@@ -3,9 +3,14 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NextTurn.API.Models.Queues;
+using NextTurn.Application.Queue.Commands.CallNext;
 using NextTurn.Application.Queue.Commands.CreateQueue;
 using NextTurn.Application.Queue.Commands.JoinQueue;
 using NextTurn.Application.Queue.Commands.LeaveQueue;
+using NextTurn.Application.Queue.Commands.MarkNoShow;
+using NextTurn.Application.Queue.Commands.MarkServed;
+using NextTurn.Application.Queue.Commands;
+using NextTurn.Application.Queue.Queries.GetQueueDashboard;
 using NextTurn.Application.Queue.Queries.GetMyQueues;
 using NextTurn.Application.Queue.Queries.GetQueueStatus;
 using NextTurn.Application.Queue.Queries.ListOrgQueues;
@@ -276,6 +281,83 @@ public sealed class QueuesController : ControllerBase
         var query  = new GetQueueStatusQuery(queueId, userId);
         var result = await _sender.Send(query, cancellationToken);
 
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Returns staff dashboard data for a queue: current serving ticket and waiting list.
+    /// </summary>
+    [HttpGet("{queueId:guid}/dashboard")]
+    [Authorize(Policy = "IsStaff")]
+    [ProducesResponseType(typeof(GetQueueDashboardResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> GetQueueDashboard(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetQueueDashboardQuery(queueId);
+        var result = await _sender.Send(query, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Calls the next waiting ticket into service.
+    /// </summary>
+    [HttpPost("{queueId:guid}/call-next")]
+    [Authorize(Policy = "IsStaff")]
+    [ProducesResponseType(typeof(QueueEntryActionResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> CallNext(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        var command = new CallNextCommand(queueId);
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Marks the currently serving ticket as served.
+    /// </summary>
+    [HttpPost("{queueId:guid}/served")]
+    [Authorize(Policy = "IsStaff")]
+    [ProducesResponseType(typeof(QueueEntryActionResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> MarkServed(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        var command = new MarkServedCommand(queueId);
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Marks the currently serving ticket as no-show.
+    /// </summary>
+    [HttpPost("{queueId:guid}/no-show")]
+    [Authorize(Policy = "IsStaff")]
+    [ProducesResponseType(typeof(QueueEntryActionResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> MarkNoShow(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        var command = new MarkNoShowCommand(queueId);
+        var result = await _sender.Send(command, cancellationToken);
         return Ok(result);
     }
 }

--- a/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommand.cs
+++ b/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using NextTurn.Application.Queue.Commands;
+
+namespace NextTurn.Application.Queue.Commands.CallNext;
+
+public sealed record CallNextCommand(Guid QueueId) : IRequest<QueueEntryActionResult>;

--- a/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommandHandler.cs
@@ -1,0 +1,59 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+
+namespace NextTurn.Application.Queue.Commands.CallNext;
+
+public sealed class CallNextCommandHandler : IRequestHandler<CallNextCommand, QueueEntryActionResult>
+{
+    private const string OneServingIndexName = "UX_QueueEntries_QueueId_OneServing";
+
+    private readonly IQueueRepository _queueRepository;
+    private readonly IApplicationDbContext _context;
+
+    public CallNextCommandHandler(
+        IQueueRepository queueRepository,
+        IApplicationDbContext context)
+    {
+        _queueRepository = queueRepository;
+        _context = context;
+    }
+
+    public async Task<QueueEntryActionResult> Handle(
+        CallNextCommand command,
+        CancellationToken cancellationToken)
+    {
+        var queue = await _queueRepository.GetByIdAsync(command.QueueId, cancellationToken);
+        if (queue is null)
+            throw new DomainException("Queue not found.");
+
+        var currentServing = await _queueRepository.GetCurrentServingEntryAsync(command.QueueId, cancellationToken);
+        if (currentServing is not null)
+            throw new ConflictDomainException("A ticket is already being served.");
+
+        var nextWaiting = await _queueRepository.GetNextWaitingEntryAsync(command.QueueId, cancellationToken);
+        if (nextWaiting is null)
+            throw new DomainException("No waiting entries in this queue.");
+
+        nextWaiting.StartServing();
+
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsOneServingConflict(ex))
+        {
+            throw new ConflictDomainException("A ticket is already being served.");
+        }
+
+        return new QueueEntryActionResult(nextWaiting.Id, nextWaiting.TicketNumber, nextWaiting.Status.ToString());
+    }
+
+    private static bool IsOneServingConflict(DbUpdateException ex)
+    {
+        return ex.ToString().Contains(OneServingIndexName, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommandValidator.cs
+++ b/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Commands.CallNext;
+
+public sealed class CallNextCommandValidator : AbstractValidator<CallNextCommand>
+{
+    public CallNextCommandValidator()
+    {
+        RuleFor(x => x.QueueId)
+            .NotEmpty().WithMessage("Queue ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommand.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using NextTurn.Application.Queue.Commands;
+
+namespace NextTurn.Application.Queue.Commands.MarkNoShow;
+
+public sealed record MarkNoShowCommand(Guid QueueId) : IRequest<QueueEntryActionResult>;

--- a/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+
+namespace NextTurn.Application.Queue.Commands.MarkNoShow;
+
+public sealed class MarkNoShowCommandHandler : IRequestHandler<MarkNoShowCommand, QueueEntryActionResult>
+{
+    private readonly IQueueRepository _queueRepository;
+    private readonly IApplicationDbContext _context;
+
+    public MarkNoShowCommandHandler(
+        IQueueRepository queueRepository,
+        IApplicationDbContext context)
+    {
+        _queueRepository = queueRepository;
+        _context = context;
+    }
+
+    public async Task<QueueEntryActionResult> Handle(
+        MarkNoShowCommand command,
+        CancellationToken cancellationToken)
+    {
+        var queue = await _queueRepository.GetByIdAsync(command.QueueId, cancellationToken);
+        if (queue is null)
+            throw new DomainException("Queue not found.");
+
+        var servingEntry = await _queueRepository.GetCurrentServingEntryAsync(command.QueueId, cancellationToken);
+        if (servingEntry is null)
+            throw new DomainException("No entry is currently being served.");
+
+        servingEntry.MarkNoShow();
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return new QueueEntryActionResult(servingEntry.Id, servingEntry.TicketNumber, servingEntry.Status.ToString());
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandValidator.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Commands.MarkNoShow;
+
+public sealed class MarkNoShowCommandValidator : AbstractValidator<MarkNoShowCommand>
+{
+    public MarkNoShowCommandValidator()
+    {
+        RuleFor(x => x.QueueId)
+            .NotEmpty().WithMessage("Queue ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommand.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using NextTurn.Application.Queue.Commands;
+
+namespace NextTurn.Application.Queue.Commands.MarkServed;
+
+public sealed record MarkServedCommand(Guid QueueId) : IRequest<QueueEntryActionResult>;

--- a/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommandHandler.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+
+namespace NextTurn.Application.Queue.Commands.MarkServed;
+
+public sealed class MarkServedCommandHandler : IRequestHandler<MarkServedCommand, QueueEntryActionResult>
+{
+    private readonly IQueueRepository _queueRepository;
+    private readonly IApplicationDbContext _context;
+
+    public MarkServedCommandHandler(
+        IQueueRepository queueRepository,
+        IApplicationDbContext context)
+    {
+        _queueRepository = queueRepository;
+        _context = context;
+    }
+
+    public async Task<QueueEntryActionResult> Handle(
+        MarkServedCommand command,
+        CancellationToken cancellationToken)
+    {
+        var queue = await _queueRepository.GetByIdAsync(command.QueueId, cancellationToken);
+        if (queue is null)
+            throw new DomainException("Queue not found.");
+
+        var servingEntry = await _queueRepository.GetCurrentServingEntryAsync(command.QueueId, cancellationToken);
+        if (servingEntry is null)
+            throw new DomainException("No entry is currently being served.");
+
+        servingEntry.MarkServed();
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return new QueueEntryActionResult(servingEntry.Id, servingEntry.TicketNumber, servingEntry.Status.ToString());
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommandValidator.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Commands.MarkServed;
+
+public sealed class MarkServedCommandValidator : AbstractValidator<MarkServedCommand>
+{
+    public MarkServedCommandValidator()
+    {
+        RuleFor(x => x.QueueId)
+            .NotEmpty().WithMessage("Queue ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/QueueEntryActionResult.cs
+++ b/src/NextTurn.Application/Queue/Commands/QueueEntryActionResult.cs
@@ -1,0 +1,9 @@
+namespace NextTurn.Application.Queue.Commands;
+
+/// <summary>
+/// Minimal response for staff ticket transition actions.
+/// </summary>
+public sealed record QueueEntryActionResult(
+    Guid EntryId,
+    int TicketNumber,
+    string Status);

--- a/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardQuery.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardQuery.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace NextTurn.Application.Queue.Queries.GetQueueDashboard;
+
+/// <summary>
+/// Returns a staff-facing snapshot of a queue: current serving ticket and waiting line.
+/// </summary>
+public sealed record GetQueueDashboardQuery(Guid QueueId) : IRequest<GetQueueDashboardResult>;

--- a/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardQueryHandler.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardQueryHandler.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+
+namespace NextTurn.Application.Queue.Queries.GetQueueDashboard;
+
+public sealed class GetQueueDashboardQueryHandler
+    : IRequestHandler<GetQueueDashboardQuery, GetQueueDashboardResult>
+{
+    private readonly IQueueRepository _queueRepository;
+
+    public GetQueueDashboardQueryHandler(IQueueRepository queueRepository)
+    {
+        _queueRepository = queueRepository;
+    }
+
+    public async Task<GetQueueDashboardResult> Handle(
+        GetQueueDashboardQuery query,
+        CancellationToken cancellationToken)
+    {
+        var queue = await _queueRepository.GetByIdAsync(query.QueueId, cancellationToken);
+        if (queue is null)
+            throw new DomainException("Queue not found.");
+
+        var currentServing = await _queueRepository.GetCurrentServingEntryAsync(query.QueueId, cancellationToken);
+        var waitingEntries = await _queueRepository.GetWaitingEntriesAsync(query.QueueId, cancellationToken);
+
+        return new GetQueueDashboardResult(
+            QueueId: query.QueueId,
+            QueueName: queue.Name,
+            QueueStatus: queue.Status.ToString(),
+            WaitingCount: waitingEntries.Count,
+            CurrentlyServing: currentServing is null
+                ? null
+                : new QueueDashboardEntry(currentServing.Id, currentServing.TicketNumber, currentServing.JoinedAt),
+            WaitingEntries: waitingEntries
+                .Select(e => new QueueDashboardEntry(e.Id, e.TicketNumber, e.JoinedAt))
+                .ToList());
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardQueryValidator.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardQueryValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Queries.GetQueueDashboard;
+
+public sealed class GetQueueDashboardQueryValidator : AbstractValidator<GetQueueDashboardQuery>
+{
+    public GetQueueDashboardQueryValidator()
+    {
+        RuleFor(x => x.QueueId)
+            .NotEmpty().WithMessage("Queue ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardResult.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueueDashboard/GetQueueDashboardResult.cs
@@ -1,0 +1,14 @@
+namespace NextTurn.Application.Queue.Queries.GetQueueDashboard;
+
+public sealed record QueueDashboardEntry(
+    Guid EntryId,
+    int TicketNumber,
+    DateTimeOffset JoinedAt);
+
+public sealed record GetQueueDashboardResult(
+    Guid QueueId,
+    string QueueName,
+    string QueueStatus,
+    int WaitingCount,
+    QueueDashboardEntry? CurrentlyServing,
+    IReadOnlyList<QueueDashboardEntry> WaitingEntries);

--- a/src/NextTurn.Domain/Queue/Entities/QueueEntry.cs
+++ b/src/NextTurn.Domain/Queue/Entities/QueueEntry.cs
@@ -89,4 +89,46 @@ public class QueueEntry
 
         Status = QueueEntryStatus.Cancelled;
     }
+
+    /// <summary>
+    /// Marks a waiting ticket as currently being served.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the entry is not in <see cref="QueueEntryStatus.Waiting"/>.
+    /// </exception>
+    public void StartServing()
+    {
+        if (Status != QueueEntryStatus.Waiting)
+            throw new DomainException("Only waiting queue entries can be moved to serving.");
+
+        Status = QueueEntryStatus.Serving;
+    }
+
+    /// <summary>
+    /// Marks a currently serving ticket as served.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the entry is not in <see cref="QueueEntryStatus.Serving"/>.
+    /// </exception>
+    public void MarkServed()
+    {
+        if (Status != QueueEntryStatus.Serving)
+            throw new DomainException("Only a serving queue entry can be marked as served.");
+
+        Status = QueueEntryStatus.Served;
+    }
+
+    /// <summary>
+    /// Marks a currently serving ticket as no-show.
+    /// </summary>
+    /// <exception cref="DomainException">
+    /// Thrown when the entry is not in <see cref="QueueEntryStatus.Serving"/>.
+    /// </exception>
+    public void MarkNoShow()
+    {
+        if (Status != QueueEntryStatus.Serving)
+            throw new DomainException("Only a serving queue entry can be marked as no-show.");
+
+        Status = QueueEntryStatus.NoShow;
+    }
 }

--- a/src/NextTurn.Domain/Queue/Repositories/IQueueRepository.cs
+++ b/src/NextTurn.Domain/Queue/Repositories/IQueueRepository.cs
@@ -94,4 +94,21 @@ public interface IQueueRepository
     /// </summary>
     Task<IReadOnlyList<(Guid QueueId, Guid OrganisationId, string QueueName, int TicketNumber, string Status)>>
         GetUserActiveEntriesAsync(Guid userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the currently serving entry in a queue, or <c>null</c> if none is being served.
+    /// </summary>
+    Task<QueueEntry?> GetCurrentServingEntryAsync(Guid queueId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the next waiting entry (lowest ticket number) in a queue, or <c>null</c>
+    /// if no one is waiting.
+    /// </summary>
+    Task<QueueEntry?> GetNextWaitingEntryAsync(Guid queueId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns all waiting entries for a queue ordered by ticket number.
+    /// Used by the staff dashboard to show who is next.
+    /// </summary>
+    Task<IReadOnlyList<QueueEntry>> GetWaitingEntriesAsync(Guid queueId, CancellationToken cancellationToken);
 }

--- a/src/NextTurn.Infrastructure/Migrations/20260315033457_AddQueueServingUniqueness.Designer.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260315033457_AddQueueServingUniqueness.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NextTurn.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using NextTurn.Infrastructure.Persistence;
 namespace NextTurn.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260315033457_AddQueueServingUniqueness")]
+    partial class AddQueueServingUniqueness
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NextTurn.Infrastructure/Migrations/20260315033457_AddQueueServingUniqueness.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260315033457_AddQueueServingUniqueness.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NextTurn.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQueueServingUniqueness : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "UX_QueueEntries_QueueId_OneServing",
+                table: "QueueEntries",
+                column: "QueueId",
+                unique: true,
+                filter: "[Status] = 'Serving'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UX_QueueEntries_QueueId_OneServing",
+                table: "QueueEntries");
+        }
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Queue/QueueEntryConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Queue/QueueEntryConfiguration.cs
@@ -65,5 +65,12 @@ public class QueueEntryConfiguration : IEntityTypeConfiguration<QueueEntry>
         // Separate index for the HasActiveEntryAsync duplicate-join check.
         builder.HasIndex(e => new { e.QueueId, e.UserId })
             .HasDatabaseName("IX_QueueEntries_QueueId_UserId");
+
+        // Enforce "at most one Serving entry per queue" at the DB layer.
+        // The filtered unique index is a concurrency safety net for parallel staff actions.
+        builder.HasIndex(e => e.QueueId)
+            .HasDatabaseName("UX_QueueEntries_QueueId_OneServing")
+            .IsUnique()
+            .HasFilter("[Status] = 'Serving'");
     }
 }

--- a/src/NextTurn.Infrastructure/Queue/QueueRepository.cs
+++ b/src/NextTurn.Infrastructure/Queue/QueueRepository.cs
@@ -172,4 +172,37 @@ public sealed class QueueRepository : IQueueRepository
             .Select(x => ValueTuple.Create(x.Id, x.OrganisationId, x.Name, x.TicketNumber, x.StatusStr))
             .ToListAsync(cancellationToken);
     }
+
+    /// <inheritdoc/>
+    public async Task<QueueEntry?> GetCurrentServingEntryAsync(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        return await _context.QueueEntries
+            .FirstOrDefaultAsync(
+                e => e.QueueId == queueId && e.Status == QueueEntryStatus.Serving,
+                cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<QueueEntry?> GetNextWaitingEntryAsync(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        return await _context.QueueEntries
+            .Where(e => e.QueueId == queueId && e.Status == QueueEntryStatus.Waiting)
+            .OrderBy(e => e.TicketNumber)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<QueueEntry>> GetWaitingEntriesAsync(
+        Guid queueId,
+        CancellationToken cancellationToken)
+    {
+        return await _context.QueueEntries
+            .Where(e => e.QueueId == queueId && e.Status == QueueEntryStatus.Waiting)
+            .OrderBy(e => e.TicketNumber)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -9,7 +9,7 @@
  *  /login/:tenantId        → LoginPage    (org-member)
  *  /dashboard              → ProtectedRoute → DashboardPage (consumer user, no tenantId)
  *  /dashboard/:tenantId    → ProtectedRoute → DashboardPage
- *  /staff/:tenantId        → ProtectedRoute (Staff+)    → stub
+ *  /staff/:tenantId        → ProtectedRoute (Staff+)    → StaffDashboardPage
  *  /admin/:tenantId        → ProtectedRoute (OrgAdmin+) → AdminDashboardPage
  *  /system/:tenantId       → ProtectedRoute (SystemAdmin) → stub
  *  /queues/:tenantId/:queueId → ProtectedRoute → QueuePage
@@ -30,12 +30,11 @@ import { ProtectedRoute }       from './components/ProtectedRoute'
 import { QueuePage }            from './pages/Queue'
 import { AppointmentPage }      from './pages/Appointment'
 import { AdminDashboardPage }   from './pages/Admin'
+import { StaffDashboardPage }   from './pages/Staff'
 import { TermsPage, PrivacyPage } from './pages/Legal'
 
 // ── Role-restricted stub pages ────────────────────────────────────────────────
-// Temporary placeholders so the route guards have real targets during NT-12
-// testing and the sprint demo. Replace with real feature pages in Sprint 2+.
-const StaffStub     = () => <main style={{ padding: '2rem' }}><h1>Staff Area — Sprint 2</h1></main>
+// System admin area is still a placeholder until the corresponding story lands.
 const SystemAdminStub = () => <main style={{ padding: '2rem' }}><h1>System Area — Sprint 2</h1></main>
 
 function App() {
@@ -74,7 +73,7 @@ function App() {
         path="/staff/:tenantId"
         element={
           <ProtectedRoute allowedRoles={['Staff', 'OrgAdmin', 'SystemAdmin']}>
-            <StaffStub />
+            <StaffDashboardPage />
           </ProtectedRoute>
         }
       />

--- a/src/web/src/api/__tests__/queues.test.ts
+++ b/src/web/src/api/__tests__/queues.test.ts
@@ -37,11 +37,17 @@ vi.mock('../../utils/authToken', () => ({
 }))
 
 import {
+  callNext,
   joinQueue,
+  getQueueDashboard,
   createQueue,
   getQueueStatus,
+  markNoShow,
+  markServed,
   type JoinQueueResult,
   type CreateQueueResult,
+  type QueueDashboardResult,
+  type QueueEntryActionResult,
   type QueueStatusResult,
 } from '../../api/queues'
 import { apiClient } from '../../api/client'
@@ -315,5 +321,94 @@ describe('getQueueStatus — errors', () => {
     await expect(getQueueStatus(QUEUE_ID, TENANT_ID)).rejects.toMatchObject({
       status: 401,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// staff dashboard endpoints
+// ---------------------------------------------------------------------------
+
+const SAMPLE_DASHBOARD: QueueDashboardResult = {
+  queueId: QUEUE_ID,
+  queueName: 'Main Counter',
+  queueStatus: 'Active',
+  waitingCount: 2,
+  currentlyServing: null,
+  waitingEntries: [
+    { entryId: 'e-1', ticketNumber: 1, joinedAt: '2026-01-01T09:00:00Z' },
+    { entryId: 'e-2', ticketNumber: 2, joinedAt: '2026-01-01T09:02:00Z' },
+  ],
+}
+
+const SAMPLE_ACTION: QueueEntryActionResult = {
+  entryId: 'e-1',
+  ticketNumber: 1,
+  status: 'Serving',
+}
+
+describe('getQueueDashboard — success', () => {
+  beforeEach(() => {
+    mockGet.mockResolvedValueOnce({ status: 200, data: SAMPLE_DASHBOARD } as AxiosResponse)
+  })
+
+  it('returns dashboard data on 200', async () => {
+    const result = await getQueueDashboard(QUEUE_ID, TENANT_ID)
+    expect(result).toEqual(SAMPLE_DASHBOARD)
+  })
+
+  it('calls GET /queues/{queueId}/dashboard with auth headers', async () => {
+    await getQueueDashboard(QUEUE_ID, TENANT_ID)
+    expect(mockGet).toHaveBeenCalledWith(
+      `/queues/${QUEUE_ID}/dashboard`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-jwt-token',
+          'X-Tenant-Id': TENANT_ID,
+        }),
+      })
+    )
+  })
+})
+
+describe('staff action endpoints — success', () => {
+  it('callNext posts to /call-next', async () => {
+    mockPost.mockResolvedValueOnce({ status: 200, data: SAMPLE_ACTION } as AxiosResponse)
+
+    const result = await callNext(QUEUE_ID, TENANT_ID)
+
+    expect(result).toEqual(SAMPLE_ACTION)
+    expect(mockPost).toHaveBeenCalledWith(
+      `/queues/${QUEUE_ID}/call-next`,
+      null,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-jwt-token', 'X-Tenant-Id': TENANT_ID }),
+      })
+    )
+  })
+
+  it('markServed posts to /served', async () => {
+    mockPost.mockResolvedValueOnce({ status: 200, data: { ...SAMPLE_ACTION, status: 'Served' } } as AxiosResponse)
+
+    const result = await markServed(QUEUE_ID, TENANT_ID)
+
+    expect(result.status).toBe('Served')
+    expect(mockPost).toHaveBeenCalledWith(
+      `/queues/${QUEUE_ID}/served`,
+      null,
+      expect.any(Object)
+    )
+  })
+
+  it('markNoShow posts to /no-show', async () => {
+    mockPost.mockResolvedValueOnce({ status: 200, data: { ...SAMPLE_ACTION, status: 'NoShow' } } as AxiosResponse)
+
+    const result = await markNoShow(QUEUE_ID, TENANT_ID)
+
+    expect(result.status).toBe('NoShow')
+    expect(mockPost).toHaveBeenCalledWith(
+      `/queues/${QUEUE_ID}/no-show`,
+      null,
+      expect.any(Object)
+    )
   })
 })

--- a/src/web/src/api/queues.ts
+++ b/src/web/src/api/queues.ts
@@ -261,3 +261,123 @@ export async function leaveQueue(
     throw parseApiError(err)
   }
 }
+
+export interface QueueDashboardEntry {
+  entryId: string
+  ticketNumber: number
+  joinedAt: string
+}
+
+export interface QueueDashboardResult {
+  queueId: string
+  queueName: string
+  queueStatus: 'Active' | 'Paused' | 'Closed'
+  waitingCount: number
+  currentlyServing: QueueDashboardEntry | null
+  waitingEntries: QueueDashboardEntry[]
+}
+
+export interface QueueEntryActionResult {
+  entryId: string
+  ticketNumber: number
+  status: 'Serving' | 'Served' | 'NoShow'
+}
+
+/**
+ * GET /api/queues/{queueId}/dashboard
+ */
+export async function getQueueDashboard(
+  queueId: string,
+  tenantId: string,
+): Promise<QueueDashboardResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<QueueDashboardResult>(
+      `/queues/${queueId}/dashboard`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      }
+    )
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+/**
+ * POST /api/queues/{queueId}/call-next
+ */
+export async function callNext(
+  queueId: string,
+  tenantId: string,
+): Promise<QueueEntryActionResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<QueueEntryActionResult>(
+      `/queues/${queueId}/call-next`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      }
+    )
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+/**
+ * POST /api/queues/{queueId}/served
+ */
+export async function markServed(
+  queueId: string,
+  tenantId: string,
+): Promise<QueueEntryActionResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<QueueEntryActionResult>(
+      `/queues/${queueId}/served`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      }
+    )
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+/**
+ * POST /api/queues/{queueId}/no-show
+ */
+export async function markNoShow(
+  queueId: string,
+  tenantId: string,
+): Promise<QueueEntryActionResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<QueueEntryActionResult>(
+      `/queues/${queueId}/no-show`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      }
+    )
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}

--- a/src/web/src/pages/Staff/StaffDashboardPage.module.css
+++ b/src/web/src/pages/Staff/StaffDashboardPage.module.css
@@ -1,0 +1,317 @@
+.page {
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 0%, rgba(81, 154, 102, 0.20), transparent 35%), var(--color-surface);
+}
+
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--color-white);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.navInner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-4) var(--space-6);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.brandWrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.logo {
+  height: 40px;
+  width: auto;
+}
+
+.brandMeta {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  font-size: var(--font-size-xl);
+  color: var(--color-text-primary);
+  line-height: 1.2;
+}
+
+.subtitle {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.navActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.userChip {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-full);
+  background: var(--color-success-bg);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.logoutBtn {
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+}
+
+.main {
+  padding: var(--space-8) var(--space-6) var(--space-12);
+}
+
+.content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.errorBanner {
+  border: 1px solid var(--color-error-border);
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+}
+
+.selectorCard,
+.emptyCard,
+.loadingCard,
+.heroCard,
+.panel {
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-sm);
+}
+
+.selectorCard {
+  padding: var(--space-5);
+}
+
+.selectorLabel {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.selector {
+  width: 100%;
+  max-width: 420px;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+}
+
+.updatedAt {
+  margin-top: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.emptyCard,
+.loadingCard {
+  padding: var(--space-6);
+}
+
+.loadingCard {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.heroCard {
+  padding: var(--space-6);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-6);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.heroLabel {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.heroTitle {
+  font-size: var(--font-size-2xl);
+  color: var(--color-text-primary);
+  margin-top: var(--space-1);
+}
+
+.heroMeta {
+  margin-top: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.primaryBtn,
+.secondaryBtn,
+.ghostBtn {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid transparent;
+  font-weight: var(--font-weight-semibold);
+}
+
+.primaryBtn {
+  background: var(--color-primary);
+  color: var(--color-white);
+}
+
+.secondaryBtn {
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+}
+
+.ghostBtn {
+  background: var(--color-white);
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.primaryBtn:disabled,
+.secondaryBtn:disabled,
+.ghostBtn:disabled,
+.logoutBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-5);
+}
+
+.panel {
+  padding: var(--space-5);
+}
+
+.panelTitle {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-3);
+}
+
+.ticketNow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-3xl);
+  color: var(--color-primary-dark);
+}
+
+.ticketBadge {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
+  background: var(--color-success-bg);
+}
+
+.muted {
+  color: var(--color-text-secondary);
+}
+
+.waitingList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.waitingItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.waitingTicket {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+}
+
+.waitingMeta {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 900px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .navInner {
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .main {
+    padding: var(--space-6) var(--space-4) var(--space-10);
+  }
+}
+
+@media (max-width: 720px) {
+  .brandWrap {
+    gap: var(--space-3);
+  }
+
+  .title {
+    font-size: var(--font-size-lg);
+  }
+
+  .subtitle {
+    display: none;
+  }
+
+  .heroTitle {
+    font-size: var(--font-size-xl);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/web/src/pages/Staff/StaffDashboardPage.tsx
+++ b/src/web/src/pages/Staff/StaffDashboardPage.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  callNext,
+  getAvailableQueues,
+  getQueueDashboard,
+  markNoShow,
+  markServed,
+  type OrgQueueSummary,
+  type QueueDashboardResult,
+} from '../../api/queues'
+import type { ApiError } from '../../types/api'
+import { clearToken, getTokenPayload } from '../../utils/authToken'
+import logoImg from '../../assets/nextTurn-logo.png'
+import styles from './StaffDashboardPage.module.css'
+
+export function StaffDashboardPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const [queues, setQueues] = useState<OrgQueueSummary[]>([])
+  const [selectedQueueId, setSelectedQueueId] = useState<string | null>(null)
+  const [dashboard, setDashboard] = useState<QueueDashboardResult | null>(null)
+
+  const [loadingQueues, setLoadingQueues] = useState(true)
+  const [loadingDashboard, setLoadingDashboard] = useState(false)
+  const [actionBusy, setActionBusy] = useState<'call-next' | 'served' | 'no-show' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+
+  if (!payload) {
+    clearToken()
+    navigate('/', { replace: true })
+    return null
+  }
+
+  const loadDashboard = useCallback(async (queueId: string, showLoading: boolean) => {
+    if (!tenantId) return
+
+    if (showLoading) {
+      setLoadingDashboard(true)
+    }
+
+    try {
+      const result = await getQueueDashboard(queueId, tenantId)
+      setDashboard(result)
+      setLastUpdated(new Date())
+      setError(null)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Failed to load queue dashboard.')
+    } finally {
+      if (showLoading) {
+        setLoadingDashboard(false)
+      }
+    }
+  }, [tenantId])
+
+  useEffect(() => {
+    if (!tenantId) return
+
+    setLoadingQueues(true)
+    setError(null)
+
+    getAvailableQueues(tenantId)
+      .then((result) => {
+        setQueues(result)
+
+        if (result.length === 0) {
+          setSelectedQueueId(null)
+          setDashboard(null)
+          return
+        }
+
+        setSelectedQueueId((prev) => {
+          if (prev && result.some(q => q.queueId === prev)) {
+            return prev
+          }
+          return result[0].queueId
+        })
+      })
+      .catch((err: ApiError) => {
+        setError(err.detail ?? 'Failed to load queues.')
+      })
+      .finally(() => {
+        setLoadingQueues(false)
+      })
+  }, [tenantId])
+
+  useEffect(() => {
+    if (!selectedQueueId) return
+    void loadDashboard(selectedQueueId, true)
+  }, [selectedQueueId, loadDashboard])
+
+  useEffect(() => {
+    if (!selectedQueueId) return
+
+    const id = setInterval(() => {
+      void loadDashboard(selectedQueueId, false)
+    }, 30_000)
+
+    return () => clearInterval(id)
+  }, [selectedQueueId, loadDashboard])
+
+  async function handleCallNext() {
+    if (!tenantId || !selectedQueueId) return
+
+    setActionBusy('call-next')
+    setError(null)
+
+    try {
+      await callNext(selectedQueueId, tenantId)
+      await loadDashboard(selectedQueueId, false)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not call the next ticket.')
+    } finally {
+      setActionBusy(null)
+    }
+  }
+
+  async function handleMarkServed() {
+    if (!tenantId || !selectedQueueId) return
+
+    setActionBusy('served')
+    setError(null)
+
+    try {
+      await markServed(selectedQueueId, tenantId)
+      await loadDashboard(selectedQueueId, false)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not mark ticket as served.')
+    } finally {
+      setActionBusy(null)
+    }
+  }
+
+  async function handleMarkNoShow() {
+    if (!tenantId || !selectedQueueId) return
+
+    setActionBusy('no-show')
+    setError(null)
+
+    try {
+      await markNoShow(selectedQueueId, tenantId)
+      await loadDashboard(selectedQueueId, false)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not mark ticket as no-show.')
+    } finally {
+      setActionBusy(null)
+    }
+  }
+
+  function handleLogout() {
+    clearToken()
+    navigate('/', { replace: true })
+  }
+
+  const hasServingEntry = Boolean(dashboard?.currentlyServing)
+  const canCallNext = Boolean(dashboard && dashboard.waitingCount > 0 && !hasServingEntry)
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.navbar}>
+        <div className={styles.navInner}>
+          <div className={styles.brandWrap}>
+            <img src={logoImg} alt="NextTurn" className={styles.logo} />
+            <div className={styles.brandMeta}>
+              <h1 className={styles.title}>Staff Queue Dashboard</h1>
+              <p className={styles.subtitle}>Live queue control and ticket flow</p>
+            </div>
+          </div>
+
+          <div className={styles.navActions}>
+            <span className={styles.userChip}>{payload.name}</span>
+            <button className={styles.logoutBtn} onClick={handleLogout} type="button">
+              Sign out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className={styles.main}>
+        <div className={styles.content}>
+          {error && (
+            <div className={styles.errorBanner} role="alert" data-testid="staff-error">
+              {error}
+            </div>
+          )}
+
+          <section className={styles.selectorCard}>
+            <label htmlFor="queue-selector" className={styles.selectorLabel}>Queue</label>
+            <select
+              id="queue-selector"
+              data-testid="queue-selector"
+              className={styles.selector}
+              value={selectedQueueId ?? ''}
+              onChange={(e) => setSelectedQueueId(e.target.value || null)}
+              disabled={loadingQueues || queues.length === 0}
+            >
+              {queues.length === 0 && <option value="">No queues available</option>}
+              {queues.map((queue) => (
+                <option key={queue.queueId} value={queue.queueId}>
+                  {queue.name} ({queue.status})
+                </option>
+              ))}
+            </select>
+            {lastUpdated && (
+              <p className={styles.updatedAt}>
+                Updated {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} · refreshes every 30s
+              </p>
+            )}
+          </section>
+
+          {!loadingQueues && queues.length === 0 && (
+            <section className={styles.emptyCard} data-testid="staff-empty">
+              <h2>No queues yet</h2>
+              <p>Ask your organisation admin to create a queue before serving tickets.</p>
+            </section>
+          )}
+
+          {selectedQueueId && loadingDashboard && (
+            <section className={styles.loadingCard}>
+              <span className={styles.spinner} aria-hidden="true" />
+              <p>Loading queue activity…</p>
+            </section>
+          )}
+
+          {dashboard && !loadingDashboard && (
+            <>
+              <section className={styles.heroCard}>
+                <div>
+                  <p className={styles.heroLabel}>Current queue</p>
+                  <h2 className={styles.heroTitle}>{dashboard.queueName}</h2>
+                  <p className={styles.heroMeta}>Status: {dashboard.queueStatus} · Waiting: {dashboard.waitingCount}</p>
+                </div>
+
+                <div className={styles.controls}>
+                  <button
+                    type="button"
+                    className={styles.primaryBtn}
+                    data-testid="call-next-btn"
+                    onClick={handleCallNext}
+                    disabled={!canCallNext || actionBusy !== null}
+                  >
+                    {actionBusy === 'call-next' ? 'Calling…' : 'Call Next'}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    data-testid="mark-served-btn"
+                    onClick={handleMarkServed}
+                    disabled={!hasServingEntry || actionBusy !== null}
+                  >
+                    {actionBusy === 'served' ? 'Saving…' : 'Mark Served'}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.ghostBtn}
+                    data-testid="mark-noshow-btn"
+                    onClick={handleMarkNoShow}
+                    disabled={!hasServingEntry || actionBusy !== null}
+                  >
+                    {actionBusy === 'no-show' ? 'Saving…' : 'Mark No-Show'}
+                  </button>
+                </div>
+              </section>
+
+              <section className={styles.grid}>
+                <article className={styles.panel}>
+                  <h3 className={styles.panelTitle}>Now Serving</h3>
+                  {dashboard.currentlyServing ? (
+                    <div className={styles.ticketNow} data-testid="current-ticket">
+                      <span className={styles.ticketBadge}>Ticket</span>
+                      <strong>#{String(dashboard.currentlyServing.ticketNumber).padStart(3, '0')}</strong>
+                    </div>
+                  ) : (
+                    <p className={styles.muted}>No ticket is currently being served.</p>
+                  )}
+                </article>
+
+                <article className={styles.panel}>
+                  <h3 className={styles.panelTitle}>Waiting Line</h3>
+                  {dashboard.waitingEntries.length === 0 ? (
+                    <p className={styles.muted}>Nobody is waiting.</p>
+                  ) : (
+                    <ol className={styles.waitingList} data-testid="waiting-list">
+                      {dashboard.waitingEntries.map(entry => (
+                        <li key={entry.entryId} className={styles.waitingItem}>
+                          <span className={styles.waitingTicket}>#{String(entry.ticketNumber).padStart(3, '0')}</span>
+                          <span className={styles.waitingMeta}>
+                            Joined {new Date(entry.joinedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                          </span>
+                        </li>
+                      ))}
+                    </ol>
+                  )}
+                </article>
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/web/src/pages/Staff/__tests__/StaffDashboardPage.test.tsx
+++ b/src/web/src/pages/Staff/__tests__/StaffDashboardPage.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import { StaffDashboardPage } from '../StaffDashboardPage'
+import * as queuesApi from '../../../api/queues'
+
+const TENANT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const QUEUE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+vi.mock('../../../api/queues', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/queues')>()
+  return {
+    ...actual,
+    getAvailableQueues: vi.fn(),
+    getQueueDashboard: vi.fn(),
+    callNext: vi.fn(),
+    markServed: vi.fn(),
+    markNoShow: vi.fn(),
+  }
+})
+
+vi.mock('../../../utils/authToken', () => ({
+  getTokenPayload: vi.fn(() => ({
+    sub: 'staff-user-id',
+    email: 'staff@nextturn.dev',
+    name: 'Test Staff',
+    role: 'Staff',
+    tid: TENANT_ID,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+  })),
+  clearToken: vi.fn(),
+  getToken: vi.fn(() => 'test-jwt-token'),
+}))
+
+const mockGetAvailableQueues = vi.mocked(queuesApi.getAvailableQueues)
+const mockGetQueueDashboard = vi.mocked(queuesApi.getQueueDashboard)
+const mockCallNext = vi.mocked(queuesApi.callNext)
+const mockMarkServed = vi.mocked(queuesApi.markServed)
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/staff/${TENANT_ID}`]}>
+      <Routes>
+        <Route path="/staff/:tenantId" element={<StaffDashboardPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  mockGetAvailableQueues.mockReset()
+  mockGetQueueDashboard.mockReset()
+  mockCallNext.mockReset()
+  mockMarkServed.mockReset()
+
+  mockGetAvailableQueues.mockResolvedValue([
+    {
+      queueId: QUEUE_ID,
+      name: 'Main Counter',
+      maxCapacity: 50,
+      averageServiceTimeSeconds: 180,
+      status: 'Active',
+      shareableLink: `/queues/${TENANT_ID}/${QUEUE_ID}`,
+    },
+  ])
+
+  mockGetQueueDashboard.mockResolvedValue({
+    queueId: QUEUE_ID,
+    queueName: 'Main Counter',
+    queueStatus: 'Active',
+    waitingCount: 1,
+    currentlyServing: null,
+    waitingEntries: [
+      {
+        entryId: 'entry-1',
+        ticketNumber: 1,
+        joinedAt: '2026-03-01T08:00:00Z',
+      },
+    ],
+  })
+
+  mockCallNext.mockResolvedValue({
+    entryId: 'entry-1',
+    ticketNumber: 1,
+    status: 'Serving',
+  })
+
+  mockMarkServed.mockResolvedValue({
+    entryId: 'entry-1',
+    ticketNumber: 1,
+    status: 'Served',
+  })
+})
+
+describe('StaffDashboardPage', () => {
+  it('loads queues and dashboard for selected queue', async () => {
+    renderPage()
+
+    await waitFor(() => expect(mockGetAvailableQueues).toHaveBeenCalledWith(TENANT_ID))
+    await waitFor(() => expect(mockGetQueueDashboard).toHaveBeenCalledWith(QUEUE_ID, TENANT_ID))
+
+    expect(await screen.findByText('Main Counter')).toBeInTheDocument()
+    expect(screen.getByTestId('queue-selector')).toBeInTheDocument()
+    expect(screen.getByTestId('waiting-list')).toBeInTheDocument()
+  })
+
+  it('calls next ticket and refreshes dashboard', async () => {
+    mockGetQueueDashboard
+      .mockResolvedValueOnce({
+        queueId: QUEUE_ID,
+        queueName: 'Main Counter',
+        queueStatus: 'Active',
+        waitingCount: 1,
+        currentlyServing: null,
+        waitingEntries: [{ entryId: 'entry-1', ticketNumber: 1, joinedAt: '2026-03-01T08:00:00Z' }],
+      })
+      .mockResolvedValueOnce({
+        queueId: QUEUE_ID,
+        queueName: 'Main Counter',
+        queueStatus: 'Active',
+        waitingCount: 0,
+        currentlyServing: { entryId: 'entry-1', ticketNumber: 1, joinedAt: '2026-03-01T08:00:00Z' },
+        waitingEntries: [],
+      })
+
+    const user = userEvent.setup()
+    renderPage()
+
+    const btn = await screen.findByTestId('call-next-btn')
+    await user.click(btn)
+
+    expect(mockCallNext).toHaveBeenCalledWith(QUEUE_ID, TENANT_ID)
+    await waitFor(() => expect(screen.getByTestId('current-ticket')).toBeInTheDocument())
+  })
+
+  it('disables served/no-show actions when nothing is currently serving', async () => {
+    renderPage()
+
+    const servedBtn = await screen.findByTestId('mark-served-btn')
+    const noShowBtn = await screen.findByTestId('mark-noshow-btn')
+
+    expect(servedBtn).toBeDisabled()
+    expect(noShowBtn).toBeDisabled()
+  })
+
+  it('marks current ticket as served when serving entry exists', async () => {
+    mockGetQueueDashboard
+      .mockResolvedValueOnce({
+        queueId: QUEUE_ID,
+        queueName: 'Main Counter',
+        queueStatus: 'Active',
+        waitingCount: 0,
+        currentlyServing: { entryId: 'entry-1', ticketNumber: 1, joinedAt: '2026-03-01T08:00:00Z' },
+        waitingEntries: [],
+      })
+      .mockResolvedValueOnce({
+        queueId: QUEUE_ID,
+        queueName: 'Main Counter',
+        queueStatus: 'Active',
+        waitingCount: 0,
+        currentlyServing: null,
+        waitingEntries: [],
+      })
+
+    const user = userEvent.setup()
+    renderPage()
+
+    const servedBtn = await screen.findByTestId('mark-served-btn')
+    await user.click(servedBtn)
+
+    expect(mockMarkServed).toHaveBeenCalledWith(QUEUE_ID, TENANT_ID)
+    await waitFor(() => expect(screen.queryByTestId('current-ticket')).not.toBeInTheDocument())
+  })
+})

--- a/src/web/src/pages/Staff/index.ts
+++ b/src/web/src/pages/Staff/index.ts
@@ -1,0 +1,1 @@
+export { StaffDashboardPage } from './StaffDashboardPage'

--- a/tests/NextTurn.IntegrationTests/Queue/StaffQueueDashboardIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Queue/StaffQueueDashboardIntegrationTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using FluentAssertions;
+using NextTurn.Domain.Auth;
+using NextTurn.IntegrationTests;
+
+namespace NextTurn.IntegrationTests.Queue;
+
+/// <summary>
+/// Integration tests for staff queue dashboard endpoints:
+/// - GET  /api/queues/{queueId}/dashboard
+/// - POST /api/queues/{queueId}/call-next
+/// - POST /api/queues/{queueId}/served
+/// - POST /api/queues/{queueId}/no-show
+/// </summary>
+[Collection("Integration")]
+public sealed class StaffQueueDashboardIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+    private Guid _queueId;
+
+    private static readonly Guid UserAId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly Guid UserBId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
+
+    public StaffQueueDashboardIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _queueId) = await _factory.SeedQueueAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetDashboard_WithWaitingEntries_ReturnsCurrentAndWaitingData()
+    {
+        await JoinQueueAsync(UserAId);
+        await JoinQueueAsync(UserBId);
+
+        var response = await StaffClient().GetAsync($"/api/queues/{_queueId}/dashboard");
+        var body = await ReadBodyAsync(response);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body["waitingCount"].GetInt32().Should().Be(2);
+        body["currentlyServing"].ValueKind.Should().Be(JsonValueKind.Null);
+
+        var waiting = body["waitingEntries"].EnumerateArray().ToList();
+        waiting.Should().HaveCount(2);
+        waiting[0].GetProperty("ticketNumber").GetInt32().Should().Be(1);
+        waiting[1].GetProperty("ticketNumber").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CallNext_WithWaitingEntries_SetsFirstTicketAsServing()
+    {
+        await JoinQueueAsync(UserAId);
+        await JoinQueueAsync(UserBId);
+
+        var callResponse = await StaffClient().PostAsync($"/api/queues/{_queueId}/call-next", null);
+        var callBody = await ReadBodyAsync(callResponse);
+
+        callResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        callBody["ticketNumber"].GetInt32().Should().Be(1);
+        callBody["status"].GetString().Should().Be("Serving");
+
+        var dashboardResponse = await StaffClient().GetAsync($"/api/queues/{_queueId}/dashboard");
+        var dashboardBody = await ReadBodyAsync(dashboardResponse);
+
+        dashboardBody["waitingCount"].GetInt32().Should().Be(1);
+        dashboardBody["currentlyServing"].GetProperty("ticketNumber").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MarkServed_WithServingEntry_ClearsCurrentServing()
+    {
+        await JoinQueueAsync(UserAId);
+        await StaffClient().PostAsync($"/api/queues/{_queueId}/call-next", null);
+
+        var servedResponse = await StaffClient().PostAsync($"/api/queues/{_queueId}/served", null);
+        var servedBody = await ReadBodyAsync(servedResponse);
+
+        servedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        servedBody["status"].GetString().Should().Be("Served");
+
+        var dashboardResponse = await StaffClient().GetAsync($"/api/queues/{_queueId}/dashboard");
+        var dashboardBody = await ReadBodyAsync(dashboardResponse);
+
+        dashboardBody["currentlyServing"].ValueKind.Should().Be(JsonValueKind.Null);
+        dashboardBody["waitingCount"].GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MarkNoShow_WithServingEntry_ClearsCurrentServing()
+    {
+        await JoinQueueAsync(UserAId);
+        await StaffClient().PostAsync($"/api/queues/{_queueId}/call-next", null);
+
+        var noShowResponse = await StaffClient().PostAsync($"/api/queues/{_queueId}/no-show", null);
+        var noShowBody = await ReadBodyAsync(noShowResponse);
+
+        noShowResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        noShowBody["status"].GetString().Should().Be("NoShow");
+
+        var dashboardResponse = await StaffClient().GetAsync($"/api/queues/{_queueId}/dashboard");
+        var dashboardBody = await ReadBodyAsync(dashboardResponse);
+
+        dashboardBody["currentlyServing"].ValueKind.Should().Be(JsonValueKind.Null);
+        dashboardBody["waitingCount"].GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CallNext_WithUserRole_Returns403Forbidden()
+    {
+        await JoinQueueAsync(UserAId);
+
+        var response = await UserClient(UserBId).PostAsync($"/api/queues/{_queueId}/call-next", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private Task<HttpResponseMessage> JoinQueueAsync(Guid userId)
+    {
+        return UserClient(userId).PostAsync($"/api/queues/{_queueId}/join", null);
+    }
+
+    private HttpClient StaffClient()
+    {
+        var token = _factory.CreateTokenForRole(UserRole.Staff, userId: Guid.NewGuid(), tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient UserClient(Guid userId)
+    {
+        var token = _factory.CreateTokenForRole(UserRole.User, userId: userId, tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient AuthenticatedClient(string token)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", _tenantId.ToString());
+        return client;
+    }
+
+    private static async Task<Dictionary<string, JsonElement>> ReadBodyAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/CallNextCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/CallNextCommandHandlerTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.CallNext;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class CallNextCommandHandlerTests
+{
+    private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly CallNextCommandHandler _handler;
+
+    private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OrgId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid UserId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    public CallNextCommandHandlerTests()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildQueue());
+
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        _queueRepositoryMock
+            .Setup(r => r.GetNextWaitingEntryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(QueueEntry.Create(QueueId, UserId, 3));
+
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new CallNextCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithWaitingEntry_MarksTicketAsServing()
+    {
+        var result = await _handler.Handle(new CallNextCommand(QueueId), CancellationToken.None);
+
+        result.TicketNumber.Should().Be(3);
+        result.Status.Should().Be("Serving");
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenQueueNotFound_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntity?)null);
+
+        var act = async () => await _handler.Handle(new CallNextCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Queue not found.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenAlreadyServingEntryExists_ThrowsConflictDomainException()
+    {
+        var serving = QueueEntry.Create(QueueId, UserId, 1);
+        serving.StartServing();
+
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(QueueId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serving);
+
+        var act = async () => await _handler.Handle(new CallNextCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictDomainException>()
+            .WithMessage("A ticket is already being served.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoWaitingEntry_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetNextWaitingEntryAsync(QueueId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        var act = async () => await _handler.Handle(new CallNextCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("No waiting entries in this queue.");
+    }
+
+    private static QueueEntity BuildQueue() =>
+        QueueEntity.Create(OrgId, "Main Queue", maxCapacity: 50, averageServiceTimeSeconds: 180);
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/GetQueueDashboardQueryHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/GetQueueDashboardQueryHandlerTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Queue.Queries.GetQueueDashboard;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Enums;
+using NextTurn.Domain.Queue.Repositories;
+using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class GetQueueDashboardQueryHandlerTests
+{
+    private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
+    private readonly GetQueueDashboardQueryHandler _handler;
+
+    private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid UserAId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid UserBId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static readonly Guid OrgId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+    public GetQueueDashboardQueryHandlerTests()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildQueue());
+
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        _queueRepositoryMock
+            .Setup(r => r.GetWaitingEntriesAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<QueueEntry>
+            {
+                QueueEntry.Create(QueueId, UserAId, 1),
+                QueueEntry.Create(QueueId, UserBId, 2),
+            });
+
+        _handler = new GetQueueDashboardQueryHandler(_queueRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidQueue_ReturnsDashboardData()
+    {
+        var result = await _handler.Handle(new GetQueueDashboardQuery(QueueId), CancellationToken.None);
+
+        result.QueueId.Should().Be(QueueId);
+        result.QueueName.Should().Be("Main Queue");
+        result.QueueStatus.Should().Be(QueueStatus.Active.ToString());
+        result.WaitingCount.Should().Be(2);
+        result.CurrentlyServing.Should().BeNull();
+        result.WaitingEntries.Select(x => x.TicketNumber).Should().ContainInOrder(1, 2);
+    }
+
+    [Fact]
+    public async Task Handle_WhenServingEntryExists_MapsCurrentServing()
+    {
+        var serving = QueueEntry.Create(QueueId, UserAId, 7);
+        serving.StartServing();
+
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(QueueId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serving);
+
+        var result = await _handler.Handle(new GetQueueDashboardQuery(QueueId), CancellationToken.None);
+
+        result.CurrentlyServing.Should().NotBeNull();
+        result.CurrentlyServing!.TicketNumber.Should().Be(7);
+        result.CurrentlyServing.EntryId.Should().Be(serving.Id);
+    }
+
+    [Fact]
+    public async Task Handle_WhenQueueNotFound_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntity?)null);
+
+        var act = async () => await _handler.Handle(new GetQueueDashboardQuery(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Queue not found.");
+    }
+
+    private static QueueEntity BuildQueue() =>
+        QueueEntity.Create(OrgId, "Main Queue", maxCapacity: 50, averageServiceTimeSeconds: 180);
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/MarkNoShowCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/MarkNoShowCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.MarkNoShow;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class MarkNoShowCommandHandlerTests
+{
+    private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly MarkNoShowCommandHandler _handler;
+
+    private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OrgId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid UserId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    public MarkNoShowCommandHandlerTests()
+    {
+        var serving = QueueEntry.Create(QueueId, UserId, 4);
+        serving.StartServing();
+
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildQueue());
+
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serving);
+
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new MarkNoShowCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithServingEntry_MarksAsNoShow()
+    {
+        var result = await _handler.Handle(new MarkNoShowCommand(QueueId), CancellationToken.None);
+
+        result.Status.Should().Be("NoShow");
+        result.TicketNumber.Should().Be(4);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenQueueNotFound_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntity?)null);
+
+        var act = async () => await _handler.Handle(new MarkNoShowCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Queue not found.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoServingEntry_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(QueueId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        var act = async () => await _handler.Handle(new MarkNoShowCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("No entry is currently being served.");
+    }
+
+    private static QueueEntity BuildQueue() =>
+        QueueEntity.Create(OrgId, "Main Queue", maxCapacity: 50, averageServiceTimeSeconds: 180);
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/MarkServedCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/MarkServedCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.MarkServed;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Repositories;
+using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class MarkServedCommandHandlerTests
+{
+    private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly MarkServedCommandHandler _handler;
+
+    private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OrgId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid UserId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    public MarkServedCommandHandlerTests()
+    {
+        var serving = QueueEntry.Create(QueueId, UserId, 4);
+        serving.StartServing();
+
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildQueue());
+
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serving);
+
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new MarkServedCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithServingEntry_MarksAsServed()
+    {
+        var result = await _handler.Handle(new MarkServedCommand(QueueId), CancellationToken.None);
+
+        result.Status.Should().Be("Served");
+        result.TicketNumber.Should().Be(4);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenQueueNotFound_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntity?)null);
+
+        var act = async () => await _handler.Handle(new MarkServedCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Queue not found.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoServingEntry_ThrowsDomainException()
+    {
+        _queueRepositoryMock
+            .Setup(r => r.GetCurrentServingEntryAsync(QueueId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QueueEntry?)null);
+
+        var act = async () => await _handler.Handle(new MarkServedCommand(QueueId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("No entry is currently being served.");
+    }
+
+    private static QueueEntity BuildQueue() =>
+        QueueEntity.Create(OrgId, "Main Queue", maxCapacity: 50, averageServiceTimeSeconds: 180);
+}

--- a/tests/NextTurn.UnitTests/Domain/Queue/QueueEntryTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Queue/QueueEntryTests.cs
@@ -125,6 +125,92 @@ public sealed class QueueEntryTests
            .WithMessage("Queue entry is already in a terminal state and cannot be cancelled.");
     }
 
+    // ── QueueEntry.StartServing behaviour ───────────────────────────────────
+
+    [Fact]
+    public void StartServing_WhenEntryIsWaiting_SetsStatusToServing()
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+
+        entry.StartServing();
+
+        entry.Status.Should().Be(QueueEntryStatus.Serving);
+    }
+
+    [Theory]
+    [InlineData(QueueEntryStatus.Serving)]
+    [InlineData(QueueEntryStatus.Served)]
+    [InlineData(QueueEntryStatus.Cancelled)]
+    [InlineData(QueueEntryStatus.NoShow)]
+    public void StartServing_WhenEntryIsNotWaiting_ThrowsDomainException(QueueEntryStatus status)
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        SetStatus(entry, status);
+
+        var act = () => entry.StartServing();
+
+        act.Should().Throw<DomainException>()
+           .WithMessage("Only waiting queue entries can be moved to serving.");
+    }
+
+    // ── QueueEntry.MarkServed behaviour ─────────────────────────────────────
+
+    [Fact]
+    public void MarkServed_WhenEntryIsServing_SetsStatusToServed()
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        entry.StartServing();
+
+        entry.MarkServed();
+
+        entry.Status.Should().Be(QueueEntryStatus.Served);
+    }
+
+    [Theory]
+    [InlineData(QueueEntryStatus.Waiting)]
+    [InlineData(QueueEntryStatus.Served)]
+    [InlineData(QueueEntryStatus.Cancelled)]
+    [InlineData(QueueEntryStatus.NoShow)]
+    public void MarkServed_WhenEntryIsNotServing_ThrowsDomainException(QueueEntryStatus status)
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        SetStatus(entry, status);
+
+        var act = () => entry.MarkServed();
+
+        act.Should().Throw<DomainException>()
+           .WithMessage("Only a serving queue entry can be marked as served.");
+    }
+
+    // ── QueueEntry.MarkNoShow behaviour ─────────────────────────────────────
+
+    [Fact]
+    public void MarkNoShow_WhenEntryIsServing_SetsStatusToNoShow()
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        entry.StartServing();
+
+        entry.MarkNoShow();
+
+        entry.Status.Should().Be(QueueEntryStatus.NoShow);
+    }
+
+    [Theory]
+    [InlineData(QueueEntryStatus.Waiting)]
+    [InlineData(QueueEntryStatus.Served)]
+    [InlineData(QueueEntryStatus.Cancelled)]
+    [InlineData(QueueEntryStatus.NoShow)]
+    public void MarkNoShow_WhenEntryIsNotServing_ThrowsDomainException(QueueEntryStatus status)
+    {
+        var entry = QueueEntry.Create(ValidQueueId, ValidUserId, ValidTicketNumber);
+        SetStatus(entry, status);
+
+        var act = () => entry.MarkNoShow();
+
+        act.Should().Throw<DomainException>()
+           .WithMessage("Only a serving queue entry can be marked as no-show.");
+    }
+
     private static void SetStatus(QueueEntry entry, QueueEntryStatus status)
     {
         typeof(QueueEntry)


### PR DESCRIPTION
## Summary
This PR implements the Staff Queue Dashboard end-to-end so staff can manage live queue flow with real-time visibility and actions:
- View current serving ticket and waiting list
- Call next waiting ticket
- Mark current ticket as served
- Mark current ticket as no-show
- Poll dashboard updates every 30 seconds

## Backend Changes
- Added queue entry lifecycle transitions:
  - Waiting -> Serving
  - Serving -> Served
  - Serving -> NoShow
- Added repository methods for staff dashboard data and ticket transitions:
  - Get current serving entry
  - Get next waiting entry
  - Get ordered waiting entries
- Added database-level concurrency guard:
  - Filtered unique index enforcing at most one Serving entry per queue
- Added new application query/commands:
  - GetQueueDashboard
  - CallNext
  - MarkServed
  - MarkNoShow
- Added new staff API endpoints:
  - GET /api/queues/{queueId}/dashboard
  - POST /api/queues/{queueId}/call-next
  - POST /api/queues/{queueId}/served
  - POST /api/queues/{queueId}/no-show
- Added conflict handling for parallel call-next attempts

## Frontend Changes
- Replaced staff route stub with a real Staff Dashboard page
- Added queue selector and live dashboard panels:
  - Now Serving
  - Waiting Line
- Added staff action buttons:
  - Call Next
  - Mark Served
  - Mark No-Show
- Added queue dashboard polling (30s)
- Added frontend API client methods/types for new dashboard/actions

## Testing
- Added/updated unit tests for:
  - QueueEntry transition rules
  - GetQueueDashboard query handler
  - CallNext command handler
  - MarkServed command handler
  - MarkNoShow command handler
- Added integration tests for staff dashboard endpoints and actions
- Added frontend tests for:
  - New queue API client methods
  - StaffDashboard page behavior

## Validation Run
- dotnet build NextTurn.slnx: passed
- dotnet test (unit tests): passed
- npm run build (web): passed
- targeted frontend tests for new NT-23 functionality: passed
- integration tests in this environment: blocked (Docker/Testcontainers unavailable)

## Notes
- Full web npm test currently includes unrelated pre-existing failing suites outside NT-23 scope.
- New work has been validated with targeted frontend tests and backend unit/build checks.