### PR TITLE
Feature/NT-15 service configuration

### DIFF
--- a/src/NextTurn.API/Controllers/ServicesController.cs
+++ b/src/NextTurn.API/Controllers/ServicesController.cs
@@ -1,0 +1,164 @@
+using System.Security.Claims;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NextTurn.API.Models.Services;
+using NextTurn.Application.Service.Commands.AssignServiceOffices;
+using NextTurn.Application.Service.Commands.CreateService;
+using NextTurn.Application.Service.Commands.DeactivateService;
+using NextTurn.Application.Service.Commands.RemoveServiceOfficeAssignment;
+using NextTurn.Application.Service.Commands.UpdateService;
+using NextTurn.Application.Service.Queries.ListServices;
+
+namespace NextTurn.API.Controllers;
+
+[ApiController]
+[Route("api/services")]
+[Authorize]
+public sealed class ServicesController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    public ServicesController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    private bool TryGetOrganisationId(out Guid organisationId)
+    {
+        var tenantIdClaim = User.FindFirstValue("tid");
+        return Guid.TryParse(tenantIdClaim, out organisationId) && organisationId != Guid.Empty;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> List(
+        [FromQuery] bool activeOnly = false,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var query = new ListServicesQuery(organisationId, activeOnly, pageNumber, pageSize);
+        var result = await _sender.Send(query, cancellationToken);
+
+        return Ok(result);
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateServiceRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new CreateServiceCommand(
+            organisationId,
+            request.Name,
+            request.Code,
+            request.Description,
+            request.EstimatedDurationMinutes,
+            request.IsActive);
+
+        var result = await _sender.Send(command, cancellationToken);
+        return CreatedAtAction(nameof(List), null, result);
+    }
+
+    [HttpPut("{serviceId:guid}")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Update(
+        Guid serviceId,
+        [FromBody] UpdateServiceRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new UpdateServiceCommand(
+            organisationId,
+            serviceId,
+            request.Name,
+            request.Description,
+            request.EstimatedDurationMinutes);
+
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPatch("{serviceId:guid}/deactivate")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Deactivate(Guid serviceId, CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new DeactivateServiceCommand(organisationId, serviceId);
+        await _sender.Send(command, cancellationToken);
+
+        return NoContent();
+    }
+
+    [HttpPost("{serviceId:guid}/offices")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> AssignOffices(
+        Guid serviceId,
+        [FromBody] AssignServiceOfficesRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new AssignServiceOfficesCommand(organisationId, serviceId, request.OfficeIds);
+        await _sender.Send(command, cancellationToken);
+
+        return NoContent();
+    }
+
+    [HttpDelete("{serviceId:guid}/offices/{officeId:guid}")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> RemoveOfficeAssignment(
+        Guid serviceId,
+        Guid officeId,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var command = new RemoveServiceOfficeAssignmentCommand(organisationId, serviceId, officeId);
+        await _sender.Send(command, cancellationToken);
+
+        return NoContent();
+    }
+}

--- a/src/NextTurn.API/Models/Services/AssignServiceOfficesRequest.cs
+++ b/src/NextTurn.API/Models/Services/AssignServiceOfficesRequest.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.API.Models.Services;
+
+public sealed class AssignServiceOfficesRequest
+{
+    public IReadOnlyList<Guid> OfficeIds { get; set; } = [];
+}

--- a/src/NextTurn.API/Models/Services/CreateServiceRequest.cs
+++ b/src/NextTurn.API/Models/Services/CreateServiceRequest.cs
@@ -1,0 +1,10 @@
+namespace NextTurn.API.Models.Services;
+
+public sealed class CreateServiceRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public int EstimatedDurationMinutes { get; set; }
+    public bool IsActive { get; set; } = true;
+}

--- a/src/NextTurn.API/Models/Services/UpdateServiceRequest.cs
+++ b/src/NextTurn.API/Models/Services/UpdateServiceRequest.cs
@@ -1,0 +1,8 @@
+namespace NextTurn.API.Models.Services;
+
+public sealed class UpdateServiceRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public int EstimatedDurationMinutes { get; set; }
+}

--- a/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -7,6 +7,8 @@ using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
 using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
 using QueueActionAuditLog = NextTurn.Domain.Queue.Entities.QueueActionAuditLog;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+using ServiceOfficeAssignment = NextTurn.Domain.Service.Entities.ServiceOfficeAssignment;
 
 namespace NextTurn.Application.Common.Interfaces;
 
@@ -25,6 +27,8 @@ public interface IApplicationDbContext
     DbSet<AppointmentEntity> Appointments { get; }
     DbSet<AppointmentProfile> AppointmentProfiles { get; }
     DbSet<AppointmentScheduleRule> AppointmentScheduleRules { get; }
+    DbSet<ServiceEntity> Services { get; }
+    DbSet<ServiceOfficeAssignment> ServiceOfficeAssignments { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/NextTurn.Application/Service/Commands/AssignServiceOffices/AssignServiceOfficesCommand.cs
+++ b/src/NextTurn.Application/Service/Commands/AssignServiceOffices/AssignServiceOfficesCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace NextTurn.Application.Service.Commands.AssignServiceOffices;
+
+public sealed record AssignServiceOfficesCommand(
+    Guid OrganisationId,
+    Guid ServiceId,
+    IReadOnlyList<Guid> OfficeIds) : IRequest<Unit>;

--- a/src/NextTurn.Application/Service/Commands/AssignServiceOffices/AssignServiceOfficesCommandHandler.cs
+++ b/src/NextTurn.Application/Service/Commands/AssignServiceOffices/AssignServiceOfficesCommandHandler.cs
@@ -1,0 +1,34 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+
+namespace NextTurn.Application.Service.Commands.AssignServiceOffices;
+
+public sealed class AssignServiceOfficesCommandHandler : IRequestHandler<AssignServiceOfficesCommand, Unit>
+{
+    private readonly IServiceRepository _serviceRepository;
+    private readonly IApplicationDbContext _context;
+
+    public AssignServiceOfficesCommandHandler(IServiceRepository serviceRepository, IApplicationDbContext context)
+    {
+        _serviceRepository = serviceRepository;
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(AssignServiceOfficesCommand request, CancellationToken cancellationToken)
+    {
+        var service = await _serviceRepository.GetByIdAsync(request.OrganisationId, request.ServiceId, cancellationToken);
+        if (service is null)
+            throw new DomainException("Service not found.");
+
+        await _serviceRepository.AssignOfficesAsync(
+            request.OrganisationId,
+            request.ServiceId,
+            request.OfficeIds.Distinct().ToList(),
+            cancellationToken);
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/AssignServiceOffices/AssignServiceOfficesCommandValidator.cs
+++ b/src/NextTurn.Application/Service/Commands/AssignServiceOffices/AssignServiceOfficesCommandValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Service.Commands.AssignServiceOffices;
+
+public sealed class AssignServiceOfficesCommandValidator : AbstractValidator<AssignServiceOfficesCommand>
+{
+    public AssignServiceOfficesCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.ServiceId)
+            .NotEmpty().WithMessage("Service ID is required.");
+
+        RuleFor(x => x.OfficeIds)
+            .NotNull().WithMessage("Office IDs are required.")
+            .Must(x => x.Count > 0).WithMessage("At least one office ID is required.");
+
+        RuleForEach(x => x.OfficeIds)
+            .NotEmpty().WithMessage("Office ID cannot be empty.");
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/CreateService/CreateServiceCommand.cs
+++ b/src/NextTurn.Application/Service/Commands/CreateService/CreateServiceCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using NextTurn.Application.Service.Common;
+
+namespace NextTurn.Application.Service.Commands.CreateService;
+
+public sealed record CreateServiceCommand(
+    Guid OrganisationId,
+    string Name,
+    string Code,
+    string Description,
+    int EstimatedDurationMinutes,
+    bool IsActive) : IRequest<ServiceDto>;

--- a/src/NextTurn.Application/Service/Commands/CreateService/CreateServiceCommandHandler.cs
+++ b/src/NextTurn.Application/Service/Commands/CreateService/CreateServiceCommandHandler.cs
@@ -1,0 +1,54 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Common;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.Application.Service.Commands.CreateService;
+
+public sealed class CreateServiceCommandHandler : IRequestHandler<CreateServiceCommand, ServiceDto>
+{
+    private readonly IServiceRepository _serviceRepository;
+    private readonly IApplicationDbContext _context;
+
+    public CreateServiceCommandHandler(IServiceRepository serviceRepository, IApplicationDbContext context)
+    {
+        _serviceRepository = serviceRepository;
+        _context = context;
+    }
+
+    public async Task<ServiceDto> Handle(CreateServiceCommand request, CancellationToken cancellationToken)
+    {
+        var normalizedCode = request.Code.Trim().ToUpperInvariant();
+        var exists = await _serviceRepository.ExistsByCodeAsync(request.OrganisationId, normalizedCode, cancellationToken);
+        if (exists)
+            throw new ConflictDomainException("Service code already exists in this tenant.");
+
+        var service = ServiceEntity.Create(
+            request.OrganisationId,
+            request.Name,
+            request.Code,
+            request.Description,
+            request.EstimatedDurationMinutes,
+            request.IsActive);
+
+        await _serviceRepository.AddAsync(service, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Map(service);
+    }
+
+    private static ServiceDto Map(ServiceEntity service) =>
+        new(
+            service.Id,
+            service.Name,
+            service.Code,
+            service.Description,
+            service.EstimatedDurationMinutes,
+            service.IsActive,
+            [],
+            service.DeactivatedAt,
+            service.CreatedAt,
+            service.UpdatedAt);
+}

--- a/src/NextTurn.Application/Service/Commands/CreateService/CreateServiceCommandValidator.cs
+++ b/src/NextTurn.Application/Service/Commands/CreateService/CreateServiceCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Service.Commands.CreateService;
+
+public sealed class CreateServiceCommandValidator : AbstractValidator<CreateServiceCommand>
+{
+    public CreateServiceCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Service name is required.")
+            .MaximumLength(120).WithMessage("Service name must not exceed 120 characters.");
+
+        RuleFor(x => x.Code)
+            .NotEmpty().WithMessage("Service code is required.")
+            .MaximumLength(40).WithMessage("Service code must not exceed 40 characters.");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("Service description is required.")
+            .MaximumLength(500).WithMessage("Service description must not exceed 500 characters.");
+
+        RuleFor(x => x.EstimatedDurationMinutes)
+            .InclusiveBetween(1, 1440).WithMessage("Estimated duration must be between 1 and 1440 minutes.");
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/DeactivateService/DeactivateServiceCommand.cs
+++ b/src/NextTurn.Application/Service/Commands/DeactivateService/DeactivateServiceCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Service.Commands.DeactivateService;
+
+public sealed record DeactivateServiceCommand(Guid OrganisationId, Guid ServiceId) : IRequest<Unit>;

--- a/src/NextTurn.Application/Service/Commands/DeactivateService/DeactivateServiceCommandHandler.cs
+++ b/src/NextTurn.Application/Service/Commands/DeactivateService/DeactivateServiceCommandHandler.cs
@@ -1,0 +1,30 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+
+namespace NextTurn.Application.Service.Commands.DeactivateService;
+
+public sealed class DeactivateServiceCommandHandler : IRequestHandler<DeactivateServiceCommand, Unit>
+{
+    private readonly IServiceRepository _serviceRepository;
+    private readonly IApplicationDbContext _context;
+
+    public DeactivateServiceCommandHandler(IServiceRepository serviceRepository, IApplicationDbContext context)
+    {
+        _serviceRepository = serviceRepository;
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(DeactivateServiceCommand request, CancellationToken cancellationToken)
+    {
+        var service = await _serviceRepository.GetByIdAsync(request.OrganisationId, request.ServiceId, cancellationToken);
+        if (service is null)
+            throw new DomainException("Service not found.");
+
+        service.Deactivate();
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/DeactivateService/DeactivateServiceCommandValidator.cs
+++ b/src/NextTurn.Application/Service/Commands/DeactivateService/DeactivateServiceCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Service.Commands.DeactivateService;
+
+public sealed class DeactivateServiceCommandValidator : AbstractValidator<DeactivateServiceCommand>
+{
+    public DeactivateServiceCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.ServiceId)
+            .NotEmpty().WithMessage("Service ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/RemoveServiceOfficeAssignment/RemoveServiceOfficeAssignmentCommand.cs
+++ b/src/NextTurn.Application/Service/Commands/RemoveServiceOfficeAssignment/RemoveServiceOfficeAssignmentCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace NextTurn.Application.Service.Commands.RemoveServiceOfficeAssignment;
+
+public sealed record RemoveServiceOfficeAssignmentCommand(
+    Guid OrganisationId,
+    Guid ServiceId,
+    Guid OfficeId) : IRequest<Unit>;

--- a/src/NextTurn.Application/Service/Commands/RemoveServiceOfficeAssignment/RemoveServiceOfficeAssignmentCommandHandler.cs
+++ b/src/NextTurn.Application/Service/Commands/RemoveServiceOfficeAssignment/RemoveServiceOfficeAssignmentCommandHandler.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Service.Repositories;
+
+namespace NextTurn.Application.Service.Commands.RemoveServiceOfficeAssignment;
+
+public sealed class RemoveServiceOfficeAssignmentCommandHandler : IRequestHandler<RemoveServiceOfficeAssignmentCommand, Unit>
+{
+    private readonly IServiceRepository _serviceRepository;
+    private readonly IApplicationDbContext _context;
+
+    public RemoveServiceOfficeAssignmentCommandHandler(IServiceRepository serviceRepository, IApplicationDbContext context)
+    {
+        _serviceRepository = serviceRepository;
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(RemoveServiceOfficeAssignmentCommand request, CancellationToken cancellationToken)
+    {
+        await _serviceRepository.RemoveOfficeAssignmentAsync(
+            request.OrganisationId,
+            request.ServiceId,
+            request.OfficeId,
+            cancellationToken);
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/RemoveServiceOfficeAssignment/RemoveServiceOfficeAssignmentCommandValidator.cs
+++ b/src/NextTurn.Application/Service/Commands/RemoveServiceOfficeAssignment/RemoveServiceOfficeAssignmentCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Service.Commands.RemoveServiceOfficeAssignment;
+
+public sealed class RemoveServiceOfficeAssignmentCommandValidator : AbstractValidator<RemoveServiceOfficeAssignmentCommand>
+{
+    public RemoveServiceOfficeAssignmentCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.ServiceId)
+            .NotEmpty().WithMessage("Service ID is required.");
+
+        RuleFor(x => x.OfficeId)
+            .NotEmpty().WithMessage("Office ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Service/Commands/UpdateService/UpdateServiceCommand.cs
+++ b/src/NextTurn.Application/Service/Commands/UpdateService/UpdateServiceCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using NextTurn.Application.Service.Common;
+
+namespace NextTurn.Application.Service.Commands.UpdateService;
+
+public sealed record UpdateServiceCommand(
+    Guid OrganisationId,
+    Guid ServiceId,
+    string Name,
+    string Description,
+    int EstimatedDurationMinutes) : IRequest<ServiceDto>;

--- a/src/NextTurn.Application/Service/Commands/UpdateService/UpdateServiceCommandHandler.cs
+++ b/src/NextTurn.Application/Service/Commands/UpdateService/UpdateServiceCommandHandler.cs
@@ -1,0 +1,45 @@
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Common;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.Application.Service.Commands.UpdateService;
+
+public sealed class UpdateServiceCommandHandler : IRequestHandler<UpdateServiceCommand, ServiceDto>
+{
+    private readonly IServiceRepository _serviceRepository;
+    private readonly IApplicationDbContext _context;
+
+    public UpdateServiceCommandHandler(IServiceRepository serviceRepository, IApplicationDbContext context)
+    {
+        _serviceRepository = serviceRepository;
+        _context = context;
+    }
+
+    public async Task<ServiceDto> Handle(UpdateServiceCommand request, CancellationToken cancellationToken)
+    {
+        var service = await _serviceRepository.GetByIdAsync(request.OrganisationId, request.ServiceId, cancellationToken);
+        if (service is null)
+            throw new DomainException("Service not found.");
+
+        service.UpdateDetails(request.Name, request.Description, request.EstimatedDurationMinutes);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Map(service);
+    }
+
+    private static ServiceDto Map(ServiceEntity service) =>
+        new(
+            service.Id,
+            service.Name,
+            service.Code,
+            service.Description,
+            service.EstimatedDurationMinutes,
+            service.IsActive,
+            [],
+            service.DeactivatedAt,
+            service.CreatedAt,
+            service.UpdatedAt);
+}

--- a/src/NextTurn.Application/Service/Commands/UpdateService/UpdateServiceCommandValidator.cs
+++ b/src/NextTurn.Application/Service/Commands/UpdateService/UpdateServiceCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Service.Commands.UpdateService;
+
+public sealed class UpdateServiceCommandValidator : AbstractValidator<UpdateServiceCommand>
+{
+    public UpdateServiceCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.ServiceId)
+            .NotEmpty().WithMessage("Service ID is required.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Service name is required.")
+            .MaximumLength(120).WithMessage("Service name must not exceed 120 characters.");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("Service description is required.")
+            .MaximumLength(500).WithMessage("Service description must not exceed 500 characters.");
+
+        RuleFor(x => x.EstimatedDurationMinutes)
+            .InclusiveBetween(1, 1440).WithMessage("Estimated duration must be between 1 and 1440 minutes.");
+    }
+}

--- a/src/NextTurn.Application/Service/Common/ServiceDto.cs
+++ b/src/NextTurn.Application/Service/Common/ServiceDto.cs
@@ -1,0 +1,13 @@
+namespace NextTurn.Application.Service.Common;
+
+public sealed record ServiceDto(
+    Guid ServiceId,
+    string Name,
+    string Code,
+    string Description,
+    int EstimatedDurationMinutes,
+    bool IsActive,
+    IReadOnlyList<Guid> AssignedOfficeIds,
+    DateTimeOffset? DeactivatedAt,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);

--- a/src/NextTurn.Application/Service/Queries/ListServices/ListServicesQuery.cs
+++ b/src/NextTurn.Application/Service/Queries/ListServices/ListServicesQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace NextTurn.Application.Service.Queries.ListServices;
+
+public sealed record ListServicesQuery(
+    Guid OrganisationId,
+    bool ActiveOnly,
+    int PageNumber,
+    int PageSize) : IRequest<ListServicesResult>;

--- a/src/NextTurn.Application/Service/Queries/ListServices/ListServicesQueryHandler.cs
+++ b/src/NextTurn.Application/Service/Queries/ListServices/ListServicesQueryHandler.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using NextTurn.Application.Service.Common;
+using NextTurn.Domain.Service.Repositories;
+
+namespace NextTurn.Application.Service.Queries.ListServices;
+
+public sealed class ListServicesQueryHandler : IRequestHandler<ListServicesQuery, ListServicesResult>
+{
+    private readonly IServiceRepository _serviceRepository;
+
+    public ListServicesQueryHandler(IServiceRepository serviceRepository)
+    {
+        _serviceRepository = serviceRepository;
+    }
+
+    public async Task<ListServicesResult> Handle(ListServicesQuery request, CancellationToken cancellationToken)
+    {
+        var (items, totalCount) = await _serviceRepository.ListAsync(
+            request.OrganisationId,
+            request.ActiveOnly,
+            request.PageNumber,
+            request.PageSize,
+            cancellationToken);
+
+        var assignmentMap = await _serviceRepository.GetAssignedOfficeIdsByServiceIdsAsync(
+            request.OrganisationId,
+            items.Select(x => x.Id).ToList(),
+            cancellationToken);
+
+        var data = items.Select(service => new ServiceDto(
+            service.Id,
+            service.Name,
+            service.Code,
+            service.Description,
+            service.EstimatedDurationMinutes,
+            service.IsActive,
+            assignmentMap.TryGetValue(service.Id, out var assignedOfficeIds) ? assignedOfficeIds : [],
+            service.DeactivatedAt,
+            service.CreatedAt,
+            service.UpdatedAt)).ToList();
+
+        return new ListServicesResult(data, request.PageNumber, request.PageSize, totalCount);
+    }
+}

--- a/src/NextTurn.Application/Service/Queries/ListServices/ListServicesQueryValidator.cs
+++ b/src/NextTurn.Application/Service/Queries/ListServices/ListServicesQueryValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Service.Queries.ListServices;
+
+public sealed class ListServicesQueryValidator : AbstractValidator<ListServicesQuery>
+{
+    public ListServicesQueryValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.PageNumber)
+            .GreaterThan(0).WithMessage("Page number must be greater than 0.");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100.");
+    }
+}

--- a/src/NextTurn.Application/Service/Queries/ListServices/ListServicesResult.cs
+++ b/src/NextTurn.Application/Service/Queries/ListServices/ListServicesResult.cs
@@ -1,0 +1,9 @@
+using NextTurn.Application.Service.Common;
+
+namespace NextTurn.Application.Service.Queries.ListServices;
+
+public sealed record ListServicesResult(
+    IReadOnlyList<ServiceDto> Items,
+    int PageNumber,
+    int PageSize,
+    int TotalCount);

--- a/src/NextTurn.Domain/Service/Entities/Service.cs
+++ b/src/NextTurn.Domain/Service/Entities/Service.cs
@@ -1,0 +1,131 @@
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Domain.Service.Entities;
+
+public sealed class Service
+{
+    public Guid Id { get; }
+    public Guid OrganisationId { get; private set; }
+    public string Name { get; private set; }
+    public string Code { get; private set; }
+    public string Description { get; private set; }
+    public int EstimatedDurationMinutes { get; private set; }
+    public bool IsActive { get; private set; }
+    public DateTimeOffset? DeactivatedAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    private Service()
+    {
+        Name = default!;
+        Code = default!;
+        Description = default!;
+    }
+
+    private Service(
+        Guid id,
+        Guid organisationId,
+        string name,
+        string code,
+        string description,
+        int estimatedDurationMinutes,
+        bool isActive,
+        DateTimeOffset? deactivatedAt,
+        DateTimeOffset createdAt,
+        DateTimeOffset updatedAt)
+    {
+        Id = id;
+        OrganisationId = organisationId;
+        Name = name;
+        Code = code;
+        Description = description;
+        EstimatedDurationMinutes = estimatedDurationMinutes;
+        IsActive = isActive;
+        DeactivatedAt = deactivatedAt;
+        CreatedAt = createdAt;
+        UpdatedAt = updatedAt;
+    }
+
+    public static Service Create(
+        Guid organisationId,
+        string name,
+        string code,
+        string description,
+        int estimatedDurationMinutes,
+        bool isActive)
+    {
+        ValidateName(name);
+        ValidateCode(code);
+        ValidateDescription(description);
+        ValidateDuration(estimatedDurationMinutes);
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        return new Service(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            name: name.Trim(),
+            code: code.Trim().ToUpperInvariant(),
+            description: description.Trim(),
+            estimatedDurationMinutes: estimatedDurationMinutes,
+            isActive: isActive,
+            deactivatedAt: isActive ? null : utcNow,
+            createdAt: utcNow,
+            updatedAt: utcNow);
+    }
+
+    public void UpdateDetails(string name, string description, int estimatedDurationMinutes)
+    {
+        ValidateName(name);
+        ValidateDescription(description);
+        ValidateDuration(estimatedDurationMinutes);
+
+        Name = name.Trim();
+        Description = description.Trim();
+        EstimatedDurationMinutes = estimatedDurationMinutes;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Deactivate()
+    {
+        if (!IsActive)
+            throw new DomainException("Service is already deactivated.");
+
+        IsActive = false;
+        DeactivatedAt = DateTimeOffset.UtcNow;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new DomainException("Service name is required.");
+
+        if (name.Trim().Length > 120)
+            throw new DomainException("Service name must not exceed 120 characters.");
+    }
+
+    private static void ValidateCode(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            throw new DomainException("Service code is required.");
+
+        if (code.Trim().Length > 40)
+            throw new DomainException("Service code must not exceed 40 characters.");
+    }
+
+    private static void ValidateDescription(string description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            throw new DomainException("Service description is required.");
+
+        if (description.Trim().Length > 500)
+            throw new DomainException("Service description must not exceed 500 characters.");
+    }
+
+    private static void ValidateDuration(int estimatedDurationMinutes)
+    {
+        if (estimatedDurationMinutes < 1 || estimatedDurationMinutes > 1440)
+            throw new DomainException("Estimated duration must be between 1 and 1440 minutes.");
+    }
+}

--- a/src/NextTurn.Domain/Service/Entities/ServiceOfficeAssignment.cs
+++ b/src/NextTurn.Domain/Service/Entities/ServiceOfficeAssignment.cs
@@ -1,0 +1,24 @@
+namespace NextTurn.Domain.Service.Entities;
+
+public sealed class ServiceOfficeAssignment
+{
+    public Guid ServiceId { get; private set; }
+    public Guid OfficeId { get; private set; }
+    public Guid OrganisationId { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    private ServiceOfficeAssignment() { }
+
+    private ServiceOfficeAssignment(Guid serviceId, Guid officeId, Guid organisationId, DateTimeOffset createdAt)
+    {
+        ServiceId = serviceId;
+        OfficeId = officeId;
+        OrganisationId = organisationId;
+        CreatedAt = createdAt;
+    }
+
+    public static ServiceOfficeAssignment Create(Guid serviceId, Guid officeId, Guid organisationId)
+    {
+        return new ServiceOfficeAssignment(serviceId, officeId, organisationId, DateTimeOffset.UtcNow);
+    }
+}

--- a/src/NextTurn.Domain/Service/Repositories/IServiceRepository.cs
+++ b/src/NextTurn.Domain/Service/Repositories/IServiceRepository.cs
@@ -1,0 +1,28 @@
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.Domain.Service.Repositories;
+
+public interface IServiceRepository
+{
+    Task AddAsync(ServiceEntity service, CancellationToken cancellationToken);
+
+    Task<ServiceEntity?> GetByIdAsync(Guid organisationId, Guid serviceId, CancellationToken cancellationToken);
+
+    Task<bool> ExistsByCodeAsync(Guid organisationId, string code, CancellationToken cancellationToken);
+
+    Task<(IReadOnlyList<ServiceEntity> Items, int TotalCount)> ListAsync(
+        Guid organisationId,
+        bool activeOnly,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetAssignedOfficeIdsByServiceIdsAsync(
+        Guid organisationId,
+        IReadOnlyCollection<Guid> serviceIds,
+        CancellationToken cancellationToken);
+
+    Task AssignOfficesAsync(Guid organisationId, Guid serviceId, IReadOnlyCollection<Guid> officeIds, CancellationToken cancellationToken);
+
+    Task RemoveOfficeAssignmentAsync(Guid organisationId, Guid serviceId, Guid officeId, CancellationToken cancellationToken);
+}

--- a/src/NextTurn.Infrastructure/DependencyInjection.cs
+++ b/src/NextTurn.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,7 @@ using NextTurn.Domain.Auth.Repositories;
 using NextTurn.Domain.Organisation.Repositories;
 using NextTurn.Domain.Office.Repositories;
 using NextTurn.Domain.Queue.Repositories;
+using NextTurn.Domain.Service.Repositories;
 using NextTurn.Infrastructure.Appointment;
 using NextTurn.Infrastructure.Auth;
 using NextTurn.Infrastructure.BusinessRegistry;
@@ -15,6 +16,7 @@ using NextTurn.Infrastructure.Organisation;
 using NextTurn.Infrastructure.Office;
 using NextTurn.Infrastructure.Persistence;
 using NextTurn.Infrastructure.Queue;
+using NextTurn.Infrastructure.Service;
 
 namespace NextTurn.Infrastructure;
 
@@ -63,6 +65,7 @@ public static class DependencyInjection
         services.AddScoped<IOfficeRepository, OfficeRepository>();
         services.AddScoped<IQueueRepository, QueueRepository>();
         services.AddScoped<IAppointmentRepository, AppointmentRepository>();
+        services.AddScoped<IServiceRepository, ServiceRepository>();
 
         // ── Security ──────────────────────────────────────────────────────────
         // Singleton is safe — BcryptPasswordHasher holds no state.

--- a/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -11,6 +11,8 @@ using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
 using QueueStaffAssignment = NextTurn.Domain.Queue.Entities.QueueStaffAssignment;
 using QueueActionAuditLog = NextTurn.Domain.Queue.Entities.QueueActionAuditLog;
 using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+using ServiceOfficeAssignment = NextTurn.Domain.Service.Entities.ServiceOfficeAssignment;
 
 namespace NextTurn.Infrastructure.Persistence;
 
@@ -51,6 +53,8 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<AppointmentEntity> Appointments => Set<AppointmentEntity>();
     public DbSet<AppointmentProfile> AppointmentProfiles => Set<AppointmentProfile>();
     public DbSet<AppointmentScheduleRule> AppointmentScheduleRules => Set<AppointmentScheduleRule>();
+    public DbSet<ServiceEntity> Services => Set<ServiceEntity>();
+    public DbSet<ServiceOfficeAssignment> ServiceOfficeAssignments => Set<ServiceOfficeAssignment>();
 
     // ── Model configuration ───────────────────────────────────────────────────
 
@@ -106,6 +110,12 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
         modelBuilder.Entity<AppointmentScheduleRule>()
             .HasQueryFilter(r => r.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<ServiceEntity>()
+            .HasQueryFilter(s => s.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<ServiceOfficeAssignment>()
+            .HasQueryFilter(s => s.OrganisationId == _tenantContext.TenantId);
     }
 
     // ── SaveChanges override ──────────────────────────────────────────────────

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Service/ServiceConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Service/ServiceConfiguration.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using NextTurn.Domain.Service.Entities;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Service;
+
+public sealed class ServiceConfiguration : IEntityTypeConfiguration<ServiceEntity>
+{
+    public void Configure(EntityTypeBuilder<ServiceEntity> builder)
+    {
+        builder.ToTable("Services");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.OrganisationId)
+            .IsRequired();
+
+        builder.Property(x => x.Name)
+            .HasMaxLength(120)
+            .IsRequired();
+
+        builder.Property(x => x.Code)
+            .HasMaxLength(40)
+            .IsRequired();
+
+        builder.Property(x => x.Description)
+            .HasMaxLength(500);
+
+        builder.Property(x => x.EstimatedDurationMinutes)
+            .IsRequired();
+
+        builder.Property(x => x.IsActive)
+            .IsRequired();
+
+        builder.Property(x => x.DeactivatedAt)
+            .IsRequired(false);
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.Property(x => x.UpdatedAt)
+            .IsRequired();
+
+        builder.HasIndex(x => new { x.OrganisationId, x.Code })
+            .IsUnique();
+
+        builder.HasMany<ServiceOfficeAssignment>()
+            .WithOne()
+            .HasForeignKey(x => new { x.OrganisationId, x.ServiceId })
+            .HasPrincipalKey(x => new { x.OrganisationId, x.Id });
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Service/ServiceOfficeAssignmentConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Service/ServiceOfficeAssignmentConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using NextTurn.Domain.Service.Entities;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Service;
+
+public sealed class ServiceOfficeAssignmentConfiguration : IEntityTypeConfiguration<ServiceOfficeAssignment>
+{
+    public void Configure(EntityTypeBuilder<ServiceOfficeAssignment> builder)
+    {
+        builder.ToTable("ServiceOfficeAssignments");
+
+        builder.HasKey(x => new { x.OrganisationId, x.ServiceId, x.OfficeId });
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne<NextTurn.Domain.Service.Entities.Service>()
+            .WithMany()
+            .HasForeignKey(x => new { x.OrganisationId, x.ServiceId })
+            .HasPrincipalKey(x => new { x.OrganisationId, x.Id })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne<NextTurn.Domain.Office.Entities.Office>()
+            .WithMany()
+            .HasForeignKey(x => new { x.OrganisationId, x.OfficeId })
+            .HasPrincipalKey(x => new { x.OrganisationId, x.Id })
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Migrations/20260326033712_AddServices.Designer.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Migrations/20260326033712_AddServices.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NextTurn.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace NextTurn.Infrastructure.Migrations
+namespace NextTurn.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260326033712_AddServices")]
+    partial class AddServices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NextTurn.Infrastructure/Persistence/Migrations/20260326033712_AddServices.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Migrations/20260326033712_AddServices.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NextTurn.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddServices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_Offices_OrganisationId_Id",
+                table: "Offices",
+                columns: new[] { "OrganisationId", "Id" });
+
+            migrationBuilder.CreateTable(
+                name: "Services",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrganisationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(120)", maxLength: 120, nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    EstimatedDurationMinutes = table.Column<int>(type: "int", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    DeactivatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Services", x => x.Id);
+                    table.UniqueConstraint("AK_Services_OrganisationId_Id", x => new { x.OrganisationId, x.Id });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServiceOfficeAssignments",
+                columns: table => new
+                {
+                    ServiceId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OfficeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrganisationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServiceOfficeAssignments", x => new { x.OrganisationId, x.ServiceId, x.OfficeId });
+                    table.ForeignKey(
+                        name: "FK_ServiceOfficeAssignments_Offices_OrganisationId_OfficeId",
+                        columns: x => new { x.OrganisationId, x.OfficeId },
+                        principalTable: "Offices",
+                        principalColumns: new[] { "OrganisationId", "Id" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ServiceOfficeAssignments_Services_OrganisationId_ServiceId",
+                        columns: x => new { x.OrganisationId, x.ServiceId },
+                        principalTable: "Services",
+                        principalColumns: new[] { "OrganisationId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceOfficeAssignments_OrganisationId_OfficeId",
+                table: "ServiceOfficeAssignments",
+                columns: new[] { "OrganisationId", "OfficeId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Services_OrganisationId_Code",
+                table: "Services",
+                columns: new[] { "OrganisationId", "Code" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ServiceOfficeAssignments");
+
+            migrationBuilder.DropTable(
+                name: "Services");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_Offices_OrganisationId_Id",
+                table: "Offices");
+        }
+    }
+}

--- a/src/NextTurn.Infrastructure/Service/ServiceRepository.cs
+++ b/src/NextTurn.Infrastructure/Service/ServiceRepository.cs
@@ -1,0 +1,123 @@
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Infrastructure.Persistence;
+using NextTurn.Domain.Service.Entities;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.Infrastructure.Service;
+
+public sealed class ServiceRepository : IServiceRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public ServiceRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<bool> ExistsByCodeAsync(Guid organisationId, string code, CancellationToken cancellationToken)
+    {
+        var normalizedCode = code.Trim().ToUpperInvariant();
+
+        return await _context.Services
+            .AnyAsync(x =>
+                x.OrganisationId == organisationId &&
+                x.Code == normalizedCode,
+                cancellationToken);
+    }
+
+    public async Task<ServiceEntity?> GetByIdAsync(Guid organisationId, Guid serviceId, CancellationToken cancellationToken)
+    {
+        return await _context.Services
+            .FirstOrDefaultAsync(x => x.OrganisationId == organisationId && x.Id == serviceId, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<ServiceEntity> Items, int TotalCount)> ListAsync(
+        Guid organisationId,
+        bool activeOnly,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var query = _context.Services
+            .AsNoTracking()
+            .Where(x => x.OrganisationId == organisationId);
+
+        if (activeOnly)
+            query = query.Where(x => x.IsActive);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderBy(x => x.Name)
+            .ThenBy(x => x.Code)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetAssignedOfficeIdsByServiceIdsAsync(
+        Guid organisationId,
+        IReadOnlyCollection<Guid> serviceIds,
+        CancellationToken cancellationToken)
+    {
+        if (serviceIds.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<Guid>>();
+
+        var assignments = await _context.ServiceOfficeAssignments
+            .AsNoTracking()
+            .Where(x => x.OrganisationId == organisationId && serviceIds.Contains(x.ServiceId))
+            .ToListAsync(cancellationToken);
+
+        return assignments
+            .GroupBy(x => x.ServiceId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<Guid>)x.Select(a => a.OfficeId).ToList());
+    }
+
+    public async Task AddAsync(ServiceEntity service, CancellationToken cancellationToken)
+    {
+        await _context.Services.AddAsync(service, cancellationToken);
+    }
+
+    public async Task AssignOfficesAsync(Guid organisationId, Guid serviceId, IReadOnlyCollection<Guid> officeIds, CancellationToken cancellationToken)
+    {
+        if (officeIds.Count == 0)
+            return;
+
+        var existingOfficeIds = await _context.ServiceOfficeAssignments
+            .Where(x => x.OrganisationId == organisationId && x.ServiceId == serviceId)
+            .Select(x => x.OfficeId)
+            .ToListAsync(cancellationToken);
+
+        var newOfficeIds = officeIds
+            .Where(id => !existingOfficeIds.Contains(id))
+            .Distinct()
+            .ToList();
+
+        foreach (var officeId in newOfficeIds)
+        {
+            await _context.ServiceOfficeAssignments.AddAsync(
+                ServiceOfficeAssignment.Create(serviceId, officeId, organisationId),
+                cancellationToken);
+        }
+    }
+
+    public async Task RemoveOfficeAssignmentAsync(Guid organisationId, Guid serviceId, Guid officeId, CancellationToken cancellationToken)
+    {
+        var assignment = await _context.ServiceOfficeAssignments
+            .FirstOrDefaultAsync(x =>
+                x.OrganisationId == organisationId &&
+                x.ServiceId == serviceId &&
+                x.OfficeId == officeId,
+                cancellationToken);
+
+        if (assignment is null)
+            return;
+
+        _context.ServiceOfficeAssignments.Remove(assignment);
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -32,6 +32,7 @@ import { AppointmentPage }      from './pages/Appointment'
 import { AdminDashboardPage }   from './pages/Admin'
 import { StaffDashboardPage }   from './pages/Staff'
 import { OfficeManagementPage } from './pages/Offices'
+import { ServiceManagementPage } from './pages/Services'
 import { StaffInviteAcceptPage } from './pages/StaffInviteAccept'
 import { OrgLoginLookupPage }   from './pages/OrgLoginLookup'
 import { TermsPage, PrivacyPage } from './pages/Legal'
@@ -97,6 +98,15 @@ function App() {
         element={
           <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
             <OfficeManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/:tenantId/services"
+        element={
+          <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
+            <ServiceManagementPage />
           </ProtectedRoute>
         }
       />

--- a/src/web/src/api/services.ts
+++ b/src/web/src/api/services.ts
@@ -1,0 +1,137 @@
+import { apiClient, parseApiError } from './client'
+import { getToken } from '../utils/authToken'
+
+export interface ServiceDto {
+  serviceId: string
+  name: string
+  code: string
+  description: string
+  estimatedDurationMinutes: number
+  isActive: boolean
+  assignedOfficeIds: string[]
+  deactivatedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ListServicesResult {
+  items: ServiceDto[]
+  pageNumber: number
+  pageSize: number
+  totalCount: number
+}
+
+export interface CreateServiceBody {
+  name: string
+  code: string
+  description: string
+  estimatedDurationMinutes: number
+  isActive: boolean
+}
+
+export interface UpdateServiceBody {
+  name: string
+  description: string
+  estimatedDurationMinutes: number
+}
+
+export interface ListServicesParams {
+  activeOnly?: boolean
+  pageNumber?: number
+  pageSize?: number
+}
+
+export async function listServices(tenantId: string, params: ListServicesParams = {}): Promise<ListServicesResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<ListServicesResult>('/services', {
+      params,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function createService(tenantId: string, body: CreateServiceBody): Promise<ServiceDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<ServiceDto>('/services', body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function updateService(tenantId: string, serviceId: string, body: UpdateServiceBody): Promise<ServiceDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.put<ServiceDto>(`/services/${serviceId}`, body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function deactivateService(tenantId: string, serviceId: string): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.patch(`/services/${serviceId}/deactivate`, null, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function assignServiceOffices(tenantId: string, serviceId: string, officeIds: string[]): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.post(
+      `/services/${serviceId}/offices`,
+      { officeIds },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      },
+    )
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function removeServiceOfficeAssignment(tenantId: string, serviceId: string, officeId: string): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.delete(`/services/${serviceId}/offices/${officeId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}

--- a/src/web/src/pages/Admin/AdminDashboardPage.tsx
+++ b/src/web/src/pages/Admin/AdminDashboardPage.tsx
@@ -492,6 +492,13 @@ export function AdminDashboardPage() {
             >
               Manage Offices
             </button>
+            <button
+              type="button"
+              className={styles.tabBtn}
+              onClick={() => navigate(`/admin/${tenantId}/services`)}
+            >
+              Manage Services
+            </button>
           </div>
           <div className={styles.tabs} role="tablist" aria-label="Admin sections">
             <button

--- a/src/web/src/pages/Services/ServiceManagementPage.module.css
+++ b/src/web/src/pages/Services/ServiceManagementPage.module.css
@@ -1,0 +1,176 @@
+.page {
+  min-height: 100vh;
+  background: linear-gradient(160deg, #f4f7ff 0%, #effaf4 100%);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.backBtn,
+.primaryBtn,
+.secondaryBtn,
+.dangerBtn {
+  border-radius: 10px;
+  border: 1px solid #d0d7de;
+  padding: 0.6rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.backBtn,
+.secondaryBtn {
+  background: #fff;
+  color: #1f2937;
+}
+
+.primaryBtn {
+  background: #0f766e;
+  border-color: #0f766e;
+  color: #fff;
+}
+
+.dangerBtn {
+  background: #dc2626;
+  border-color: #dc2626;
+  color: #fff;
+}
+
+.filters,
+.formCard,
+.listCard,
+.assignmentsCard {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #dbe4ec;
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.7rem 0.8rem;
+  font-size: 0.95rem;
+}
+
+.textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+
+.checkboxRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.error,
+.success {
+  padding: 0.7rem 0.9rem;
+  border-radius: 10px;
+  font-weight: 600;
+}
+
+.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.success {
+  background: #dcfce7;
+  color: #14532d;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.item {
+  border: 1px solid #dbe4ec;
+  border-radius: 12px;
+  padding: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.item h3 {
+  margin: 0 0 0.2rem;
+}
+
+.item p {
+  margin: 0.2rem 0;
+}
+
+.meta {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.itemActions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.officeGrid {
+  margin: 1rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.6rem;
+}
+
+.officeCard {
+  border: 1px solid #dbe4ec;
+  border-radius: 10px;
+  padding: 0.7rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  background: #fff;
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+
+  .item {
+    flex-direction: column;
+  }
+}

--- a/src/web/src/pages/Services/ServiceManagementPage.tsx
+++ b/src/web/src/pages/Services/ServiceManagementPage.tsx
@@ -1,0 +1,385 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  assignServiceOffices,
+  createService,
+  deactivateService,
+  listServices,
+  removeServiceOfficeAssignment,
+  updateService,
+  type ServiceDto,
+} from '../../api/services'
+import { listOffices, type OfficeDto } from '../../api/offices'
+import type { ApiError } from '../../types/api'
+import { clearToken, getTokenPayload } from '../../utils/authToken'
+import styles from './ServiceManagementPage.module.css'
+
+type Mode = 'create' | 'edit'
+
+interface ServiceForm {
+  name: string
+  code: string
+  description: string
+  estimatedDurationMinutes: string
+  isActive: boolean
+}
+
+const defaultForm: ServiceForm = {
+  name: '',
+  code: '',
+  description: '',
+  estimatedDurationMinutes: '15',
+  isActive: true,
+}
+
+export function ServiceManagementPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const [services, setServices] = useState<ServiceDto[]>([])
+  const [offices, setOffices] = useState<OfficeDto[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [form, setForm] = useState<ServiceForm>(defaultForm)
+  const [mode, setMode] = useState<Mode>('create')
+  const [editServiceId, setEditServiceId] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [activeOnly, setActiveOnly] = useState(true)
+
+  const [assignmentServiceId, setAssignmentServiceId] = useState<string>('')
+  const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
+  const [savingAssignments, setSavingAssignments] = useState(false)
+
+  const selectedService = useMemo(
+    () => services.find(s => s.serviceId === assignmentServiceId) ?? null,
+    [services, assignmentServiceId],
+  )
+
+  useEffect(() => {
+    if (!payload) {
+      clearToken()
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (!tenantId) return
+
+    void loadData(tenantId, activeOnly)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenantId, activeOnly])
+
+  useEffect(() => {
+    if (!selectedService) {
+      setSelectedOfficeIds([])
+      return
+    }
+
+    setSelectedOfficeIds(selectedService.assignedOfficeIds)
+  }, [selectedService])
+
+  async function loadData(currentTenantId: string, activeOnlyFilter: boolean) {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const [serviceResult, officeResult] = await Promise.all([
+        listServices(currentTenantId, { activeOnly: activeOnlyFilter, pageNumber: 1, pageSize: 100 }),
+        listOffices(currentTenantId, { isActive: true, pageNumber: 1, pageSize: 100 }),
+      ])
+
+      setServices(serviceResult.items)
+      setOffices(officeResult.items)
+      setAssignmentServiceId(prev => {
+        if (prev && serviceResult.items.some(x => x.serviceId === prev)) return prev
+        return serviceResult.items[0]?.serviceId ?? ''
+      })
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not load services.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function resetForm() {
+    setMode('create')
+    setEditServiceId(null)
+    setForm(defaultForm)
+  }
+
+  function beginEdit(service: ServiceDto) {
+    setMode('edit')
+    setEditServiceId(service.serviceId)
+    setForm({
+      name: service.name,
+      code: service.code,
+      description: service.description,
+      estimatedDurationMinutes: String(service.estimatedDurationMinutes),
+      isActive: service.isActive,
+    })
+    setError(null)
+    setSuccess(null)
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!tenantId) return
+
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      if (mode === 'create') {
+        await createService(tenantId, {
+          name: form.name.trim(),
+          code: form.code.trim(),
+          description: form.description.trim(),
+          estimatedDurationMinutes: Number(form.estimatedDurationMinutes),
+          isActive: form.isActive,
+        })
+        setSuccess('Service created successfully.')
+      } else if (editServiceId) {
+        await updateService(tenantId, editServiceId, {
+          name: form.name.trim(),
+          description: form.description.trim(),
+          estimatedDurationMinutes: Number(form.estimatedDurationMinutes),
+        })
+        setSuccess('Service updated successfully.')
+      }
+
+      resetForm()
+      await loadData(tenantId, activeOnly)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not save service.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDeactivate(serviceId: string) {
+    if (!tenantId) return
+
+    setError(null)
+    setSuccess(null)
+
+    try {
+      await deactivateService(tenantId, serviceId)
+      setSuccess('Service deactivated successfully.')
+      await loadData(tenantId, activeOnly)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not deactivate service.')
+    }
+  }
+
+  function toggleOfficeSelection(officeId: string) {
+    setSelectedOfficeIds(prev =>
+      prev.includes(officeId)
+        ? prev.filter(id => id !== officeId)
+        : [...prev, officeId],
+    )
+  }
+
+  async function handleSaveAssignments() {
+    if (!tenantId || !selectedService) return
+
+    setSavingAssignments(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const currentSet = new Set(selectedService.assignedOfficeIds)
+      const nextSet = new Set(selectedOfficeIds)
+
+      const toAdd = selectedOfficeIds.filter(id => !currentSet.has(id))
+      const toRemove = selectedService.assignedOfficeIds.filter(id => !nextSet.has(id))
+
+      if (toAdd.length > 0) {
+        await assignServiceOffices(tenantId, selectedService.serviceId, toAdd)
+      }
+
+      for (const officeId of toRemove) {
+        await removeServiceOfficeAssignment(tenantId, selectedService.serviceId, officeId)
+      }
+
+      setSuccess('Service-office assignments updated.')
+      await loadData(tenantId, activeOnly)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not update assignments.')
+    } finally {
+      setSavingAssignments(false)
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1>Service Configuration</h1>
+        <button type="button" className={styles.backBtn} onClick={() => navigate(`/admin/${tenantId}`)}>
+          Back to Admin
+        </button>
+      </header>
+
+      {error && <div className={styles.error}>{error}</div>}
+      {success && <div className={styles.success}>{success}</div>}
+
+      <section className={styles.filters}>
+        <label className={styles.checkboxRow}>
+          <input
+            type="checkbox"
+            checked={activeOnly}
+            onChange={(event) => setActiveOnly(event.target.checked)}
+          />
+          Show active services only
+        </label>
+      </section>
+
+      <section className={styles.formCard}>
+        <h2>{mode === 'create' ? 'Create Service' : 'Update Service'}</h2>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <input
+            className={styles.input}
+            placeholder="Service name"
+            value={form.name}
+            onChange={(event) => setForm(prev => ({ ...prev, name: event.target.value }))}
+            required
+          />
+          <input
+            className={styles.input}
+            placeholder="Service code"
+            value={form.code}
+            onChange={(event) => setForm(prev => ({ ...prev, code: event.target.value }))}
+            disabled={mode === 'edit'}
+            required
+          />
+          <textarea
+            className={styles.textarea}
+            placeholder="Description"
+            value={form.description}
+            onChange={(event) => setForm(prev => ({ ...prev, description: event.target.value }))}
+            required
+          />
+          <input
+            className={styles.input}
+            type="number"
+            min={1}
+            max={1440}
+            placeholder="Estimated duration (minutes)"
+            value={form.estimatedDurationMinutes}
+            onChange={(event) => setForm(prev => ({ ...prev, estimatedDurationMinutes: event.target.value }))}
+            required
+          />
+          {mode === 'create' && (
+            <label className={styles.checkboxRow}>
+              <input
+                type="checkbox"
+                checked={form.isActive}
+                onChange={(event) => setForm(prev => ({ ...prev, isActive: event.target.checked }))}
+              />
+              Active at creation
+            </label>
+          )}
+
+          <div className={styles.actions}>
+            <button type="submit" className={styles.primaryBtn} disabled={saving}>
+              {saving ? 'Saving...' : mode === 'create' ? 'Create Service' : 'Update Service'}
+            </button>
+            {mode === 'edit' && (
+              <button type="button" className={styles.secondaryBtn} onClick={resetForm}>
+                Cancel Edit
+              </button>
+            )}
+          </div>
+        </form>
+      </section>
+
+      <section className={styles.listCard}>
+        <h2>Services</h2>
+        {loading ? (
+          <p>Loading services...</p>
+        ) : services.length === 0 ? (
+          <p>No services found for current filter.</p>
+        ) : (
+          <ul className={styles.list}>
+            {services.map(service => (
+              <li key={service.serviceId} className={styles.item}>
+                <div>
+                  <h3>{service.name}</h3>
+                  <p className={styles.meta}>Code: {service.code} · {service.estimatedDurationMinutes} mins</p>
+                  <p>{service.description}</p>
+                  <p className={styles.meta}>{service.isActive ? 'Active' : 'Inactive'}</p>
+                </div>
+                <div className={styles.itemActions}>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    onClick={() => beginEdit(service)}
+                    disabled={!service.isActive}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.dangerBtn}
+                    onClick={() => handleDeactivate(service.serviceId)}
+                    disabled={!service.isActive}
+                  >
+                    Deactivate
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className={styles.assignmentsCard}>
+        <h2>Assign Services to Offices</h2>
+        {services.length === 0 ? (
+          <p>Create a service first.</p>
+        ) : (
+          <>
+            <select
+              className={styles.select}
+              value={assignmentServiceId}
+              onChange={(event) => setAssignmentServiceId(event.target.value)}
+            >
+              {services.map(service => (
+                <option key={service.serviceId} value={service.serviceId}>
+                  {service.name} ({service.code})
+                </option>
+              ))}
+            </select>
+
+            <div className={styles.officeGrid}>
+              {offices.map(office => (
+                <label key={office.officeId} className={styles.officeCard}>
+                  <input
+                    type="checkbox"
+                    checked={selectedOfficeIds.includes(office.officeId)}
+                    onChange={() => toggleOfficeSelection(office.officeId)}
+                  />
+                  <span>{office.name}</span>
+                </label>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              onClick={handleSaveAssignments}
+              disabled={savingAssignments || !selectedService}
+            >
+              {savingAssignments ? 'Saving assignments...' : 'Save Assignments'}
+            </button>
+          </>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/web/src/pages/Services/index.ts
+++ b/src/web/src/pages/Services/index.ts
@@ -1,0 +1,1 @@
+export { ServiceManagementPage } from './ServiceManagementPage'

--- a/tests/NextTurn.IntegrationTests/Service/ServiceConfigurationIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Service/ServiceConfigurationIntegrationTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NextTurn.Domain.Auth;
+
+namespace NextTurn.IntegrationTests.Service;
+
+[Collection("Integration")]
+public sealed class ServiceConfigurationIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+
+    public ServiceConfigurationIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _) = await _factory.SeedQueueAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ServiceFlow_CreateAssignUpdateDeactivateAndList_WorksForOrgAdmin()
+    {
+        var adminClient = AuthenticatedClient(UserRole.OrgAdmin, Guid.NewGuid(), _tenantId);
+
+        var officeCreate = await adminClient.PostAsJsonAsync("/api/offices", new
+        {
+            name = "Main Office",
+            address = "1 Main Street",
+            latitude = 6.9271,
+            longitude = 79.8612,
+            openingHours = "Mon-Fri 09:00-17:00"
+        });
+        officeCreate.StatusCode.Should().Be(HttpStatusCode.Created);
+        var office = await officeCreate.Content.ReadFromJsonAsync<OfficeDto>();
+        office.Should().NotBeNull();
+
+        var createResponse = await adminClient.PostAsJsonAsync("/api/services", new
+        {
+            name = "Passport Renewal",
+            code = "SVC-01",
+            description = "Renewal processing",
+            estimatedDurationMinutes = 20,
+            isActive = true
+        });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<ServiceDto>();
+        created.Should().NotBeNull();
+        created!.Code.Should().Be("SVC-01");
+
+        var assignResponse = await adminClient.PostAsJsonAsync($"/api/services/{created.ServiceId}/offices", new
+        {
+            officeIds = new[] { office!.OfficeId }
+        });
+        assignResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listResponse = await adminClient.GetAsync("/api/services?activeOnly=true&pageNumber=1&pageSize=20");
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var listed = await listResponse.Content.ReadFromJsonAsync<ListServicesResponse>();
+        listed.Should().NotBeNull();
+        listed!.Items.Should().Contain(x => x.ServiceId == created.ServiceId && x.AssignedOfficeIds.Contains(office.OfficeId));
+
+        var updateResponse = await adminClient.PutAsJsonAsync($"/api/services/{created.ServiceId}", new
+        {
+            name = "Passport Renewal Updated",
+            description = "Updated description",
+            estimatedDurationMinutes = 25
+        });
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<ServiceDto>();
+        updated.Should().NotBeNull();
+        updated!.Name.Should().Be("Passport Renewal Updated");
+
+        var removeAssignment = await adminClient.DeleteAsync($"/api/services/{created.ServiceId}/offices/{office.OfficeId}");
+        removeAssignment.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var deactivateResponse = await adminClient.PatchAsync($"/api/services/{created.ServiceId}/deactivate", null);
+        deactivateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var activeOnlyListAfterDeactivate = await adminClient.GetAsync("/api/services?activeOnly=true&pageNumber=1&pageSize=20");
+        activeOnlyListAfterDeactivate.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var activeOnlyResult = await activeOnlyListAfterDeactivate.Content.ReadFromJsonAsync<ListServicesResponse>();
+        activeOnlyResult.Should().NotBeNull();
+        activeOnlyResult!.Items.Should().NotContain(x => x.ServiceId == created.ServiceId);
+    }
+
+    [Fact]
+    public async Task CreateService_WithUserRole_ReturnsForbidden()
+    {
+        var userClient = AuthenticatedClient(UserRole.User, Guid.NewGuid(), _tenantId);
+
+        var response = await userClient.PostAsJsonAsync("/api/services", new
+        {
+            name = "Passport Renewal",
+            code = "SVC-01",
+            description = "Renewal processing",
+            estimatedDurationMinutes = 20,
+            isActive = true
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListServices_WithUserRole_ReturnsOnlyActiveWhenRequested()
+    {
+        var adminClient = AuthenticatedClient(UserRole.OrgAdmin, Guid.NewGuid(), _tenantId);
+
+        var activeCreate = await adminClient.PostAsJsonAsync("/api/services", new
+        {
+            name = "Active Service",
+            code = "SVC-A",
+            description = "Active",
+            estimatedDurationMinutes = 10,
+            isActive = true
+        });
+        activeCreate.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var inactiveCreate = await adminClient.PostAsJsonAsync("/api/services", new
+        {
+            name = "Inactive Service",
+            code = "SVC-I",
+            description = "Inactive",
+            estimatedDurationMinutes = 15,
+            isActive = false
+        });
+        inactiveCreate.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var userClient = AuthenticatedClient(UserRole.User, Guid.NewGuid(), _tenantId);
+        var listResponse = await userClient.GetAsync("/api/services?activeOnly=true&pageNumber=1&pageSize=20");
+
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await listResponse.Content.ReadFromJsonAsync<ListServicesResponse>();
+        list.Should().NotBeNull();
+        list!.Items.Should().Contain(x => x.Code == "SVC-A");
+        list.Items.Should().NotContain(x => x.Code == "SVC-I");
+    }
+
+    private HttpClient AuthenticatedClient(UserRole role, Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(role, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private sealed record OfficeDto(Guid OfficeId, string Name);
+
+    private sealed record ServiceDto(
+        Guid ServiceId,
+        string Name,
+        string Code,
+        string Description,
+        int EstimatedDurationMinutes,
+        bool IsActive,
+        IReadOnlyList<Guid> AssignedOfficeIds,
+        DateTimeOffset? DeactivatedAt,
+        DateTimeOffset CreatedAt,
+        DateTimeOffset UpdatedAt);
+
+    private sealed record ListServicesResponse(
+        IReadOnlyList<ServiceDto> Items,
+        int PageNumber,
+        int PageSize,
+        int TotalCount);
+}

--- a/tests/NextTurn.UnitTests/Application/Service/AssignServiceOfficesCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/AssignServiceOfficesCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Commands.AssignServiceOffices;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class AssignServiceOfficesCommandHandlerTests
+{
+    private readonly Mock<IServiceRepository> _serviceRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly AssignServiceOfficesCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid ServiceId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public AssignServiceOfficesCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new AssignServiceOfficesCommandHandler(_serviceRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingService_AssignsDistinctOfficesAndPersists()
+    {
+        var service = ServiceEntity.Create(OrganisationId, "Passport Renewal", "SVC-01", "Renewal", 20, true);
+        var officeA = Guid.NewGuid();
+        var officeB = Guid.NewGuid();
+
+        _serviceRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(service);
+
+        var command = new AssignServiceOfficesCommand(OrganisationId, ServiceId, new[] { officeA, officeA, officeB });
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+
+        _serviceRepositoryMock.Verify(r => r.AssignOfficesAsync(
+            OrganisationId,
+            ServiceId,
+            It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 2 && ids.Contains(officeA) && ids.Contains(officeB)),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenServiceNotFound_ThrowsDomainException()
+    {
+        _serviceRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ServiceEntity?)null);
+
+        var command = new AssignServiceOfficesCommand(OrganisationId, ServiceId, new[] { Guid.NewGuid() });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Service not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/AssignServiceOfficesCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/AssignServiceOfficesCommandValidatorTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using NextTurn.Application.Service.Commands.AssignServiceOffices;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class AssignServiceOfficesCommandValidatorTests
+{
+    private readonly AssignServiceOfficesCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new AssignServiceOfficesCommand(Guid.NewGuid(), Guid.NewGuid(), new[] { Guid.NewGuid() });
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithNoOffices_ReturnsError()
+    {
+        var command = new AssignServiceOfficesCommand(Guid.NewGuid(), Guid.NewGuid(), Array.Empty<Guid>());
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(AssignServiceOfficesCommand.OfficeIds));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/CreateServiceCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/CreateServiceCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Commands.CreateService;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class CreateServiceCommandHandlerTests
+{
+    private readonly Mock<IServiceRepository> _serviceRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly CreateServiceCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public CreateServiceCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new CreateServiceCommandHandler(_serviceRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithUniqueCode_CreatesServiceAndPersists()
+    {
+        _serviceRepositoryMock
+            .Setup(r => r.ExistsByCodeAsync(OrganisationId, "SVC-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var command = new CreateServiceCommand(
+            OrganisationId,
+            "Passport Renewal",
+            "svc-01",
+            "Renewal processing",
+            20,
+            true);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.ServiceId.Should().NotBeEmpty();
+        result.Name.Should().Be("Passport Renewal");
+        result.Code.Should().Be("SVC-01");
+
+        _serviceRepositoryMock.Verify(
+            r => r.AddAsync(It.Is<ServiceEntity>(s =>
+                s.OrganisationId == OrganisationId &&
+                s.Name == "Passport Renewal" &&
+                s.Code == "SVC-01"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithDuplicateCode_ThrowsConflictDomainException()
+    {
+        _serviceRepositoryMock
+            .Setup(r => r.ExistsByCodeAsync(OrganisationId, "SVC-01", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var command = new CreateServiceCommand(
+            OrganisationId,
+            "Passport Renewal",
+            "svc-01",
+            "Renewal processing",
+            20,
+            true);
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictDomainException>()
+            .WithMessage("Service code already exists in this tenant.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/CreateServiceCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/CreateServiceCommandValidatorTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using NextTurn.Application.Service.Commands.CreateService;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class CreateServiceCommandValidatorTests
+{
+    private readonly CreateServiceCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new CreateServiceCommand(
+            Guid.NewGuid(),
+            "Passport Renewal",
+            "SVC-01",
+            "Renewal processing",
+            20,
+            true);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithMissingCode_ReturnsError()
+    {
+        var command = new CreateServiceCommand(
+            Guid.NewGuid(),
+            "Passport Renewal",
+            string.Empty,
+            "Renewal processing",
+            20,
+            true);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(CreateServiceCommand.Code));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/DeactivateServiceCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/DeactivateServiceCommandHandlerTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Commands.DeactivateService;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class DeactivateServiceCommandHandlerTests
+{
+    private readonly Mock<IServiceRepository> _serviceRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly DeactivateServiceCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid ServiceId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public DeactivateServiceCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new DeactivateServiceCommandHandler(_serviceRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithActiveService_DeactivatesAndPersists()
+    {
+        var service = ServiceEntity.Create(OrganisationId, "Renewal", "SVC-01", "Desc", 15, true);
+
+        _serviceRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(service);
+
+        await _handler.Handle(new DeactivateServiceCommand(OrganisationId, ServiceId), CancellationToken.None);
+
+        service.IsActive.Should().BeFalse();
+        service.DeactivatedAt.Should().NotBeNull();
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenServiceNotFound_ThrowsDomainException()
+    {
+        _serviceRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ServiceEntity?)null);
+
+        var act = async () => await _handler.Handle(new DeactivateServiceCommand(OrganisationId, ServiceId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Service not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/DeactivateServiceCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/DeactivateServiceCommandValidatorTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using NextTurn.Application.Service.Commands.DeactivateService;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class DeactivateServiceCommandValidatorTests
+{
+    private readonly DeactivateServiceCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new DeactivateServiceCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithEmptyServiceId_ReturnsError()
+    {
+        var command = new DeactivateServiceCommand(Guid.NewGuid(), Guid.Empty);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(DeactivateServiceCommand.ServiceId));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/ListServicesQueryHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/ListServicesQueryHandlerTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Service.Queries.ListServices;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class ListServicesQueryHandlerTests
+{
+    private readonly Mock<IServiceRepository> _serviceRepositoryMock = new();
+    private readonly ListServicesQueryHandler _handler;
+
+    public ListServicesQueryHandlerTests()
+    {
+        _handler = new ListServicesQueryHandler(_serviceRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithAssignedOffices_MapsResultIncludingAssignmentIds()
+    {
+        var organisationId = Guid.NewGuid();
+        var query = new ListServicesQuery(organisationId, true, 1, 20);
+
+        var serviceA = ServiceEntity.Create(organisationId, "Passport", "SVC-01", "Passport service", 20, true);
+        var serviceB = ServiceEntity.Create(organisationId, "License", "SVC-02", "License service", 15, true);
+
+        _serviceRepositoryMock
+            .Setup(r => r.ListAsync(organisationId, true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ServiceEntity> { serviceA, serviceB }, 2));
+
+        var office1 = Guid.NewGuid();
+        var office2 = Guid.NewGuid();
+        IReadOnlyDictionary<Guid, IReadOnlyList<Guid>> assignmentMap = new Dictionary<Guid, IReadOnlyList<Guid>>
+        {
+            [serviceA.Id] = new List<Guid> { office1, office2 },
+        };
+
+        _serviceRepositoryMock
+            .Setup(r => r.GetAssignedOfficeIdsByServiceIdsAsync(
+                organisationId,
+                It.IsAny<IReadOnlyCollection<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(assignmentMap);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.TotalCount.Should().Be(2);
+        result.Items.Should().HaveCount(2);
+        result.PageNumber.Should().Be(1);
+        result.PageSize.Should().Be(20);
+
+        var first = result.Items.Single(x => x.ServiceId == serviceA.Id);
+        first.AssignedOfficeIds.Should().BeEquivalentTo(new[] { office1, office2 });
+
+        var second = result.Items.Single(x => x.ServiceId == serviceB.Id);
+        second.AssignedOfficeIds.Should().BeEmpty();
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/ListServicesQueryValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/ListServicesQueryValidatorTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using NextTurn.Application.Service.Queries.ListServices;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class ListServicesQueryValidatorTests
+{
+    private readonly ListServicesQueryValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidQuery_HasNoErrors()
+    {
+        var query = new ListServicesQuery(Guid.NewGuid(), true, 1, 20);
+
+        var result = await _validator.ValidateAsync(query);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithInvalidPageSize_ReturnsError()
+    {
+        var query = new ListServicesQuery(Guid.NewGuid(), true, 1, 0);
+
+        var result = await _validator.ValidateAsync(query);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(ListServicesQuery.PageSize));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/RemoveServiceOfficeAssignmentCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/RemoveServiceOfficeAssignmentCommandHandlerTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Commands.RemoveServiceOfficeAssignment;
+using NextTurn.Domain.Service.Repositories;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class RemoveServiceOfficeAssignmentCommandHandlerTests
+{
+    private readonly Mock<IServiceRepository> _serviceRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly RemoveServiceOfficeAssignmentCommandHandler _handler;
+
+    public RemoveServiceOfficeAssignmentCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new RemoveServiceOfficeAssignmentCommandHandler(_serviceRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_RemovesAssignmentAndPersists()
+    {
+        var organisationId = Guid.NewGuid();
+        var serviceId = Guid.NewGuid();
+        var officeId = Guid.NewGuid();
+
+        var command = new RemoveServiceOfficeAssignmentCommand(organisationId, serviceId, officeId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Should().Be(MediatR.Unit.Value);
+
+        _serviceRepositoryMock.Verify(r => r.RemoveOfficeAssignmentAsync(
+            organisationId,
+            serviceId,
+            officeId,
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/RemoveServiceOfficeAssignmentCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/RemoveServiceOfficeAssignmentCommandValidatorTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using NextTurn.Application.Service.Commands.RemoveServiceOfficeAssignment;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class RemoveServiceOfficeAssignmentCommandValidatorTests
+{
+    private readonly RemoveServiceOfficeAssignmentCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new RemoveServiceOfficeAssignmentCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithEmptyOfficeId_ReturnsError()
+    {
+        var command = new RemoveServiceOfficeAssignmentCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.Empty);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(RemoveServiceOfficeAssignmentCommand.OfficeId));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/UpdateServiceCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/UpdateServiceCommandHandlerTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Service.Commands.UpdateService;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Service.Repositories;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class UpdateServiceCommandHandlerTests
+{
+    private readonly Mock<IServiceRepository> _serviceRepositoryMock = new();
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    private readonly UpdateServiceCommandHandler _handler;
+
+    private static readonly Guid OrganisationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid ServiceId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public UpdateServiceCommandHandlerTests()
+    {
+        _contextMock
+            .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new UpdateServiceCommandHandler(_serviceRepositoryMock.Object, _contextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingService_UpdatesAndPersists()
+    {
+        var service = ServiceEntity.Create(OrganisationId, "Old Name", "SVC-01", "Old Description", 10, true);
+
+        _serviceRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(service);
+
+        var command = new UpdateServiceCommand(OrganisationId, ServiceId, "New Name", "Updated Description", 30);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Name.Should().Be("New Name");
+        result.Description.Should().Be("Updated Description");
+        result.EstimatedDurationMinutes.Should().Be(30);
+
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenServiceNotFound_ThrowsDomainException()
+    {
+        _serviceRepositoryMock
+            .Setup(r => r.GetByIdAsync(OrganisationId, ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ServiceEntity?)null);
+
+        var command = new UpdateServiceCommand(OrganisationId, ServiceId, "New Name", "Updated Description", 30);
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Service not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Service/UpdateServiceCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Service/UpdateServiceCommandValidatorTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using NextTurn.Application.Service.Commands.UpdateService;
+
+namespace NextTurn.UnitTests.Application.Service;
+
+public sealed class UpdateServiceCommandValidatorTests
+{
+    private readonly UpdateServiceCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new UpdateServiceCommand(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Passport Renewal",
+            "Renewal processing",
+            20);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithInvalidDuration_ReturnsError()
+    {
+        var command = new UpdateServiceCommand(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Passport Renewal",
+            "Renewal processing",
+            0);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(UpdateServiceCommand.EstimatedDurationMinutes));
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements NT-15 end-to-end for service management in a clean-architecture vertical slice.

It adds:
- Service create, update, deactivate, and list capabilities for Org Admin and System Admin.
- Service-to-office assignment and unassignment.
- Tenant-aware persistence and filtering for services and service-office mappings.
- Consumer-safe listing behavior through active-only filtering support.
- Admin frontend page for managing services and office assignments.
- Unit and integration test coverage for core flows.
- EF Core migration for new tables.

## User Story
As an Org Admin, I want to configure services and map them to offices so staff and consumers can interact only with valid, active service offerings per tenant.

## Scope Delivered
- Domain: Service aggregate and ServiceOfficeAssignment join entity.
- Application: CQRS commands, queries, handlers, validators.
- Infrastructure: Repository implementation, EF configurations, DI wiring, DbContext updates.
- API: Services controller endpoints and request models.
- Web: Service management UI and API client wiring for admin workflows.
- Tests: Unit tests for handlers/validators and integration tests for full API flow.
- Database: Migration for Services and ServiceOfficeAssignments.

## Architecture Notes
- Preserves existing modular monolith boundaries across Domain/Application/Infrastructure/API/Web.
- Uses MediatR + FluentValidation pattern consistently with existing slices.
- Enforces tenant isolation through global query filters and tenant-bound repository queries.
- Keeps controllers thin and business logic in application handlers/domain methods.
- Uses soft-deactivate semantics for services.

## Backend Changes

### Domain
- Added Service entity with invariants:
  - Name required and length bound.
  - Code required and normalized.
  - Description required and length bound.
  - Estimated duration bounds.
  - Soft deactivation with DeactivatedAt.
- Added ServiceOfficeAssignment entity for many-to-many mapping between services and offices.

### Application
- Added commands:
  - CreateService
  - UpdateService
  - DeactivateService
  - AssignServiceOffices
  - RemoveServiceOfficeAssignment
- Added query:
  - ListServices with pagination and activeOnly filter.
- Added Service DTO and list result model.
- Added validators for all commands/query inputs.
- Added assignment-aware projection so service list includes assigned office IDs.

### Infrastructure
- Added IServiceRepository implementation with:
  - Code uniqueness check by tenant.
  - Tenant-scoped get/list.
  - Assignment add/remove operations.
  - Bulk lookup of assigned office IDs by service IDs.
- Added EF configurations:
  - Services table mapping and constraints.
  - ServiceOfficeAssignments composite key and FKs.
- Wired repository in DI.
- Added DbSet properties and tenant query filters to DbContext.

### API
- Added Services controller endpoints:
  - GET /api/services
  - POST /api/services
  - PUT /api/services/{serviceId}
  - PATCH /api/services/{serviceId}/deactivate
  - POST /api/services/{serviceId}/offices
  - DELETE /api/services/{serviceId}/offices/{officeId}
- Added request models:
  - CreateServiceRequest
  - UpdateServiceRequest
  - AssignServiceOfficesRequest
- Authorization behavior:
  - Admin-only mutations.
  - Authenticated listing with tenant claim enforcement.

## Frontend Changes
- Added admin API client for service endpoints and assignment operations.
- Added Service Management page for:
  - Creating services.
  - Editing service metadata.
  - Deactivating services.
  - Selecting a service and assigning/removing offices.
  - Filtering by active-only view.
- Added route and admin dashboard navigation entry for service management.
- Added CSS module styling for responsive service admin UI.

## Database Migration
- Added migration:
  - AddServices
- Adds:
  - Services table
  - ServiceOfficeAssignments table
  - Keys, indexes, and relationships
- Updated model snapshot accordingly.

## Testing

### Unit Tests Added
- CreateServiceCommandHandlerTests
- UpdateServiceCommandHandlerTests
- DeactivateServiceCommandHandlerTests
- CreateServiceCommandValidatorTests
- UpdateServiceCommandValidatorTests

Result:
- Passed: 10
- Failed: 0

### Integration Tests Added
- ServiceConfigurationIntegrationTests covering:
  - Create service
  - Assign office
  - Update service
  - Remove assignment
  - Deactivate service
  - Active-only listing behavior
  - Forbidden access for non-admin create

Environment note:
- Integration execution is blocked in this environment because Docker/Testcontainers is not running.
- Test fixture initialization fails before test logic due to Docker endpoint configuration.

### Build Validation
- dotnet build solution: passed.
- web build (tsc + vite): passed.

## Acceptance Criteria Mapping
- Admin can create/update/deactivate services: implemented.
- Admin can assign/unassign services to offices: implemented.
- Service listing supports active-only consumer-compatible filtering: implemented.
- Tenant isolation enforced in persistence/query paths: implemented.
- API + UI + tests + migration delivered: implemented.

## Commits
- a6e3411 feat(service): add service configuration APIs and assignments
- c704224 test(service): add service configuration unit and integration tests
- 298a09f feat(web): add service management page for admins

## Risks and Notes
- Integration tests require Docker runtime for Testcontainers.
- Current service update flow intentionally does not allow code mutation after creation.
- Assignment save operation performs add/remove based on diff in UI state.

## Manual QA Checklist
- Login as OrgAdmin.
- Open admin dashboard and navigate to Manage Services.
- Create a new active service.
- Create at least one office (if none exists).
- Assign the service to one or more offices and save.
- Verify list shows assignments and service metadata.
- Update service fields and confirm persistence.
- Deactivate service and confirm it disappears from active-only view.
- Verify non-admin user cannot create/update/deactivate services.