### PR TITLE
Feature/NT-14 office management

### DIFF
--- a/src/NextTurn.API/Controllers/OfficesController.cs
+++ b/src/NextTurn.API/Controllers/OfficesController.cs
@@ -1,0 +1,139 @@
+using System.Security.Claims;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NextTurn.API.Models.Offices;
+using NextTurn.Application.Office.Commands.CreateOffice;
+using NextTurn.Application.Office.Commands.DeactivateOffice;
+using NextTurn.Application.Office.Commands.UpdateOffice;
+using NextTurn.Application.Office.Queries.GetOfficeById;
+using NextTurn.Application.Office.Queries.ListOffices;
+
+namespace NextTurn.API.Controllers;
+
+[ApiController]
+[Route("api/offices")]
+[Authorize(Roles = "OrgAdmin,SystemAdmin")]
+public sealed class OfficesController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    public OfficesController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    private bool TryGetOrganisationId(out Guid organisationId)
+    {
+        var tenantIdClaim = User.FindFirstValue("tid");
+        return Guid.TryParse(tenantIdClaim, out organisationId) && organisationId != Guid.Empty;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateOfficeRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new CreateOfficeCommand(
+            organisationId,
+            request.Name,
+            request.Address,
+            request.Latitude,
+            request.Longitude,
+            request.OpeningHours);
+
+        var result = await _sender.Send(command, cancellationToken);
+        return CreatedAtAction(nameof(GetById), new { officeId = result.OfficeId }, result);
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> List(
+        [FromQuery] bool? isActive,
+        [FromQuery] string? search,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var query = new ListOfficesQuery(organisationId, isActive, search, pageNumber, pageSize);
+        var result = await _sender.Send(query, cancellationToken);
+
+        return Ok(result);
+    }
+
+    [HttpGet("{officeId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> GetById(Guid officeId, CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var query = new GetOfficeByIdQuery(organisationId, officeId);
+        var result = await _sender.Send(query, cancellationToken);
+
+        return Ok(result);
+    }
+
+    [HttpPut("{officeId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Update(
+        Guid officeId,
+        [FromBody] UpdateOfficeRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new UpdateOfficeCommand(
+            organisationId,
+            officeId,
+            request.Name,
+            request.Address,
+            request.Latitude,
+            request.Longitude,
+            request.OpeningHours);
+
+        var result = await _sender.Send(command, cancellationToken);
+
+        return Ok(result);
+    }
+
+    [HttpPatch("{officeId:guid}/deactivate")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Deactivate(Guid officeId, CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new DeactivateOfficeCommand(organisationId, officeId);
+        await _sender.Send(command, cancellationToken);
+
+        return NoContent();
+    }
+}

--- a/src/NextTurn.API/Models/Offices/CreateOfficeRequest.cs
+++ b/src/NextTurn.API/Models/Offices/CreateOfficeRequest.cs
@@ -1,0 +1,10 @@
+namespace NextTurn.API.Models.Offices;
+
+public sealed class CreateOfficeRequest
+{
+    public string Name { get; init; } = string.Empty;
+    public string Address { get; init; } = string.Empty;
+    public decimal? Latitude { get; init; }
+    public decimal? Longitude { get; init; }
+    public string OpeningHours { get; init; } = string.Empty;
+}

--- a/src/NextTurn.API/Models/Offices/UpdateOfficeRequest.cs
+++ b/src/NextTurn.API/Models/Offices/UpdateOfficeRequest.cs
@@ -1,0 +1,10 @@
+namespace NextTurn.API.Models.Offices;
+
+public sealed class UpdateOfficeRequest
+{
+    public string Name { get; init; } = string.Empty;
+    public string Address { get; init; } = string.Empty;
+    public decimal? Latitude { get; init; }
+    public decimal? Longitude { get; init; }
+    public string OpeningHours { get; init; } = string.Empty;
+}

--- a/src/NextTurn.Application/Office/Commands/CreateOffice/CreateOfficeCommand.cs
+++ b/src/NextTurn.Application/Office/Commands/CreateOffice/CreateOfficeCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using NextTurn.Application.Office.Common;
+
+namespace NextTurn.Application.Office.Commands.CreateOffice;
+
+public sealed record CreateOfficeCommand(
+    Guid OrganisationId,
+    string Name,
+    string Address,
+    decimal? Latitude,
+    decimal? Longitude,
+    string OpeningHours) : IRequest<OfficeDto>;

--- a/src/NextTurn.Application/Office/Commands/CreateOffice/CreateOfficeCommandHandler.cs
+++ b/src/NextTurn.Application/Office/Commands/CreateOffice/CreateOfficeCommandHandler.cs
@@ -1,0 +1,50 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Office.Common;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Application.Office.Commands.CreateOffice;
+
+public sealed class CreateOfficeCommandHandler : IRequestHandler<CreateOfficeCommand, OfficeDto>
+{
+    private readonly IOfficeRepository _officeRepository;
+    private readonly IApplicationDbContext _context;
+
+    public CreateOfficeCommandHandler(
+        IOfficeRepository officeRepository,
+        IApplicationDbContext context)
+    {
+        _officeRepository = officeRepository;
+        _context = context;
+    }
+
+    public async Task<OfficeDto> Handle(CreateOfficeCommand request, CancellationToken cancellationToken)
+    {
+        var office = OfficeEntity.Create(
+            request.OrganisationId,
+            request.Name,
+            request.Address,
+            request.Latitude,
+            request.Longitude,
+            request.OpeningHours);
+
+        await _officeRepository.AddAsync(office, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Map(office);
+    }
+
+    private static OfficeDto Map(OfficeEntity office) =>
+        new(
+            office.Id,
+            office.Name,
+            office.Address,
+            office.Latitude,
+            office.Longitude,
+            office.OpeningHours,
+            office.IsActive,
+            office.DeactivatedAt,
+            office.CreatedAt,
+            office.UpdatedAt);
+}

--- a/src/NextTurn.Application/Office/Commands/CreateOffice/CreateOfficeCommandValidator.cs
+++ b/src/NextTurn.Application/Office/Commands/CreateOffice/CreateOfficeCommandValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Office.Commands.CreateOffice;
+
+public sealed class CreateOfficeCommandValidator : AbstractValidator<CreateOfficeCommand>
+{
+    public CreateOfficeCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Office name is required.")
+            .MaximumLength(120).WithMessage("Office name must not exceed 120 characters.");
+
+        RuleFor(x => x.Address)
+            .NotEmpty().WithMessage("Office address is required.")
+            .MaximumLength(300).WithMessage("Office address must not exceed 300 characters.");
+
+        RuleFor(x => x.OpeningHours)
+            .NotEmpty().WithMessage("Opening hours are required.")
+            .MaximumLength(4000).WithMessage("Opening hours must not exceed 4000 characters.");
+
+        RuleFor(x => x.Latitude)
+            .InclusiveBetween(-90m, 90m)
+            .When(x => x.Latitude.HasValue)
+            .WithMessage("Latitude must be between -90 and 90.");
+
+        RuleFor(x => x.Longitude)
+            .InclusiveBetween(-180m, 180m)
+            .When(x => x.Longitude.HasValue)
+            .WithMessage("Longitude must be between -180 and 180.");
+    }
+}

--- a/src/NextTurn.Application/Office/Commands/DeactivateOffice/DeactivateOfficeCommand.cs
+++ b/src/NextTurn.Application/Office/Commands/DeactivateOffice/DeactivateOfficeCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Office.Commands.DeactivateOffice;
+
+public sealed record DeactivateOfficeCommand(Guid OrganisationId, Guid OfficeId) : IRequest<Unit>;

--- a/src/NextTurn.Application/Office/Commands/DeactivateOffice/DeactivateOfficeCommandHandler.cs
+++ b/src/NextTurn.Application/Office/Commands/DeactivateOffice/DeactivateOfficeCommandHandler.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Office.Repositories;
+
+namespace NextTurn.Application.Office.Commands.DeactivateOffice;
+
+public sealed class DeactivateOfficeCommandHandler : IRequestHandler<DeactivateOfficeCommand, Unit>
+{
+    private readonly IOfficeRepository _officeRepository;
+    private readonly IApplicationDbContext _context;
+
+    public DeactivateOfficeCommandHandler(IOfficeRepository officeRepository, IApplicationDbContext context)
+    {
+        _officeRepository = officeRepository;
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(DeactivateOfficeCommand request, CancellationToken cancellationToken)
+    {
+        var office = await _officeRepository.GetByIdAsync(request.OrganisationId, request.OfficeId, cancellationToken);
+        if (office is null)
+            throw new DomainException("Office not found.");
+
+        office.Deactivate();
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Office/Commands/DeactivateOffice/DeactivateOfficeCommandValidator.cs
+++ b/src/NextTurn.Application/Office/Commands/DeactivateOffice/DeactivateOfficeCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Office.Commands.DeactivateOffice;
+
+public sealed class DeactivateOfficeCommandValidator : AbstractValidator<DeactivateOfficeCommand>
+{
+    public DeactivateOfficeCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.OfficeId)
+            .NotEmpty().WithMessage("Office ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Office/Commands/UpdateOffice/UpdateOfficeCommand.cs
+++ b/src/NextTurn.Application/Office/Commands/UpdateOffice/UpdateOfficeCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using NextTurn.Application.Office.Common;
+
+namespace NextTurn.Application.Office.Commands.UpdateOffice;
+
+public sealed record UpdateOfficeCommand(
+    Guid OrganisationId,
+    Guid OfficeId,
+    string Name,
+    string Address,
+    decimal? Latitude,
+    decimal? Longitude,
+    string OpeningHours) : IRequest<OfficeDto>;

--- a/src/NextTurn.Application/Office/Commands/UpdateOffice/UpdateOfficeCommandHandler.cs
+++ b/src/NextTurn.Application/Office/Commands/UpdateOffice/UpdateOfficeCommandHandler.cs
@@ -1,0 +1,51 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Office.Common;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Application.Office.Commands.UpdateOffice;
+
+public sealed class UpdateOfficeCommandHandler : IRequestHandler<UpdateOfficeCommand, OfficeDto>
+{
+    private readonly IOfficeRepository _officeRepository;
+    private readonly IApplicationDbContext _context;
+
+    public UpdateOfficeCommandHandler(IOfficeRepository officeRepository, IApplicationDbContext context)
+    {
+        _officeRepository = officeRepository;
+        _context = context;
+    }
+
+    public async Task<OfficeDto> Handle(UpdateOfficeCommand request, CancellationToken cancellationToken)
+    {
+        var office = await _officeRepository.GetByIdAsync(request.OrganisationId, request.OfficeId, cancellationToken);
+        if (office is null)
+            throw new DomainException("Office not found.");
+
+        office.UpdateDetails(
+            request.Name,
+            request.Address,
+            request.Latitude,
+            request.Longitude,
+            request.OpeningHours);
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Map(office);
+    }
+
+    private static OfficeDto Map(OfficeEntity office) =>
+        new(
+            office.Id,
+            office.Name,
+            office.Address,
+            office.Latitude,
+            office.Longitude,
+            office.OpeningHours,
+            office.IsActive,
+            office.DeactivatedAt,
+            office.CreatedAt,
+            office.UpdatedAt);
+}

--- a/src/NextTurn.Application/Office/Commands/UpdateOffice/UpdateOfficeCommandValidator.cs
+++ b/src/NextTurn.Application/Office/Commands/UpdateOffice/UpdateOfficeCommandValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Office.Commands.UpdateOffice;
+
+public sealed class UpdateOfficeCommandValidator : AbstractValidator<UpdateOfficeCommand>
+{
+    public UpdateOfficeCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.OfficeId)
+            .NotEmpty().WithMessage("Office ID is required.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Office name is required.")
+            .MaximumLength(120).WithMessage("Office name must not exceed 120 characters.");
+
+        RuleFor(x => x.Address)
+            .NotEmpty().WithMessage("Office address is required.")
+            .MaximumLength(300).WithMessage("Office address must not exceed 300 characters.");
+
+        RuleFor(x => x.OpeningHours)
+            .NotEmpty().WithMessage("Opening hours are required.")
+            .MaximumLength(4000).WithMessage("Opening hours must not exceed 4000 characters.");
+
+        RuleFor(x => x.Latitude)
+            .InclusiveBetween(-90m, 90m)
+            .When(x => x.Latitude.HasValue)
+            .WithMessage("Latitude must be between -90 and 90.");
+
+        RuleFor(x => x.Longitude)
+            .InclusiveBetween(-180m, 180m)
+            .When(x => x.Longitude.HasValue)
+            .WithMessage("Longitude must be between -180 and 180.");
+    }
+}

--- a/src/NextTurn.Application/Office/Common/OfficeDto.cs
+++ b/src/NextTurn.Application/Office/Common/OfficeDto.cs
@@ -1,0 +1,13 @@
+namespace NextTurn.Application.Office.Common;
+
+public sealed record OfficeDto(
+    Guid OfficeId,
+    string Name,
+    string Address,
+    decimal? Latitude,
+    decimal? Longitude,
+    string OpeningHours,
+    bool IsActive,
+    DateTimeOffset? DeactivatedAt,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);

--- a/src/NextTurn.Application/Office/Queries/GetOfficeById/GetOfficeByIdQuery.cs
+++ b/src/NextTurn.Application/Office/Queries/GetOfficeById/GetOfficeByIdQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using NextTurn.Application.Office.Common;
+
+namespace NextTurn.Application.Office.Queries.GetOfficeById;
+
+public sealed record GetOfficeByIdQuery(Guid OrganisationId, Guid OfficeId) : IRequest<OfficeDto>;

--- a/src/NextTurn.Application/Office/Queries/GetOfficeById/GetOfficeByIdQueryHandler.cs
+++ b/src/NextTurn.Application/Office/Queries/GetOfficeById/GetOfficeByIdQueryHandler.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using NextTurn.Application.Office.Common;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Application.Office.Queries.GetOfficeById;
+
+public sealed class GetOfficeByIdQueryHandler : IRequestHandler<GetOfficeByIdQuery, OfficeDto>
+{
+    private readonly IOfficeRepository _officeRepository;
+
+    public GetOfficeByIdQueryHandler(IOfficeRepository officeRepository)
+    {
+        _officeRepository = officeRepository;
+    }
+
+    public async Task<OfficeDto> Handle(GetOfficeByIdQuery request, CancellationToken cancellationToken)
+    {
+        var office = await _officeRepository.GetByIdAsync(request.OrganisationId, request.OfficeId, cancellationToken);
+        if (office is null)
+            throw new DomainException("Office not found.");
+
+        return Map(office);
+    }
+
+    private static OfficeDto Map(OfficeEntity office) =>
+        new(
+            office.Id,
+            office.Name,
+            office.Address,
+            office.Latitude,
+            office.Longitude,
+            office.OpeningHours,
+            office.IsActive,
+            office.DeactivatedAt,
+            office.CreatedAt,
+            office.UpdatedAt);
+}

--- a/src/NextTurn.Application/Office/Queries/GetOfficeById/GetOfficeByIdQueryValidator.cs
+++ b/src/NextTurn.Application/Office/Queries/GetOfficeById/GetOfficeByIdQueryValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Office.Queries.GetOfficeById;
+
+public sealed class GetOfficeByIdQueryValidator : AbstractValidator<GetOfficeByIdQuery>
+{
+    public GetOfficeByIdQueryValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.OfficeId)
+            .NotEmpty().WithMessage("Office ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesQuery.cs
+++ b/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace NextTurn.Application.Office.Queries.ListOffices;
+
+public sealed record ListOfficesQuery(
+    Guid OrganisationId,
+    bool? IsActive,
+    string? Search,
+    int PageNumber,
+    int PageSize) : IRequest<ListOfficesResult>;

--- a/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesQueryHandler.cs
+++ b/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesQueryHandler.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using NextTurn.Application.Office.Common;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Application.Office.Queries.ListOffices;
+
+public sealed class ListOfficesQueryHandler : IRequestHandler<ListOfficesQuery, ListOfficesResult>
+{
+    private readonly IOfficeRepository _officeRepository;
+
+    public ListOfficesQueryHandler(IOfficeRepository officeRepository)
+    {
+        _officeRepository = officeRepository;
+    }
+
+    public async Task<ListOfficesResult> Handle(ListOfficesQuery request, CancellationToken cancellationToken)
+    {
+        var (items, totalCount) = await _officeRepository.ListAsync(
+            request.OrganisationId,
+            request.IsActive,
+            request.Search,
+            request.PageNumber,
+            request.PageSize,
+            cancellationToken);
+
+        return new ListOfficesResult(
+            items.Select(Map).ToList(),
+            request.PageNumber,
+            request.PageSize,
+            totalCount);
+    }
+
+    private static OfficeDto Map(OfficeEntity office) =>
+        new(
+            office.Id,
+            office.Name,
+            office.Address,
+            office.Latitude,
+            office.Longitude,
+            office.OpeningHours,
+            office.IsActive,
+            office.DeactivatedAt,
+            office.CreatedAt,
+            office.UpdatedAt);
+}

--- a/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesQueryValidator.cs
+++ b/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesQueryValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Office.Queries.ListOffices;
+
+public sealed class ListOfficesQueryValidator : AbstractValidator<ListOfficesQuery>
+{
+    public ListOfficesQueryValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.PageNumber)
+            .GreaterThan(0).WithMessage("Page number must be greater than 0.");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100.");
+
+        RuleFor(x => x.Search)
+            .MaximumLength(200).WithMessage("Search must not exceed 200 characters.");
+    }
+}

--- a/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesResult.cs
+++ b/src/NextTurn.Application/Office/Queries/ListOffices/ListOfficesResult.cs
@@ -1,0 +1,9 @@
+using NextTurn.Application.Office.Common;
+
+namespace NextTurn.Application.Office.Queries.ListOffices;
+
+public sealed record ListOfficesResult(
+    IReadOnlyList<OfficeDto> Items,
+    int PageNumber,
+    int PageSize,
+    int TotalCount);

--- a/src/NextTurn.Domain/Office/Entities/Office.cs
+++ b/src/NextTurn.Domain/Office/Entities/Office.cs
@@ -1,0 +1,146 @@
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Domain.Office.Entities;
+
+public sealed class Office
+{
+    public Guid Id { get; }
+    public Guid OrganisationId { get; private set; }
+    public string Name { get; private set; }
+    public string Address { get; private set; }
+    public decimal? Latitude { get; private set; }
+    public decimal? Longitude { get; private set; }
+    public string OpeningHours { get; private set; }
+    public bool IsActive { get; private set; }
+    public DateTimeOffset? DeactivatedAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private Office()
+    {
+        Name = default!;
+        Address = default!;
+        OpeningHours = default!;
+    }
+
+    private Office(
+        Guid id,
+        Guid organisationId,
+        string name,
+        string address,
+        decimal? latitude,
+        decimal? longitude,
+        string openingHours,
+        bool isActive,
+        DateTimeOffset? deactivatedAt,
+        DateTimeOffset createdAt,
+        DateTimeOffset updatedAt)
+    {
+        Id = id;
+        OrganisationId = organisationId;
+        Name = name;
+        Address = address;
+        Latitude = latitude;
+        Longitude = longitude;
+        OpeningHours = openingHours;
+        IsActive = isActive;
+        DeactivatedAt = deactivatedAt;
+        CreatedAt = createdAt;
+        UpdatedAt = updatedAt;
+    }
+
+    public static Office Create(
+        Guid organisationId,
+        string name,
+        string address,
+        decimal? latitude,
+        decimal? longitude,
+        string openingHours)
+    {
+        ValidateName(name);
+        ValidateAddress(address);
+        ValidateCoordinates(latitude, longitude);
+        ValidateOpeningHours(openingHours);
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        return new Office(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            name: name.Trim(),
+            address: address.Trim(),
+            latitude: latitude,
+            longitude: longitude,
+            openingHours: openingHours.Trim(),
+            isActive: true,
+            deactivatedAt: null,
+            createdAt: utcNow,
+            updatedAt: utcNow);
+    }
+
+    public void UpdateDetails(
+        string name,
+        string address,
+        decimal? latitude,
+        decimal? longitude,
+        string openingHours)
+    {
+        ValidateName(name);
+        ValidateAddress(address);
+        ValidateCoordinates(latitude, longitude);
+        ValidateOpeningHours(openingHours);
+
+        Name = name.Trim();
+        Address = address.Trim();
+        Latitude = latitude;
+        Longitude = longitude;
+        OpeningHours = openingHours.Trim();
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Deactivate()
+    {
+        if (!IsActive)
+            throw new DomainException("Office is already deactivated.");
+
+        IsActive = false;
+        DeactivatedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new DomainException("Office name is required.");
+
+        if (name.Trim().Length > 120)
+            throw new DomainException("Office name must not exceed 120 characters.");
+    }
+
+    private static void ValidateAddress(string address)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+            throw new DomainException("Office address is required.");
+
+        if (address.Trim().Length > 300)
+            throw new DomainException("Office address must not exceed 300 characters.");
+    }
+
+    private static void ValidateCoordinates(decimal? latitude, decimal? longitude)
+    {
+        if (latitude.HasValue && (latitude.Value < -90m || latitude.Value > 90m))
+            throw new DomainException("Latitude must be between -90 and 90.");
+
+        if (longitude.HasValue && (longitude.Value < -180m || longitude.Value > 180m))
+            throw new DomainException("Longitude must be between -180 and 180.");
+    }
+
+    private static void ValidateOpeningHours(string openingHours)
+    {
+        if (string.IsNullOrWhiteSpace(openingHours))
+            throw new DomainException("Opening hours are required.");
+
+        if (openingHours.Trim().Length > 4000)
+            throw new DomainException("Opening hours must not exceed 4000 characters.");
+    }
+}

--- a/src/NextTurn.Domain/Office/Repositories/IOfficeRepository.cs
+++ b/src/NextTurn.Domain/Office/Repositories/IOfficeRepository.cs
@@ -1,0 +1,18 @@
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Domain.Office.Repositories;
+
+public interface IOfficeRepository
+{
+    Task AddAsync(OfficeEntity office, CancellationToken cancellationToken);
+
+    Task<OfficeEntity?> GetByIdAsync(Guid organisationId, Guid officeId, CancellationToken cancellationToken);
+
+    Task<(IReadOnlyList<OfficeEntity> Items, int TotalCount)> ListAsync(
+        Guid organisationId,
+        bool? isActive,
+        string? search,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken);
+}

--- a/src/NextTurn.Infrastructure/DependencyInjection.cs
+++ b/src/NextTurn.Infrastructure/DependencyInjection.cs
@@ -5,12 +5,14 @@ using NextTurn.Application.Common.Interfaces;
 using NextTurn.Domain.Appointment.Repositories;
 using NextTurn.Domain.Auth.Repositories;
 using NextTurn.Domain.Organisation.Repositories;
+using NextTurn.Domain.Office.Repositories;
 using NextTurn.Domain.Queue.Repositories;
 using NextTurn.Infrastructure.Appointment;
 using NextTurn.Infrastructure.Auth;
 using NextTurn.Infrastructure.BusinessRegistry;
 using NextTurn.Infrastructure.Email;
 using NextTurn.Infrastructure.Organisation;
+using NextTurn.Infrastructure.Office;
 using NextTurn.Infrastructure.Persistence;
 using NextTurn.Infrastructure.Queue;
 
@@ -58,6 +60,7 @@ public static class DependencyInjection
         // Scoped lifetime matches DbContext — one instance per HTTP request.
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IOrganisationRepository, OrganisationRepository>();
+        services.AddScoped<IOfficeRepository, OfficeRepository>();
         services.AddScoped<IQueueRepository, QueueRepository>();
         services.AddScoped<IAppointmentRepository, AppointmentRepository>();
 

--- a/src/NextTurn.Infrastructure/Migrations/20260324101906_AddOffices.Designer.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260324101906_AddOffices.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NextTurn.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using NextTurn.Infrastructure.Persistence;
 namespace NextTurn.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324101906_AddOffices")]
+    partial class AddOffices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NextTurn.Infrastructure/Migrations/20260324101906_AddOffices.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260324101906_AddOffices.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NextTurn.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOffices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Offices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrganisationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(120)", maxLength: 120, nullable: false),
+                    Address = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    Latitude = table.Column<decimal>(type: "decimal(9,6)", precision: 9, scale: 6, nullable: true),
+                    Longitude = table.Column<decimal>(type: "decimal(9,6)", precision: 9, scale: 6, nullable: true),
+                    OpeningHours = table.Column<string>(type: "nvarchar(4000)", maxLength: 4000, nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    DeactivatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Offices", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Offices_OrganisationId_IsActive",
+                table: "Offices",
+                columns: new[] { "OrganisationId", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Offices_OrganisationId_Name",
+                table: "Offices",
+                columns: new[] { "OrganisationId", "Name" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Offices");
+        }
+    }
+}

--- a/src/NextTurn.Infrastructure/Office/OfficeRepository.cs
+++ b/src/NextTurn.Infrastructure/Office/OfficeRepository.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Domain.Office.Repositories;
+using NextTurn.Infrastructure.Persistence;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Infrastructure.Office;
+
+public sealed class OfficeRepository : IOfficeRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public OfficeRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(OfficeEntity office, CancellationToken cancellationToken)
+    {
+        await _context.Offices.AddAsync(office, cancellationToken);
+    }
+
+    public async Task<OfficeEntity?> GetByIdAsync(Guid organisationId, Guid officeId, CancellationToken cancellationToken)
+    {
+        return await _context.Offices
+            .FirstOrDefaultAsync(
+                x => x.OrganisationId == organisationId && x.Id == officeId,
+                cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<OfficeEntity> Items, int TotalCount)> ListAsync(
+        Guid organisationId,
+        bool? isActive,
+        string? search,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var query = _context.Offices
+            .Where(x => x.OrganisationId == organisationId)
+            .AsQueryable();
+
+        if (isActive.HasValue)
+        {
+            query = query.Where(x => x.IsActive == isActive.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var normalized = search.Trim();
+            query = query.Where(x =>
+                x.Name.Contains(normalized) ||
+                x.Address.Contains(normalized));
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(x => x.CreatedAt)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -10,6 +10,7 @@ using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
 using QueueStaffAssignment = NextTurn.Domain.Queue.Entities.QueueStaffAssignment;
 using QueueActionAuditLog = NextTurn.Domain.Queue.Entities.QueueActionAuditLog;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
 
 namespace NextTurn.Infrastructure.Persistence;
 
@@ -38,6 +39,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
     public DbSet<User>             Users        => Set<User>();
     public DbSet<OrganisationEntity> Organisations => Set<OrganisationEntity>();
+    public DbSet<OfficeEntity> Offices => Set<OfficeEntity>();
 
     // Queue module (NT-16) — EF Core entity configurations and migration added in NT-16-3.
     public DbSet<QueueEntity> Queues       => Set<QueueEntity>();
@@ -91,6 +93,9 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
         modelBuilder.Entity<QueueActionAuditLog>()
             .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<OfficeEntity>()
+            .HasQueryFilter(o => o.OrganisationId == _tenantContext.TenantId);
 
         // Appointments: scoped by organisation (tenant).
         modelBuilder.Entity<AppointmentEntity>()

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Office/OfficeConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Office/OfficeConfiguration.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Office;
+
+public sealed class OfficeConfiguration : IEntityTypeConfiguration<OfficeEntity>
+{
+    public void Configure(EntityTypeBuilder<OfficeEntity> builder)
+    {
+        builder.ToTable("Offices");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(x => x.OrganisationId)
+            .IsRequired();
+
+        builder.Property(x => x.Name)
+            .HasMaxLength(120)
+            .IsRequired();
+
+        builder.Property(x => x.Address)
+            .HasMaxLength(300)
+            .IsRequired();
+
+        builder.Property(x => x.Latitude)
+            .HasPrecision(9, 6)
+            .IsRequired(false);
+
+        builder.Property(x => x.Longitude)
+            .HasPrecision(9, 6)
+            .IsRequired(false);
+
+        builder.Property(x => x.OpeningHours)
+            .HasMaxLength(4000)
+            .IsRequired();
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(x => x.DeactivatedAt)
+            .IsRequired(false);
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.Property(x => x.UpdatedAt)
+            .IsRequired();
+
+        builder.HasIndex(x => new { x.OrganisationId, x.IsActive })
+            .HasDatabaseName("IX_Offices_OrganisationId_IsActive");
+
+        builder.HasIndex(x => new { x.OrganisationId, x.Name })
+            .HasDatabaseName("IX_Offices_OrganisationId_Name");
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -31,6 +31,7 @@ import { QueuePage }            from './pages/Queue'
 import { AppointmentPage }      from './pages/Appointment'
 import { AdminDashboardPage }   from './pages/Admin'
 import { StaffDashboardPage }   from './pages/Staff'
+import { OfficeManagementPage } from './pages/Offices'
 import { StaffInviteAcceptPage } from './pages/StaffInviteAccept'
 import { OrgLoginLookupPage }   from './pages/OrgLoginLookup'
 import { TermsPage, PrivacyPage } from './pages/Legal'
@@ -87,6 +88,15 @@ function App() {
         element={
           <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
             <AdminDashboardPage />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/:tenantId/offices"
+        element={
+          <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
+            <OfficeManagementPage />
           </ProtectedRoute>
         }
       />

--- a/src/web/src/api/offices.ts
+++ b/src/web/src/api/offices.ts
@@ -1,0 +1,116 @@
+import { apiClient, parseApiError } from './client'
+import { getToken } from '../utils/authToken'
+
+export interface OfficeDto {
+  officeId: string
+  name: string
+  address: string
+  latitude: number | null
+  longitude: number | null
+  openingHours: string
+  isActive: boolean
+  deactivatedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ListOfficesResult {
+  items: OfficeDto[]
+  pageNumber: number
+  pageSize: number
+  totalCount: number
+}
+
+export interface UpsertOfficeBody {
+  name: string
+  address: string
+  latitude?: number | null
+  longitude?: number | null
+  openingHours: string
+}
+
+export interface ListOfficesParams {
+  isActive?: boolean
+  search?: string
+  pageNumber?: number
+  pageSize?: number
+}
+
+export async function createOffice(tenantId: string, body: UpsertOfficeBody): Promise<OfficeDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<OfficeDto>('/offices', body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function listOffices(tenantId: string, params: ListOfficesParams = {}): Promise<ListOfficesResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<ListOfficesResult>('/offices', {
+      params,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function getOfficeById(tenantId: string, officeId: string): Promise<OfficeDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<OfficeDto>(`/offices/${officeId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function updateOffice(tenantId: string, officeId: string, body: UpsertOfficeBody): Promise<OfficeDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.put<OfficeDto>(`/offices/${officeId}`, body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function deactivateOffice(tenantId: string, officeId: string): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.patch(`/offices/${officeId}/deactivate`, null, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}

--- a/src/web/src/pages/Admin/AdminDashboardPage.tsx
+++ b/src/web/src/pages/Admin/AdminDashboardPage.tsx
@@ -484,6 +484,15 @@ export function AdminDashboardPage() {
             <h1 className={styles.pageTitle}>Operations Control Center</h1>
             <p className={styles.pageSubtitle}>Manage queues and appointment capacity from one place.</p>
           </div>
+          <div className={styles.tabs}>
+            <button
+              type="button"
+              className={styles.tabBtn}
+              onClick={() => navigate(`/admin/${tenantId}/offices`)}
+            >
+              Manage Offices
+            </button>
+          </div>
           <div className={styles.tabs} role="tablist" aria-label="Admin sections">
             <button
               type="button"

--- a/src/web/src/pages/Offices/OfficeManagementPage.module.css
+++ b/src/web/src/pages/Offices/OfficeManagementPage.module.css
@@ -1,0 +1,159 @@
+.page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.backBtn,
+.primaryBtn,
+.secondaryBtn,
+.dangerBtn {
+  border: 0;
+  border-radius: 10px;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.backBtn,
+.secondaryBtn {
+  background: #e8ecf5;
+  color: #1f2937;
+}
+
+.primaryBtn {
+  background: #0f766e;
+  color: white;
+}
+
+.dangerBtn {
+  background: #b91c1c;
+  color: white;
+}
+
+.error,
+.success {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.filters,
+.formCard,
+.listCard {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.filters {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr 200px;
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.coords {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+}
+
+.textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.item {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0.85rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.item h3 {
+  margin: 0 0 0.35rem;
+}
+
+.item p {
+  margin: 0;
+}
+
+.meta {
+  color: #4b5563;
+  margin-top: 0.45rem;
+  font-size: 0.92rem;
+}
+
+.itemActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .filters {
+    grid-template-columns: 1fr;
+  }
+
+  .coords {
+    grid-template-columns: 1fr;
+  }
+
+  .item {
+    flex-direction: column;
+  }
+
+  .itemActions {
+    justify-content: flex-start;
+  }
+}

--- a/src/web/src/pages/Offices/OfficeManagementPage.tsx
+++ b/src/web/src/pages/Offices/OfficeManagementPage.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  createOffice,
+  deactivateOffice,
+  listOffices,
+  updateOffice,
+  type OfficeDto,
+} from '../../api/offices'
+import type { ApiError } from '../../types/api'
+import { clearToken, getTokenPayload } from '../../utils/authToken'
+import styles from './OfficeManagementPage.module.css'
+
+type Mode = 'create' | 'edit'
+
+interface OfficeForm {
+  name: string
+  address: string
+  latitude: string
+  longitude: string
+  openingHours: string
+}
+
+const defaultForm: OfficeForm = {
+  name: '',
+  address: '',
+  latitude: '',
+  longitude: '',
+  openingHours: '',
+}
+
+export function OfficeManagementPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const [offices, setOffices] = useState<OfficeDto[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [isActiveFilter, setIsActiveFilter] = useState<'all' | 'active' | 'inactive'>('active')
+  const [search, setSearch] = useState('')
+  const [form, setForm] = useState<OfficeForm>(defaultForm)
+  const [mode, setMode] = useState<Mode>('create')
+  const [editOfficeId, setEditOfficeId] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const derivedIsActive = useMemo(() => {
+    if (isActiveFilter === 'all') return undefined
+    return isActiveFilter === 'active'
+  }, [isActiveFilter])
+
+  useEffect(() => {
+    if (!payload) {
+      clearToken()
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (!tenantId) return
+
+    void loadOffices(tenantId, derivedIsActive, search)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenantId, derivedIsActive, search])
+
+  async function loadOffices(currentTenantId: string, isActive?: boolean, searchTerm?: string) {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await listOffices(currentTenantId, {
+        isActive,
+        search: searchTerm?.trim() ? searchTerm.trim() : undefined,
+        pageNumber: 1,
+        pageSize: 50,
+      })
+
+      setOffices(result.items)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not load offices.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function resetForm() {
+    setForm(defaultForm)
+    setMode('create')
+    setEditOfficeId(null)
+  }
+
+  function selectForEdit(office: OfficeDto) {
+    setMode('edit')
+    setEditOfficeId(office.officeId)
+    setForm({
+      name: office.name,
+      address: office.address,
+      latitude: office.latitude?.toString() ?? '',
+      longitude: office.longitude?.toString() ?? '',
+      openingHours: office.openingHours,
+    })
+    setSuccess(null)
+    setError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!tenantId) return
+
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    const payloadBody = {
+      name: form.name.trim(),
+      address: form.address.trim(),
+      latitude: form.latitude.trim() ? Number(form.latitude) : null,
+      longitude: form.longitude.trim() ? Number(form.longitude) : null,
+      openingHours: form.openingHours.trim(),
+    }
+
+    try {
+      if (mode === 'create') {
+        await createOffice(tenantId, payloadBody)
+        setSuccess('Office created successfully.')
+      } else if (editOfficeId) {
+        await updateOffice(tenantId, editOfficeId, payloadBody)
+        setSuccess('Office updated successfully.')
+      }
+
+      resetForm()
+      await loadOffices(tenantId, derivedIsActive, search)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not save office.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDeactivate(officeId: string) {
+    if (!tenantId) return
+
+    setError(null)
+    setSuccess(null)
+
+    try {
+      await deactivateOffice(tenantId, officeId)
+      setSuccess('Office deactivated successfully.')
+      await loadOffices(tenantId, derivedIsActive, search)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not deactivate office.')
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1>Office Management</h1>
+        <button type="button" className={styles.backBtn} onClick={() => navigate(`/admin/${tenantId}`)}>
+          Back to Admin
+        </button>
+      </header>
+
+      {error && <div className={styles.error}>{error}</div>}
+      {success && <div className={styles.success}>{success}</div>}
+
+      <section className={styles.filters}>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name or address"
+          className={styles.input}
+        />
+        <select
+          value={isActiveFilter}
+          onChange={(e) => setIsActiveFilter(e.target.value as 'all' | 'active' | 'inactive')}
+          className={styles.select}
+        >
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+          <option value="all">All</option>
+        </select>
+      </section>
+
+      <section className={styles.formCard}>
+        <h2>{mode === 'create' ? 'Create Office' : 'Update Office'}</h2>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <input
+            className={styles.input}
+            placeholder="Office name"
+            value={form.name}
+            onChange={(e) => setForm(f => ({ ...f, name: e.target.value }))}
+            required
+          />
+          <input
+            className={styles.input}
+            placeholder="Office address"
+            value={form.address}
+            onChange={(e) => setForm(f => ({ ...f, address: e.target.value }))}
+            required
+          />
+          <div className={styles.coords}>
+            <input
+              className={styles.input}
+              placeholder="Latitude (optional)"
+              value={form.latitude}
+              onChange={(e) => setForm(f => ({ ...f, latitude: e.target.value }))}
+            />
+            <input
+              className={styles.input}
+              placeholder="Longitude (optional)"
+              value={form.longitude}
+              onChange={(e) => setForm(f => ({ ...f, longitude: e.target.value }))}
+            />
+          </div>
+          <textarea
+            className={styles.textarea}
+            placeholder="Opening hours (string or JSON)"
+            value={form.openingHours}
+            onChange={(e) => setForm(f => ({ ...f, openingHours: e.target.value }))}
+            required
+          />
+
+          <div className={styles.actions}>
+            <button type="submit" className={styles.primaryBtn} disabled={saving}>
+              {saving ? 'Saving...' : mode === 'create' ? 'Create Office' : 'Update Office'}
+            </button>
+            {mode === 'edit' && (
+              <button type="button" className={styles.secondaryBtn} onClick={resetForm}>
+                Cancel Edit
+              </button>
+            )}
+          </div>
+        </form>
+      </section>
+
+      <section className={styles.listCard}>
+        <h2>Offices</h2>
+        {loading ? (
+          <p>Loading offices...</p>
+        ) : offices.length === 0 ? (
+          <p>No offices found for current filters.</p>
+        ) : (
+          <ul className={styles.list}>
+            {offices.map((office) => (
+              <li key={office.officeId} className={styles.item}>
+                <div>
+                  <h3>{office.name}</h3>
+                  <p>{office.address}</p>
+                  <p className={styles.meta}>
+                    {office.isActive ? 'Active' : 'Inactive'}
+                    {office.deactivatedAt ? ` · Deactivated ${new Date(office.deactivatedAt).toLocaleString()}` : ''}
+                  </p>
+                </div>
+
+                <div className={styles.itemActions}>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    onClick={() => selectForEdit(office)}
+                    disabled={!office.isActive}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.dangerBtn}
+                    onClick={() => handleDeactivate(office.officeId)}
+                    disabled={!office.isActive}
+                  >
+                    Deactivate
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/web/src/pages/Offices/index.ts
+++ b/src/web/src/pages/Offices/index.ts
@@ -1,0 +1,1 @@
+export { OfficeManagementPage } from './OfficeManagementPage'

--- a/tests/NextTurn.IntegrationTests/Office/OfficeCrudIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Office/OfficeCrudIntegrationTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NextTurn.Domain.Auth;
+
+namespace NextTurn.IntegrationTests.Office;
+
+[Collection("Integration")]
+public sealed class OfficeCrudIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+
+    public OfficeCrudIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _) = await _factory.SeedQueueAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task OfficeCrudFlow_CreateGetUpdateDeactivateAndFilter_WorksForOrgAdmin()
+    {
+        var adminClient = AuthenticatedClient(UserRole.OrgAdmin, Guid.NewGuid(), _tenantId);
+
+        var createResponse = await adminClient.PostAsJsonAsync("/api/offices", new
+        {
+            name = "Main Branch",
+            address = "123 Main Street",
+            latitude = 6.9271,
+            longitude = 79.8612,
+            openingHours = "{\"mon\":\"09:00-17:00\"}"
+        });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<OfficeDto>();
+        created.Should().NotBeNull();
+        created!.Name.Should().Be("Main Branch");
+        created.IsActive.Should().BeTrue();
+
+        var getResponse = await adminClient.GetAsync($"/api/offices/{created.OfficeId}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var getOffice = await getResponse.Content.ReadFromJsonAsync<OfficeDto>();
+        getOffice.Should().NotBeNull();
+        getOffice!.Address.Should().Be("123 Main Street");
+
+        var updateResponse = await adminClient.PutAsJsonAsync($"/api/offices/{created.OfficeId}", new
+        {
+            name = "Main Branch Updated",
+            address = "456 Updated Avenue",
+            latitude = 6.9000,
+            longitude = 79.8500,
+            openingHours = "Mon-Fri 08:00-16:00"
+        });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<OfficeDto>();
+        updated.Should().NotBeNull();
+        updated!.Name.Should().Be("Main Branch Updated");
+
+        var activeListResponse = await adminClient.GetAsync("/api/offices?isActive=true&pageNumber=1&pageSize=20");
+        activeListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var activeList = await activeListResponse.Content.ReadFromJsonAsync<ListOfficesResponse>();
+        activeList.Should().NotBeNull();
+        activeList!.Items.Should().Contain(x => x.OfficeId == created.OfficeId);
+
+        var deactivateResponse = await adminClient.PatchAsync($"/api/offices/{created.OfficeId}/deactivate", null);
+        deactivateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var inactiveListResponse = await adminClient.GetAsync("/api/offices?isActive=false&pageNumber=1&pageSize=20");
+        inactiveListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var inactiveList = await inactiveListResponse.Content.ReadFromJsonAsync<ListOfficesResponse>();
+        inactiveList.Should().NotBeNull();
+        inactiveList!.Items.Should().Contain(x => x.OfficeId == created.OfficeId && !x.IsActive);
+
+        var activeListAfterDeactivateResponse = await adminClient.GetAsync("/api/offices?isActive=true&pageNumber=1&pageSize=20");
+        activeListAfterDeactivateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var activeListAfterDeactivate = await activeListAfterDeactivateResponse.Content.ReadFromJsonAsync<ListOfficesResponse>();
+        activeListAfterDeactivate.Should().NotBeNull();
+        activeListAfterDeactivate!.Items.Should().NotContain(x => x.OfficeId == created.OfficeId);
+
+        var searchResponse = await adminClient.GetAsync("/api/offices?search=Updated&pageNumber=1&pageSize=20");
+        searchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var searched = await searchResponse.Content.ReadFromJsonAsync<ListOfficesResponse>();
+        searched.Should().NotBeNull();
+        searched!.Items.Should().Contain(x => x.OfficeId == created.OfficeId);
+    }
+
+    [Fact]
+    public async Task CreateOffice_WithUserRole_ReturnsForbidden()
+    {
+        var userClient = AuthenticatedClient(UserRole.User, Guid.NewGuid(), _tenantId);
+
+        var response = await userClient.PostAsJsonAsync("/api/offices", new
+        {
+            name = "Main Branch",
+            address = "123 Main Street",
+            openingHours = "Mon-Fri 09:00-17:00"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private HttpClient AuthenticatedClient(UserRole role, Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(role, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private sealed record OfficeDto(
+        Guid OfficeId,
+        string Name,
+        string Address,
+        decimal? Latitude,
+        decimal? Longitude,
+        string OpeningHours,
+        bool IsActive,
+        DateTimeOffset? DeactivatedAt,
+        DateTimeOffset CreatedAt,
+        DateTimeOffset UpdatedAt);
+
+    private sealed record ListOfficesResponse(
+        IReadOnlyList<OfficeDto> Items,
+        int PageNumber,
+        int PageSize,
+        int TotalCount);
+}

--- a/tests/NextTurn.UnitTests/Application/Office/CreateOfficeCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Office/CreateOfficeCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Office.Commands.CreateOffice;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.UnitTests.Application.Office;
+
+public sealed class CreateOfficeCommandHandlerTests
+{
+    private readonly Mock<IOfficeRepository> _officeRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly CreateOfficeCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public CreateOfficeCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new CreateOfficeCommandHandler(_officeRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidCommand_CreatesOfficeAndPersists()
+    {
+        var command = new CreateOfficeCommand(
+            OrganisationId,
+            "Main Branch",
+            "123 Main Street",
+            6.9271m,
+            79.8612m,
+            "{\"mon\":\"09:00-17:00\"}");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.OfficeId.Should().NotBeEmpty();
+        result.Name.Should().Be("Main Branch");
+        result.Address.Should().Be("123 Main Street");
+        result.IsActive.Should().BeTrue();
+
+        _officeRepositoryMock.Verify(
+            r => r.AddAsync(It.Is<OfficeEntity>(o =>
+                o.OrganisationId == OrganisationId &&
+                o.Name == "Main Branch" &&
+                o.Address == "123 Main Street"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Office/CreateOfficeCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Office/CreateOfficeCommandValidatorTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using NextTurn.Application.Office.Commands.CreateOffice;
+
+namespace NextTurn.UnitTests.Application.Office;
+
+public sealed class CreateOfficeCommandValidatorTests
+{
+    private readonly CreateOfficeCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new CreateOfficeCommand(
+            Guid.NewGuid(),
+            "Main Branch",
+            "123 Main Street",
+            6.9271m,
+            79.8612m,
+            "{\"mon\":\"09:00-17:00\"}");
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithInvalidLatitude_ReturnsError()
+    {
+        var command = new CreateOfficeCommand(
+            Guid.NewGuid(),
+            "Main Branch",
+            "123 Main Street",
+            140m,
+            79.8612m,
+            "{\"mon\":\"09:00-17:00\"}");
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(CreateOfficeCommand.Latitude));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Office/DeactivateOfficeCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Office/DeactivateOfficeCommandHandlerTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Office.Commands.DeactivateOffice;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.UnitTests.Application.Office;
+
+public sealed class DeactivateOfficeCommandHandlerTests
+{
+    private readonly Mock<IOfficeRepository> _officeRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly DeactivateOfficeCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OfficeId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public DeactivateOfficeCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new DeactivateOfficeCommandHandler(_officeRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithActiveOffice_DeactivatesAndPersists()
+    {
+        var office = OfficeEntity.Create(OrganisationId, "Main", "Address", null, null, "9-5");
+
+        _officeRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, OfficeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(office);
+
+        await _handler.Handle(new DeactivateOfficeCommand(OrganisationId, OfficeId), CancellationToken.None);
+
+        office.IsActive.Should().BeFalse();
+        office.DeactivatedAt.Should().NotBeNull();
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOfficeNotFound_ThrowsDomainException()
+    {
+        _officeRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, OfficeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OfficeEntity?)null);
+
+        var act = async () => await _handler.Handle(new DeactivateOfficeCommand(OrganisationId, OfficeId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Office not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Office/UpdateOfficeCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Office/UpdateOfficeCommandHandlerTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Office.Commands.UpdateOffice;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Office.Repositories;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+
+namespace NextTurn.UnitTests.Application.Office;
+
+public sealed class UpdateOfficeCommandHandlerTests
+{
+    private readonly Mock<IOfficeRepository> _officeRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly UpdateOfficeCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid OfficeId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public UpdateOfficeCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new UpdateOfficeCommandHandler(_officeRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingOffice_UpdatesAndPersists()
+    {
+        var office = OfficeEntity.Create(OrganisationId, "Old", "Old Address", null, null, "9-5");
+
+        _officeRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, OfficeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(office);
+
+        var command = new UpdateOfficeCommand(
+            OrganisationId,
+            OfficeId,
+            "Updated Office",
+            "Updated Address",
+            null,
+            null,
+            "{\"mon\":\"08:00-16:00\"}");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Name.Should().Be("Updated Office");
+        result.Address.Should().Be("Updated Address");
+        result.OpeningHours.Should().Be("{\"mon\":\"08:00-16:00\"}");
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOfficeNotFound_ThrowsDomainException()
+    {
+        _officeRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, OfficeId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OfficeEntity?)null);
+
+        var command = new UpdateOfficeCommand(
+            OrganisationId,
+            OfficeId,
+            "Updated Office",
+            "Updated Address",
+            null,
+            null,
+            "{\"mon\":\"08:00-16:00\"}");
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Office not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Office/UpdateOfficeCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Office/UpdateOfficeCommandValidatorTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using NextTurn.Application.Office.Commands.UpdateOffice;
+
+namespace NextTurn.UnitTests.Application.Office;
+
+public sealed class UpdateOfficeCommandValidatorTests
+{
+    private readonly UpdateOfficeCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new UpdateOfficeCommand(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Main Branch",
+            "123 Main Street",
+            6.9271m,
+            79.8612m,
+            "{\"mon\":\"09:00-17:00\"}");
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithEmptyName_ReturnsError()
+    {
+        var command = new UpdateOfficeCommand(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            string.Empty,
+            "123 Main Street",
+            null,
+            null,
+            "{\"mon\":\"09:00-17:00\"}");
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(UpdateOfficeCommand.Name));
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements Office Management for organisation admins/system admins, enabling tenant-scoped office configuration in the modular monolith.

Implemented capabilities:
- Create office
- List offices with pagination/filter/search
- Get office details
- Update office
- Soft-deactivate office (`IsActive = false`, `DeactivatedAt = now`)

The implementation follows Clean Architecture boundaries:
- API controllers (thin)
- Application commands/queries + validators
- Domain `Office` entity with business rules
- Infrastructure EF repository + configuration + migration
- Frontend office management page and API client
- Unit and integration tests

---

## User Story
As an organisation admin, I want to create, read, update and deactivate offices so that multiple branches/locations are supported.

---

## API Endpoints Delivered

### 1. Create Office
`POST /api/offices`

Body:
- `name` (required)
- `address` (required)
- `latitude` (optional)
- `longitude` (optional)
- `openingHours` (required; JSON string or plain string)

### 2. List Offices
`GET /api/offices`

Query params:
- `pageNumber` (default 1)
- `pageSize` (default 20, max 100)
- `isActive` (optional: true/false)
- `search` (optional; matches name/address)

### 3. Get Office Detail
`GET /api/offices/{id}`

### 4. Update Office
`PUT /api/offices/{id}`

Body:
- `name`
- `address`
- `latitude` (optional)
- `longitude` (optional)
- `openingHours`

Tenant is always derived from authenticated context and is not mutable.

### 5. Soft Deactivate Office
`PATCH /api/offices/{id}/deactivate`

Behavior:
- sets `IsActive = false`
- sets `DeactivatedAt = UtcNow`
- preserves history/data (no hard delete)

---

## Authorization & Tenant Enforcement
- Controller guarded with `Authorize(Roles = "OrgAdmin,SystemAdmin")`
- Organisation/Tenant is resolved from JWT `tid` claim
- Repository methods are organisation-scoped
- EF global query filters enforce tenant isolation for `Office`

This satisfies:
- 403 for non-admin roles
- tenant-context constrained operations

---

## Architecture Changes

### Domain
Added:
- `Office` aggregate/entity with:
  - `Name`, `Address`, `Latitude`, `Longitude`, `OpeningHours`
  - `IsActive`, `DeactivatedAt`
  - `CreatedAt`, `UpdatedAt`
  - Domain methods: create/update/deactivate
  - Domain validation (name/address/opening hours length, coordinate ranges)

File:
- Office.cs

Added repository contract:
- IOfficeRepository.cs

### Application
Added Office module with CQRS + validation:

Commands:
- `CreateOfficeCommand` (+ handler + validator)
- `UpdateOfficeCommand` (+ handler + validator)
- `DeactivateOfficeCommand` (+ handler + validator)

Queries:
- `GetOfficeByIdQuery` (+ handler + validator)
- `ListOfficesQuery` (+ handler + validator)
- `ListOfficesResult`

Shared DTO:
- `OfficeDto`

### Infrastructure
Added:
- `OfficeRepository` EF implementation
- `OfficeConfiguration` for EF mapping/indexes
- `DbSet<Office>` in `ApplicationDbContext`
- Tenant query filter for `Office`
- DI registration for `IOfficeRepository`

Migration added:
- `20260324101906_AddOffices`

### API
Added:
- `OfficesController`
- request models:
  - `CreateOfficeRequest`
  - `UpdateOfficeRequest`

### Frontend
Added:
- API client:
  - offices.ts
- Office management page:
  - OfficeManagementPage.tsx
  - OfficeManagementPage.module.css
  - index.ts
- Routing:
  - added `/admin/:tenantId/offices` in App.tsx
- Navigation entry:
  - added “Manage Offices” from admin dashboard

---

## Behavior Notes
- Soft-deactivated offices are excluded from active filter views and can be listed via inactive/all filters.
- Search supports office name/address matching.
- Update keeps office within same tenant context (no tenant mutation path exists).
- Deactivation does not delete related operational data and is intended to hide offices from active/public selection lists.

---

## Tests

### Unit Tests (Application.Office)
Added:
- `CreateOfficeCommandHandlerTests`
- `UpdateOfficeCommandHandlerTests`
- `DeactivateOfficeCommandHandlerTests`
- `CreateOfficeCommandValidatorTests`
- `UpdateOfficeCommandValidatorTests`

Status:
- Passed (9 tests in office-focused filter run)

### Integration Tests
Added:
- `OfficeCrudIntegrationTests`
  - full admin CRUD flow
  - deactivate + active/inactive list visibility
  - search behavior
  - forbidden access for non-admin role

Status:
- Implemented and compile successfully
- Execution requires Docker/Testcontainers (blocked in this environment due Docker runtime unavailable)

### Build Validation
- `dotnet build NextTurn.slnx` passed
- `npm run build` in web passed

---

## Commits (Granular)
1. `feat(office): add Office domain, repository, app handlers, and API CRUD endpoints`
2. `test(office): add command/validator coverage and CRUD integration scenarios`
3. `feat(web): add org admin office management page with list/create/update/deactivate`

---

## Acceptance Criteria Mapping
- `POST /api/offices` create: implemented
- `GET /api/offices` paginated/filter/search: implemented
- `GET /api/offices/{id}` detail: implemented
- `PUT /api/offices/{id}` update without tenant change: implemented
- `PATCH /api/offices/{id}/deactivate` soft delete: implemented
- Tenant context and admin-role enforcement: implemented
- Soft delete preserves data and supports hidden-by-active filtering: implemented
- Unit + integration tests added: implemented (integration runtime env-dependent)

---

## Manual Demo Steps
1. Login as OrgAdmin in tenant workspace.
2. Open office management from admin dashboard.
3. Create office with name/address/hours (+ optional coordinates).
4. Verify it appears in active list.
5. Edit office details and save.
6. Deactivate office.
7. Verify:
   - hidden from active filter
   - visible in inactive filter
   - searchable in all/inactive views
8. Verify non-admin user receives forbidden on create endpoint.

---

## Follow-up / Non-code
- Update Confluence:
  - SRS → Configuration → Offices
  - ER diagram to include `Offices` table/fields and soft-delete fields (`IsActive`, `DeactivatedAt`)