### PR TITLE
Feature/NT-22 staff account management

### DIFF
--- a/src/NextTurn.API/Controllers/StaffController.cs
+++ b/src/NextTurn.API/Controllers/StaffController.cs
@@ -1,0 +1,105 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NextTurn.Domain.Common;
+using NextTurn.API.Models.Staff;
+using NextTurn.Application.Staff.Commands.CreateStaff;
+using NextTurn.Application.Staff.Commands.DeactivateStaff;
+using NextTurn.Application.Staff.Commands.UpdateStaff;
+using NextTurn.Application.Staff.Queries.ListStaff;
+
+namespace NextTurn.API.Controllers;
+
+[ApiController]
+[Route("api/staff")]
+[Authorize(Roles = "OrgAdmin,SystemAdmin")]
+public sealed class StaffController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    public StaffController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateStaffRequest request,
+        CancellationToken cancellationToken)
+    {
+        var command = new CreateStaffCommand(
+            request.Name,
+            request.Email,
+            request.Phone,
+            request.OfficeIds,
+            request.CounterName,
+            ParseShift(request.ShiftStart),
+            ParseShift(request.ShiftEnd));
+
+        var result = await _sender.Send(command, cancellationToken);
+        return CreatedAtAction(nameof(List), null, result);
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> List(
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _sender.Send(new ListStaffQuery(pageNumber, pageSize), cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateStaffRequest request,
+        CancellationToken cancellationToken)
+    {
+        var command = new UpdateStaffCommand(
+            id,
+            request.Name,
+            request.Phone,
+            request.OfficeIds,
+            request.CounterName,
+            ParseShift(request.ShiftStart),
+            ParseShift(request.ShiftEnd));
+
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPatch("{id:guid}/deactivate")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Deactivate(Guid id, CancellationToken cancellationToken)
+    {
+        await _sender.Send(new DeactivateStaffCommand(id), cancellationToken);
+        return NoContent();
+    }
+
+    private static TimeSpan? ParseShift(string? shift)
+    {
+        if (string.IsNullOrWhiteSpace(shift))
+            return null;
+
+        if (!TimeSpan.TryParse(shift, out var value))
+            throw new DomainException("Shift time must be a valid time value.");
+
+        return value;
+    }
+}

--- a/src/NextTurn.API/Models/Staff/CreateStaffRequest.cs
+++ b/src/NextTurn.API/Models/Staff/CreateStaffRequest.cs
@@ -1,0 +1,12 @@
+namespace NextTurn.API.Models.Staff;
+
+public sealed class CreateStaffRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Phone { get; set; }
+    public IReadOnlyList<Guid> OfficeIds { get; set; } = [];
+    public string? CounterName { get; set; }
+    public string? ShiftStart { get; set; }
+    public string? ShiftEnd { get; set; }
+}

--- a/src/NextTurn.API/Models/Staff/UpdateStaffRequest.cs
+++ b/src/NextTurn.API/Models/Staff/UpdateStaffRequest.cs
@@ -1,0 +1,11 @@
+namespace NextTurn.API.Models.Staff;
+
+public sealed class UpdateStaffRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Phone { get; set; }
+    public IReadOnlyList<Guid> OfficeIds { get; set; } = [];
+    public string? CounterName { get; set; }
+    public string? ShiftStart { get; set; }
+    public string? ShiftEnd { get; set; }
+}

--- a/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -3,6 +3,7 @@ using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
 using AppointmentProfile = NextTurn.Domain.Appointment.Entities.AppointmentProfile;
 using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.AppointmentScheduleRule;
 using NextTurn.Domain.Auth.Entities;
+using StaffOfficeAssignment = NextTurn.Domain.Auth.Entities.StaffOfficeAssignment;
 using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
 using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
@@ -27,6 +28,7 @@ public interface IApplicationDbContext
     DbSet<AppointmentEntity> Appointments { get; }
     DbSet<AppointmentProfile> AppointmentProfiles { get; }
     DbSet<AppointmentScheduleRule> AppointmentScheduleRules { get; }
+    DbSet<StaffOfficeAssignment> StaffOfficeAssignments { get; }
     DbSet<ServiceEntity> Services { get; }
     DbSet<ServiceOfficeAssignment> ServiceOfficeAssignments { get; }
 

--- a/src/NextTurn.Application/Staff/Commands/CreateStaff/CreateStaffCommand.cs
+++ b/src/NextTurn.Application/Staff/Commands/CreateStaff/CreateStaffCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using NextTurn.Application.Staff.Common;
+
+namespace NextTurn.Application.Staff.Commands.CreateStaff;
+
+public sealed record CreateStaffCommand(
+    string Name,
+    string Email,
+    string? Phone,
+    IReadOnlyList<Guid> OfficeIds,
+    string? CounterName,
+    TimeSpan? ShiftStart,
+    TimeSpan? ShiftEnd) : IRequest<StaffDto>;

--- a/src/NextTurn.Application/Staff/Commands/CreateStaff/CreateStaffCommandHandler.cs
+++ b/src/NextTurn.Application/Staff/Commands/CreateStaff/CreateStaffCommandHandler.cs
@@ -1,0 +1,88 @@
+using System.Security.Cryptography;
+using System.Text;
+using MediatR;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Staff.Common;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.Repositories;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Staff.Commands.CreateStaff;
+
+public sealed class CreateStaffCommandHandler : IRequestHandler<CreateStaffCommand, StaffDto>
+{
+    private static readonly TimeSpan InviteTtl = TimeSpan.FromDays(2);
+
+    private readonly IUserRepository _userRepository;
+    private readonly ITenantContext _tenantContext;
+
+    public CreateStaffCommandHandler(IUserRepository userRepository, ITenantContext tenantContext)
+    {
+        _userRepository = userRepository;
+        _tenantContext = tenantContext;
+    }
+
+    public async Task<StaffDto> Handle(CreateStaffCommand request, CancellationToken cancellationToken)
+    {
+        var email = new EmailAddress(request.Email);
+        var existing = await _userRepository.GetByEmailAsync(email, cancellationToken);
+        if (existing is not null)
+            throw new DomainException("Email address is already in use.");
+
+        var officesExist = await _userRepository.OfficesExistAsync(request.OfficeIds, cancellationToken);
+        if (!officesExist)
+            throw new DomainException("One or more offices were not found for this tenant.");
+
+        var bootstrapPasswordHash = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+        var staffUser = User.Create(
+            _tenantContext.TenantId,
+            request.Name,
+            email,
+            request.Phone,
+            bootstrapPasswordHash,
+            UserRole.Staff);
+
+        staffUser.UpdateStaffProfile(
+            request.Name,
+            request.Phone,
+            request.CounterName,
+            request.ShiftStart,
+            request.ShiftEnd);
+
+        var rawToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+
+        staffUser.StartStaffInvite(ComputeSha256(rawToken), DateTimeOffset.UtcNow.Add(InviteTtl));
+
+        await _userRepository.AddAsync(staffUser, cancellationToken);
+        await _userRepository.ReplaceStaffOfficeAssignmentsAsync(staffUser.Id, request.OfficeIds, cancellationToken);
+
+        return new StaffDto(
+            staffUser.Id,
+            staffUser.Name,
+            staffUser.Email.Value,
+            staffUser.Phone,
+            staffUser.IsActive,
+            staffUser.CounterName,
+            ToShiftString(staffUser.ShiftStart),
+            ToShiftString(staffUser.ShiftEnd),
+            request.OfficeIds.Distinct().ToList(),
+            staffUser.CreatedAt);
+    }
+
+    private static string? ToShiftString(TimeSpan? value)
+    {
+        return value.HasValue ? value.Value.ToString(@"hh\:mm") : null;
+    }
+
+    private static string ComputeSha256(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/src/NextTurn.Application/Staff/Commands/CreateStaff/CreateStaffCommandValidator.cs
+++ b/src/NextTurn.Application/Staff/Commands/CreateStaff/CreateStaffCommandValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Staff.Commands.CreateStaff;
+
+public sealed class CreateStaffCommandValidator : AbstractValidator<CreateStaffCommand>
+{
+    public CreateStaffCommandValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Name is required.")
+            .MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Email is not valid.")
+            .MaximumLength(254).WithMessage("Email must not exceed 254 characters.");
+
+        RuleFor(x => x.Phone)
+            .MaximumLength(20).WithMessage("Phone must not exceed 20 characters.");
+
+        RuleFor(x => x.OfficeIds)
+            .NotNull().WithMessage("Office assignments are required.")
+            .Must(x => x.Count > 0).WithMessage("At least one office must be assigned.");
+
+        RuleForEach(x => x.OfficeIds)
+            .NotEmpty().WithMessage("Office ID cannot be empty.");
+
+        RuleFor(x => x.CounterName)
+            .MaximumLength(80).WithMessage("Counter name must not exceed 80 characters.");
+
+        RuleFor(x => x)
+            .Must(x => x.ShiftStart.HasValue == x.ShiftEnd.HasValue)
+            .WithMessage("Shift start and shift end must both be provided.")
+            .Must(x => !x.ShiftStart.HasValue || !x.ShiftEnd.HasValue || x.ShiftStart.Value < x.ShiftEnd.Value)
+            .WithMessage("Shift end must be after shift start.");
+    }
+}

--- a/src/NextTurn.Application/Staff/Commands/DeactivateStaff/DeactivateStaffCommand.cs
+++ b/src/NextTurn.Application/Staff/Commands/DeactivateStaff/DeactivateStaffCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Staff.Commands.DeactivateStaff;
+
+public sealed record DeactivateStaffCommand(Guid StaffUserId) : IRequest<Unit>;

--- a/src/NextTurn.Application/Staff/Commands/DeactivateStaff/DeactivateStaffCommandHandler.cs
+++ b/src/NextTurn.Application/Staff/Commands/DeactivateStaff/DeactivateStaffCommandHandler.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Repositories;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Staff.Commands.DeactivateStaff;
+
+public sealed class DeactivateStaffCommandHandler : IRequestHandler<DeactivateStaffCommand, Unit>
+{
+    private readonly IUserRepository _userRepository;
+
+    public DeactivateStaffCommandHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<Unit> Handle(DeactivateStaffCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.GetByIdAsync(request.StaffUserId, cancellationToken);
+        if (user is null)
+            throw new DomainException("Staff user not found.");
+
+        if (user.Role != UserRole.Staff)
+            throw new DomainException("Only staff accounts can be deactivated from this endpoint.");
+
+        user.DeactivateStaffAccess();
+        await _userRepository.UpdateAsync(user, cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Staff/Commands/DeactivateStaff/DeactivateStaffCommandValidator.cs
+++ b/src/NextTurn.Application/Staff/Commands/DeactivateStaff/DeactivateStaffCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Staff.Commands.DeactivateStaff;
+
+public sealed class DeactivateStaffCommandValidator : AbstractValidator<DeactivateStaffCommand>
+{
+    public DeactivateStaffCommandValidator()
+    {
+        RuleFor(x => x.StaffUserId)
+            .NotEmpty().WithMessage("Staff user ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Staff/Commands/UpdateStaff/UpdateStaffCommand.cs
+++ b/src/NextTurn.Application/Staff/Commands/UpdateStaff/UpdateStaffCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using NextTurn.Application.Staff.Common;
+
+namespace NextTurn.Application.Staff.Commands.UpdateStaff;
+
+public sealed record UpdateStaffCommand(
+    Guid StaffUserId,
+    string Name,
+    string? Phone,
+    IReadOnlyList<Guid> OfficeIds,
+    string? CounterName,
+    TimeSpan? ShiftStart,
+    TimeSpan? ShiftEnd) : IRequest<StaffDto>;

--- a/src/NextTurn.Application/Staff/Commands/UpdateStaff/UpdateStaffCommandHandler.cs
+++ b/src/NextTurn.Application/Staff/Commands/UpdateStaff/UpdateStaffCommandHandler.cs
@@ -1,0 +1,58 @@
+using MediatR;
+using NextTurn.Application.Staff.Common;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Repositories;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Staff.Commands.UpdateStaff;
+
+public sealed class UpdateStaffCommandHandler : IRequestHandler<UpdateStaffCommand, StaffDto>
+{
+    private readonly IUserRepository _userRepository;
+
+    public UpdateStaffCommandHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<StaffDto> Handle(UpdateStaffCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.GetByIdAsync(request.StaffUserId, cancellationToken);
+        if (user is null)
+            throw new DomainException("Staff user not found.");
+
+        if (user.Role != UserRole.Staff)
+            throw new DomainException("Only staff accounts can be updated from this endpoint.");
+
+        var officesExist = await _userRepository.OfficesExistAsync(request.OfficeIds, cancellationToken);
+        if (!officesExist)
+            throw new DomainException("One or more offices were not found for this tenant.");
+
+        user.UpdateStaffProfile(
+            request.Name,
+            request.Phone,
+            request.CounterName,
+            request.ShiftStart,
+            request.ShiftEnd);
+
+        await _userRepository.UpdateAsync(user, cancellationToken);
+        await _userRepository.ReplaceStaffOfficeAssignmentsAsync(user.Id, request.OfficeIds, cancellationToken);
+
+        return new StaffDto(
+            user.Id,
+            user.Name,
+            user.Email.Value,
+            user.Phone,
+            user.IsActive,
+            user.CounterName,
+            ToShiftString(user.ShiftStart),
+            ToShiftString(user.ShiftEnd),
+            request.OfficeIds.Distinct().ToList(),
+            user.CreatedAt);
+    }
+
+    private static string? ToShiftString(TimeSpan? value)
+    {
+        return value.HasValue ? value.Value.ToString(@"hh\:mm") : null;
+    }
+}

--- a/src/NextTurn.Application/Staff/Commands/UpdateStaff/UpdateStaffCommandValidator.cs
+++ b/src/NextTurn.Application/Staff/Commands/UpdateStaff/UpdateStaffCommandValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Staff.Commands.UpdateStaff;
+
+public sealed class UpdateStaffCommandValidator : AbstractValidator<UpdateStaffCommand>
+{
+    public UpdateStaffCommandValidator()
+    {
+        RuleFor(x => x.StaffUserId)
+            .NotEmpty().WithMessage("Staff user ID is required.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Name is required.")
+            .MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
+
+        RuleFor(x => x.Phone)
+            .MaximumLength(20).WithMessage("Phone must not exceed 20 characters.");
+
+        RuleFor(x => x.OfficeIds)
+            .NotNull().WithMessage("Office assignments are required.");
+
+        RuleForEach(x => x.OfficeIds)
+            .NotEmpty().WithMessage("Office ID cannot be empty.");
+
+        RuleFor(x => x.CounterName)
+            .MaximumLength(80).WithMessage("Counter name must not exceed 80 characters.");
+
+        RuleFor(x => x)
+            .Must(x => x.ShiftStart.HasValue == x.ShiftEnd.HasValue)
+            .WithMessage("Shift start and shift end must both be provided.")
+            .Must(x => !x.ShiftStart.HasValue || !x.ShiftEnd.HasValue || x.ShiftStart.Value < x.ShiftEnd.Value)
+            .WithMessage("Shift end must be after shift start.");
+    }
+}

--- a/src/NextTurn.Application/Staff/Common/StaffDto.cs
+++ b/src/NextTurn.Application/Staff/Common/StaffDto.cs
@@ -1,0 +1,13 @@
+namespace NextTurn.Application.Staff.Common;
+
+public sealed record StaffDto(
+    Guid StaffUserId,
+    string Name,
+    string Email,
+    string? Phone,
+    bool IsActive,
+    string? CounterName,
+    string? ShiftStart,
+    string? ShiftEnd,
+    IReadOnlyList<Guid> OfficeIds,
+    DateTimeOffset CreatedAt);

--- a/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffQuery.cs
+++ b/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Staff.Queries.ListStaff;
+
+public sealed record ListStaffQuery(int PageNumber, int PageSize) : IRequest<ListStaffResult>;

--- a/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffQueryHandler.cs
+++ b/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffQueryHandler.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using NextTurn.Application.Staff.Common;
+using NextTurn.Domain.Auth.Repositories;
+
+namespace NextTurn.Application.Staff.Queries.ListStaff;
+
+public sealed class ListStaffQueryHandler : IRequestHandler<ListStaffQuery, ListStaffResult>
+{
+    private readonly IUserRepository _userRepository;
+
+    public ListStaffQueryHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<ListStaffResult> Handle(ListStaffQuery request, CancellationToken cancellationToken)
+    {
+        var (items, totalCount) = await _userRepository.ListStaffPagedAsync(
+            request.PageNumber,
+            request.PageSize,
+            cancellationToken);
+
+        var assignmentMap = await _userRepository.GetAssignedOfficeIdsByStaffUserIdsAsync(
+            items.Select(x => x.Id).ToList(),
+            cancellationToken);
+
+        var data = items.Select(user => new StaffDto(
+            user.Id,
+            user.Name,
+            user.Email.Value,
+            user.Phone,
+            user.IsActive,
+            user.CounterName,
+            ToShiftString(user.ShiftStart),
+            ToShiftString(user.ShiftEnd),
+            assignmentMap.TryGetValue(user.Id, out var officeIds) ? officeIds : [],
+            user.CreatedAt)).ToList();
+
+        return new ListStaffResult(data, request.PageNumber, request.PageSize, totalCount);
+    }
+
+    private static string? ToShiftString(TimeSpan? value)
+    {
+        return value.HasValue ? value.Value.ToString(@"hh\:mm") : null;
+    }
+}

--- a/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffQueryValidator.cs
+++ b/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffQueryValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Staff.Queries.ListStaff;
+
+public sealed class ListStaffQueryValidator : AbstractValidator<ListStaffQuery>
+{
+    public ListStaffQueryValidator()
+    {
+        RuleFor(x => x.PageNumber)
+            .GreaterThan(0).WithMessage("Page number must be greater than 0.");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100).WithMessage("Page size must be between 1 and 100.");
+    }
+}

--- a/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffResult.cs
+++ b/src/NextTurn.Application/Staff/Queries/ListStaff/ListStaffResult.cs
@@ -1,0 +1,9 @@
+using NextTurn.Application.Staff.Common;
+
+namespace NextTurn.Application.Staff.Queries.ListStaff;
+
+public sealed record ListStaffResult(
+    IReadOnlyList<StaffDto> Items,
+    int PageNumber,
+    int PageSize,
+    int TotalCount);

--- a/src/NextTurn.Domain/Auth/Entities/StaffOfficeAssignment.cs
+++ b/src/NextTurn.Domain/Auth/Entities/StaffOfficeAssignment.cs
@@ -1,0 +1,32 @@
+namespace NextTurn.Domain.Auth.Entities;
+
+public sealed class StaffOfficeAssignment
+{
+    public Guid OrganisationId { get; private set; }
+    public Guid StaffUserId { get; private set; }
+    public Guid OfficeId { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    private StaffOfficeAssignment() { }
+
+    private StaffOfficeAssignment(
+        Guid organisationId,
+        Guid staffUserId,
+        Guid officeId,
+        DateTimeOffset createdAt)
+    {
+        OrganisationId = organisationId;
+        StaffUserId = staffUserId;
+        OfficeId = officeId;
+        CreatedAt = createdAt;
+    }
+
+    public static StaffOfficeAssignment Create(Guid organisationId, Guid staffUserId, Guid officeId)
+    {
+        return new StaffOfficeAssignment(
+            organisationId,
+            staffUserId,
+            officeId,
+            DateTimeOffset.UtcNow);
+    }
+}

--- a/src/NextTurn.Domain/Auth/Entities/User.cs
+++ b/src/NextTurn.Domain/Auth/Entities/User.cs
@@ -18,6 +18,9 @@ public class User {
   public DateTimeOffset CreatedAt { get; }
   public string PasswordHash { get; private set; }
   public bool IsActive { get; private set; }
+  public string? CounterName { get; private set; }
+  public TimeSpan? ShiftStart { get; private set; }
+  public TimeSpan? ShiftEnd { get; private set; }
 
   // ── Role & security ──────────────────────────────────────────────────────
   public UserRole Role { get; private set; }
@@ -88,6 +91,44 @@ public class User {
   }
 
   public void Deactivate() {
+    IsActive = false;
+  }
+
+  public void UpdateStaffProfile(
+    string name,
+    string? phone,
+    string? counterName,
+    TimeSpan? shiftStart,
+    TimeSpan? shiftEnd)
+  {
+    if (Role != UserRole.Staff)
+      throw new DomainException("Only staff accounts can update staff profile data.");
+
+    if (string.IsNullOrWhiteSpace(name))
+      throw new DomainException("Name is required.");
+
+    if (counterName is not null && counterName.Trim().Length > 80)
+      throw new DomainException("Counter name must not exceed 80 characters.");
+
+    if (shiftStart.HasValue != shiftEnd.HasValue)
+      throw new DomainException("Shift start and shift end must both be provided.");
+
+    if (shiftStart.HasValue && shiftEnd.HasValue && shiftStart.Value >= shiftEnd.Value)
+      throw new DomainException("Shift end must be after shift start.");
+
+    Name = name.Trim();
+    Phone = string.IsNullOrWhiteSpace(phone) ? null : phone.Trim();
+    CounterName = string.IsNullOrWhiteSpace(counterName) ? null : counterName.Trim();
+    ShiftStart = shiftStart;
+    ShiftEnd = shiftEnd;
+  }
+
+  public void DeactivateStaffAccess()
+  {
+    if (Role != UserRole.Staff)
+      throw new DomainException("Only staff accounts can be deactivated from this endpoint.");
+
+    Role = UserRole.User;
     IsActive = false;
   }
 

--- a/src/NextTurn.Domain/Auth/Repositories/IUserRepository.cs
+++ b/src/NextTurn.Domain/Auth/Repositories/IUserRepository.cs
@@ -11,6 +11,10 @@ public interface IUserRepository {
   Task<bool> ExistsAsync(EmailAddress email, CancellationToken cancellationToken);          // check if email is taken before registration (tenant-scoped)
   Task<bool> ExistsGlobalAsync(EmailAddress email, CancellationToken cancellationToken);    // check if email is taken across ALL tenants (for consumer registration)
   Task<IReadOnlyList<User>> ListStaffAsync(CancellationToken cancellationToken);            // lists staff users in current tenant
+  Task<(IReadOnlyList<User> Items, int TotalCount)> ListStaffPagedAsync(int pageNumber, int pageSize, CancellationToken cancellationToken);
+  Task<bool> OfficesExistAsync(IReadOnlyCollection<Guid> officeIds, CancellationToken cancellationToken);
+  Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetAssignedOfficeIdsByStaffUserIdsAsync(IReadOnlyCollection<Guid> staffUserIds, CancellationToken cancellationToken);
+  Task ReplaceStaffOfficeAssignmentsAsync(Guid staffUserId, IReadOnlyCollection<Guid> officeIds, CancellationToken cancellationToken);
   Task AddAsync(User user, CancellationToken cancellationToken);                            // saving the registered user
   Task UpdateAsync(User user, CancellationToken cancellationToken);                         // persists lockout state and failed attempt count after login attempts
 }

--- a/src/NextTurn.Infrastructure/Auth/UserRepository.cs
+++ b/src/NextTurn.Infrastructure/Auth/UserRepository.cs
@@ -85,6 +85,94 @@ public sealed class UserRepository : IUserRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<(IReadOnlyList<User> Items, int TotalCount)> ListStaffPagedAsync(
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.Users
+            .Where(u => u.Role == UserRole.Staff)
+            .OrderBy(u => u.Name)
+            .ThenBy(u => u.CreatedAt);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public async Task<bool> OfficesExistAsync(
+        IReadOnlyCollection<Guid> officeIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (officeIds.Count == 0)
+            return true;
+
+        var distinctIds = officeIds.Distinct().ToList();
+        var foundCount = await _context.Offices
+            .CountAsync(o => distinctIds.Contains(o.Id), cancellationToken);
+
+        return foundCount == distinctIds.Count;
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<Guid>>> GetAssignedOfficeIdsByStaffUserIdsAsync(
+        IReadOnlyCollection<Guid> staffUserIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (staffUserIds.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<Guid>>();
+
+        var assignments = await _context.StaffOfficeAssignments
+            .AsNoTracking()
+            .Where(x => staffUserIds.Contains(x.StaffUserId))
+            .ToListAsync(cancellationToken);
+
+        return assignments
+            .GroupBy(x => x.StaffUserId)
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<Guid>)x.Select(a => a.OfficeId).ToList());
+    }
+
+    public async Task ReplaceStaffOfficeAssignmentsAsync(
+        Guid staffUserId,
+        IReadOnlyCollection<Guid> officeIds,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await _context.Users
+            .FirstOrDefaultAsync(u => u.Id == staffUserId, cancellationToken);
+
+        if (user is null)
+            return;
+
+        var organisationId = user.TenantId;
+
+        var existing = await _context.StaffOfficeAssignments
+            .Where(x => x.OrganisationId == organisationId && x.StaffUserId == staffUserId)
+            .ToListAsync(cancellationToken);
+
+        var nextOfficeIds = officeIds.Distinct().ToHashSet();
+
+        var toRemove = existing
+            .Where(x => !nextOfficeIds.Contains(x.OfficeId))
+            .ToList();
+
+        if (toRemove.Count > 0)
+            _context.StaffOfficeAssignments.RemoveRange(toRemove);
+
+        var existingOfficeIds = existing.Select(x => x.OfficeId).ToHashSet();
+        var toAdd = nextOfficeIds
+            .Where(id => !existingOfficeIds.Contains(id))
+            .Select(id => StaffOfficeAssignment.Create(organisationId, staffUserId, id));
+
+        await _context.StaffOfficeAssignments.AddRangeAsync(toAdd, cancellationToken);
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
     /// <inheritdoc/>
     public async Task<User?> GetByEmailGlobalAsync(
         EmailAddress email,

--- a/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -4,6 +4,7 @@ using AppointmentEntity  = NextTurn.Domain.Appointment.Entities.Appointment;
 using AppointmentProfile = NextTurn.Domain.Appointment.Entities.AppointmentProfile;
 using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.AppointmentScheduleRule;
 using NextTurn.Domain.Auth.Entities;
+using StaffOfficeAssignment = NextTurn.Domain.Auth.Entities.StaffOfficeAssignment;
 using NextTurn.Infrastructure.Persistence.Configurations.Auth;
 using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
 using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
@@ -53,6 +54,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<AppointmentEntity> Appointments => Set<AppointmentEntity>();
     public DbSet<AppointmentProfile> AppointmentProfiles => Set<AppointmentProfile>();
     public DbSet<AppointmentScheduleRule> AppointmentScheduleRules => Set<AppointmentScheduleRule>();
+    public DbSet<StaffOfficeAssignment> StaffOfficeAssignments => Set<StaffOfficeAssignment>();
     public DbSet<ServiceEntity> Services => Set<ServiceEntity>();
     public DbSet<ServiceOfficeAssignment> ServiceOfficeAssignments => Set<ServiceOfficeAssignment>();
 
@@ -110,6 +112,9 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
         modelBuilder.Entity<AppointmentScheduleRule>()
             .HasQueryFilter(r => r.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<StaffOfficeAssignment>()
+            .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
 
         modelBuilder.Entity<ServiceEntity>()
             .HasQueryFilter(s => s.OrganisationId == _tenantContext.TenantId);

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/StaffOfficeAssignmentConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/StaffOfficeAssignmentConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using NextTurn.Domain.Auth.Entities;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Auth;
+
+public sealed class StaffOfficeAssignmentConfiguration : IEntityTypeConfiguration<StaffOfficeAssignment>
+{
+    public void Configure(EntityTypeBuilder<StaffOfficeAssignment> builder)
+    {
+        builder.ToTable("StaffOfficeAssignments");
+
+        builder.HasKey(x => new { x.OrganisationId, x.StaffUserId, x.OfficeId });
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne<User>()
+            .WithMany()
+            .HasForeignKey(x => new { x.OrganisationId, x.StaffUserId })
+            .HasPrincipalKey(x => new { x.TenantId, x.Id })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne<NextTurn.Domain.Office.Entities.Office>()
+            .WithMany()
+            .HasForeignKey(x => new { x.OrganisationId, x.OfficeId })
+            .HasPrincipalKey(x => new { x.OrganisationId, x.Id })
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.OrganisationId, x.StaffUserId })
+            .HasDatabaseName("IX_StaffOfficeAssignments_Org_Staff");
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
@@ -61,6 +61,13 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(u => u.Phone)
             .HasMaxLength(20);
 
+        builder.Property(u => u.CounterName)
+            .HasMaxLength(80);
+
+        builder.Property(u => u.ShiftStart);
+
+        builder.Property(u => u.ShiftEnd);
+
         builder.Property(u => u.PasswordHash)
             .IsRequired()
             .HasMaxLength(255);

--- a/src/NextTurn.Infrastructure/Persistence/Migrations/20260326044222_AddStaffManagement.Designer.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Migrations/20260326044222_AddStaffManagement.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NextTurn.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace NextTurn.Infrastructure.Migrations
+namespace NextTurn.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260326044222_AddStaffManagement")]
+    partial class AddStaffManagement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NextTurn.Infrastructure/Persistence/Migrations/20260326044222_AddStaffManagement.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Migrations/20260326044222_AddStaffManagement.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NextTurn.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStaffManagement : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CounterName",
+                table: "Users",
+                type: "nvarchar(80)",
+                maxLength: 80,
+                nullable: true);
+
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "ShiftEnd",
+                table: "Users",
+                type: "time",
+                nullable: true);
+
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "ShiftStart",
+                table: "Users",
+                type: "time",
+                nullable: true);
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_Users_TenantId_Id",
+                table: "Users",
+                columns: new[] { "TenantId", "Id" });
+
+            migrationBuilder.CreateTable(
+                name: "StaffOfficeAssignments",
+                columns: table => new
+                {
+                    OrganisationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    StaffUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OfficeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StaffOfficeAssignments", x => new { x.OrganisationId, x.StaffUserId, x.OfficeId });
+                    table.ForeignKey(
+                        name: "FK_StaffOfficeAssignments_Offices_OrganisationId_OfficeId",
+                        columns: x => new { x.OrganisationId, x.OfficeId },
+                        principalTable: "Offices",
+                        principalColumns: new[] { "OrganisationId", "Id" },
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_StaffOfficeAssignments_Users_OrganisationId_StaffUserId",
+                        columns: x => new { x.OrganisationId, x.StaffUserId },
+                        principalTable: "Users",
+                        principalColumns: new[] { "TenantId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StaffOfficeAssignments_Org_Staff",
+                table: "StaffOfficeAssignments",
+                columns: new[] { "OrganisationId", "StaffUserId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StaffOfficeAssignments_OrganisationId_OfficeId",
+                table: "StaffOfficeAssignments",
+                columns: new[] { "OrganisationId", "OfficeId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StaffOfficeAssignments");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_Users_TenantId_Id",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "CounterName",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ShiftEnd",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ShiftStart",
+                table: "Users");
+        }
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -33,6 +33,7 @@ import { AdminDashboardPage }   from './pages/Admin'
 import { StaffDashboardPage }   from './pages/Staff'
 import { OfficeManagementPage } from './pages/Offices'
 import { ServiceManagementPage } from './pages/Services'
+import { StaffManagementPage } from './pages/StaffManagement'
 import { StaffInviteAcceptPage } from './pages/StaffInviteAccept'
 import { OrgLoginLookupPage }   from './pages/OrgLoginLookup'
 import { TermsPage, PrivacyPage } from './pages/Legal'
@@ -107,6 +108,15 @@ function App() {
         element={
           <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
             <ServiceManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/:tenantId/staff-management"
+        element={
+          <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
+            <StaffManagementPage />
           </ProtectedRoute>
         }
       />

--- a/src/web/src/api/staff.ts
+++ b/src/web/src/api/staff.ts
@@ -1,0 +1,104 @@
+import { apiClient, parseApiError } from './client'
+import { getToken } from '../utils/authToken'
+
+export interface StaffDto {
+  staffUserId: string
+  name: string
+  email: string
+  phone: string | null
+  isActive: boolean
+  counterName: string | null
+  shiftStart: string | null
+  shiftEnd: string | null
+  officeIds: string[]
+  createdAt: string
+}
+
+export interface ListStaffResult {
+  items: StaffDto[]
+  pageNumber: number
+  pageSize: number
+  totalCount: number
+}
+
+export interface CreateStaffBody {
+  name: string
+  email: string
+  phone?: string | null
+  officeIds: string[]
+  counterName?: string | null
+  shiftStart?: string | null
+  shiftEnd?: string | null
+}
+
+export interface UpdateStaffBody {
+  name: string
+  phone?: string | null
+  officeIds: string[]
+  counterName?: string | null
+  shiftStart?: string | null
+  shiftEnd?: string | null
+}
+
+export async function listStaff(tenantId: string, pageNumber = 1, pageSize = 20): Promise<ListStaffResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<ListStaffResult>('/staff', {
+      params: { pageNumber, pageSize },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function createStaff(tenantId: string, body: CreateStaffBody): Promise<StaffDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.post<StaffDto>('/staff', body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function updateStaff(tenantId: string, staffUserId: string, body: UpdateStaffBody): Promise<StaffDto> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.put<StaffDto>(`/staff/${staffUserId}`, body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+export async function deactivateStaff(tenantId: string, staffUserId: string): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.patch(`/staff/${staffUserId}/deactivate`, null, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Tenant-Id': tenantId,
+      },
+    })
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}

--- a/src/web/src/pages/Admin/AdminDashboardPage.tsx
+++ b/src/web/src/pages/Admin/AdminDashboardPage.tsx
@@ -499,6 +499,13 @@ export function AdminDashboardPage() {
             >
               Manage Services
             </button>
+            <button
+              type="button"
+              className={styles.tabBtn}
+              onClick={() => navigate(`/admin/${tenantId}/staff-management`)}
+            >
+              Staff Management
+            </button>
           </div>
           <div className={styles.tabs} role="tablist" aria-label="Admin sections">
             <button

--- a/src/web/src/pages/StaffManagement/StaffManagementPage.module.css
+++ b/src/web/src/pages/StaffManagement/StaffManagementPage.module.css
@@ -1,0 +1,159 @@
+.page {
+  min-height: 100vh;
+  background: linear-gradient(160deg, #f3f8ff 0%, #f6fff7 100%);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h1 {
+  margin: 0;
+}
+
+.formCard,
+.listCard {
+  background: #ffffffea;
+  border: 1px solid #d7e3ef;
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.form {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.input {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+}
+
+.shiftRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.sectionLabel {
+  margin: 0.1rem 0 0.5rem;
+  font-weight: 600;
+}
+
+.officeGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 0.45rem;
+}
+
+.officeItem {
+  border: 1px solid #d7e3ef;
+  border-radius: 8px;
+  padding: 0.55rem;
+  display: flex;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.actions,
+.rowActions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.backBtn,
+.primaryBtn,
+.secondaryBtn,
+.dangerBtn {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.backBtn,
+.secondaryBtn {
+  background: #fff;
+}
+
+.primaryBtn {
+  background: #0f766e;
+  border-color: #0f766e;
+  color: #fff;
+}
+
+.dangerBtn {
+  background: #dc2626;
+  border-color: #dc2626;
+  color: #fff;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.listItem {
+  border: 1px solid #d7e3ef;
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.listItem h3 {
+  margin: 0 0 0.2rem;
+}
+
+.listItem p {
+  margin: 0.12rem 0;
+}
+
+.meta {
+  color: #4b5563;
+}
+
+.error,
+.success {
+  border-radius: 10px;
+  padding: 0.65rem 0.85rem;
+  font-weight: 600;
+}
+
+.error {
+  background: #fee2e2;
+  color: #7f1d1d;
+}
+
+.success {
+  background: #dcfce7;
+  color: #14532d;
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .header,
+  .listItem {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shiftRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/web/src/pages/StaffManagement/StaffManagementPage.tsx
+++ b/src/web/src/pages/StaffManagement/StaffManagementPage.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { listOffices, type OfficeDto } from '../../api/offices'
+import { createStaff, deactivateStaff, listStaff, updateStaff, type StaffDto } from '../../api/staff'
+import type { ApiError } from '../../types/api'
+import { clearToken, getTokenPayload } from '../../utils/authToken'
+import styles from './StaffManagementPage.module.css'
+
+type Mode = 'create' | 'edit'
+
+interface StaffForm {
+  name: string
+  email: string
+  phone: string
+  counterName: string
+  shiftStart: string
+  shiftEnd: string
+}
+
+const defaultForm: StaffForm = {
+  name: '',
+  email: '',
+  phone: '',
+  counterName: '',
+  shiftStart: '',
+  shiftEnd: '',
+}
+
+export function StaffManagementPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const [staff, setStaff] = useState<StaffDto[]>([])
+  const [offices, setOffices] = useState<OfficeDto[]>([])
+  const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
+  const [mode, setMode] = useState<Mode>('create')
+  const [editStaffId, setEditStaffId] = useState<string | null>(null)
+  const [form, setForm] = useState<StaffForm>(defaultForm)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const activeOfficeSet = useMemo(() => new Set(selectedOfficeIds), [selectedOfficeIds])
+
+  useEffect(() => {
+    if (!payload) {
+      clearToken()
+      navigate('/', { replace: true })
+      return
+    }
+
+    if (!tenantId) return
+    void loadData(tenantId)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenantId])
+
+  async function loadData(currentTenantId: string) {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const [staffResult, officesResult] = await Promise.all([
+        listStaff(currentTenantId, 1, 100),
+        listOffices(currentTenantId, { isActive: true, pageNumber: 1, pageSize: 200 }),
+      ])
+
+      setStaff(staffResult.items)
+      setOffices(officesResult.items)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not load staff management data.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function resetForm() {
+    setMode('create')
+    setEditStaffId(null)
+    setForm(defaultForm)
+    setSelectedOfficeIds([])
+  }
+
+  function beginEdit(staffUser: StaffDto) {
+    setMode('edit')
+    setEditStaffId(staffUser.staffUserId)
+    setForm({
+      name: staffUser.name,
+      email: staffUser.email,
+      phone: staffUser.phone ?? '',
+      counterName: staffUser.counterName ?? '',
+      shiftStart: staffUser.shiftStart ?? '',
+      shiftEnd: staffUser.shiftEnd ?? '',
+    })
+    setSelectedOfficeIds(staffUser.officeIds)
+    setError(null)
+    setSuccess(null)
+  }
+
+  function toggleOfficeSelection(officeId: string) {
+    setSelectedOfficeIds(prev => prev.includes(officeId) ? prev.filter(x => x !== officeId) : [...prev, officeId])
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!tenantId) return
+
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      if (mode === 'create') {
+        await createStaff(tenantId, {
+          name: form.name.trim(),
+          email: form.email.trim(),
+          phone: form.phone.trim() || null,
+          officeIds: selectedOfficeIds,
+          counterName: form.counterName.trim() || null,
+          shiftStart: form.shiftStart || null,
+          shiftEnd: form.shiftEnd || null,
+        })
+        setSuccess('Staff account created successfully.')
+      } else if (editStaffId) {
+        await updateStaff(tenantId, editStaffId, {
+          name: form.name.trim(),
+          phone: form.phone.trim() || null,
+          officeIds: selectedOfficeIds,
+          counterName: form.counterName.trim() || null,
+          shiftStart: form.shiftStart || null,
+          shiftEnd: form.shiftEnd || null,
+        })
+        setSuccess('Staff account updated successfully.')
+      }
+
+      resetForm()
+      await loadData(tenantId)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not save staff account.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDeactivate(staffUserId: string) {
+    if (!tenantId) return
+
+    setError(null)
+    setSuccess(null)
+
+    try {
+      await deactivateStaff(tenantId, staffUserId)
+      setSuccess('Staff account deactivated successfully.')
+      await loadData(tenantId)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not deactivate staff account.')
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1>Staff Account Management</h1>
+        <button type="button" className={styles.backBtn} onClick={() => navigate(`/admin/${tenantId}`)}>
+          Back to Admin
+        </button>
+      </header>
+
+      {error && <div className={styles.error}>{error}</div>}
+      {success && <div className={styles.success}>{success}</div>}
+
+      <section className={styles.formCard}>
+        <h2>{mode === 'create' ? 'Create Staff Account' : 'Update Staff Account'}</h2>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <input
+            className={styles.input}
+            placeholder="Name"
+            value={form.name}
+            onChange={event => setForm(prev => ({ ...prev, name: event.target.value }))}
+            required
+          />
+          <input
+            className={styles.input}
+            placeholder="Email"
+            type="email"
+            value={form.email}
+            onChange={event => setForm(prev => ({ ...prev, email: event.target.value }))}
+            disabled={mode === 'edit'}
+            required
+          />
+          <input
+            className={styles.input}
+            placeholder="Phone"
+            value={form.phone}
+            onChange={event => setForm(prev => ({ ...prev, phone: event.target.value }))}
+          />
+          <input
+            className={styles.input}
+            placeholder="Counter name (optional)"
+            value={form.counterName}
+            onChange={event => setForm(prev => ({ ...prev, counterName: event.target.value }))}
+          />
+
+          <div className={styles.shiftRow}>
+            <input
+              className={styles.input}
+              placeholder="Shift start (HH:mm)"
+              value={form.shiftStart}
+              onChange={event => setForm(prev => ({ ...prev, shiftStart: event.target.value }))}
+            />
+            <input
+              className={styles.input}
+              placeholder="Shift end (HH:mm)"
+              value={form.shiftEnd}
+              onChange={event => setForm(prev => ({ ...prev, shiftEnd: event.target.value }))}
+            />
+          </div>
+
+          <div>
+            <p className={styles.sectionLabel}>Assigned Offices</p>
+            <div className={styles.officeGrid}>
+              {offices.map(office => (
+                <label key={office.officeId} className={styles.officeItem}>
+                  <input
+                    type="checkbox"
+                    checked={activeOfficeSet.has(office.officeId)}
+                    onChange={() => toggleOfficeSelection(office.officeId)}
+                  />
+                  <span>{office.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.actions}>
+            <button type="submit" className={styles.primaryBtn} disabled={saving}>
+              {saving ? 'Saving...' : mode === 'create' ? 'Create Staff' : 'Update Staff'}
+            </button>
+            {mode === 'edit' && (
+              <button type="button" className={styles.secondaryBtn} onClick={resetForm}>
+                Cancel Edit
+              </button>
+            )}
+          </div>
+        </form>
+      </section>
+
+      <section className={styles.listCard}>
+        <h2>Staff Accounts</h2>
+        {loading ? (
+          <p>Loading staff accounts...</p>
+        ) : staff.length === 0 ? (
+          <p>No staff accounts found.</p>
+        ) : (
+          <ul className={styles.list}>
+            {staff.map(item => (
+              <li key={item.staffUserId} className={styles.listItem}>
+                <div>
+                  <h3>{item.name}</h3>
+                  <p>{item.email}</p>
+                  <p className={styles.meta}>{item.phone ?? 'No phone'}</p>
+                  <p className={styles.meta}>
+                    {item.isActive ? 'Active' : 'Inactive'}
+                    {item.counterName ? ` · ${item.counterName}` : ''}
+                    {item.shiftStart && item.shiftEnd ? ` · ${item.shiftStart}-${item.shiftEnd}` : ''}
+                  </p>
+                </div>
+                <div className={styles.rowActions}>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    onClick={() => beginEdit(item)}
+                    disabled={!item.isActive}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.dangerBtn}
+                    onClick={() => handleDeactivate(item.staffUserId)}
+                    disabled={!item.isActive}
+                  >
+                    Deactivate
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/web/src/pages/StaffManagement/index.ts
+++ b/src/web/src/pages/StaffManagement/index.ts
@@ -1,0 +1,1 @@
+export { StaffManagementPage } from './StaffManagementPage'

--- a/tests/NextTurn.IntegrationTests/Auth/StaffManagementIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Auth/StaffManagementIntegrationTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NextTurn.Domain.Auth;
+
+namespace NextTurn.IntegrationTests.Auth;
+
+[Collection("Integration")]
+public sealed class StaffManagementIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+
+    public StaffManagementIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _) = await _factory.SeedQueueAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task StaffManagementFlow_CreateUpdateDeactivate_AndPersistOfficeAssignments()
+    {
+        var adminClient = AuthenticatedClient(UserRole.OrgAdmin, Guid.NewGuid(), _tenantId);
+
+        var officeResponse = await adminClient.PostAsJsonAsync("/api/offices", new
+        {
+            name = "Main Office",
+            address = "No. 1 Main Street",
+            openingHours = "Mon-Fri 09:00-17:00"
+        });
+
+        officeResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var office = await officeResponse.Content.ReadFromJsonAsync<OfficeDto>();
+        office.Should().NotBeNull();
+
+        var createStaff = await adminClient.PostAsJsonAsync("/api/staff", new
+        {
+            name = "Counter Agent",
+            email = "counter.agent@example.com",
+            phone = "0711111111",
+            officeIds = new[] { office!.OfficeId },
+            counterName = "Counter A",
+            shiftStart = "09:00",
+            shiftEnd = "17:00"
+        });
+
+        createStaff.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var created = await createStaff.Content.ReadFromJsonAsync<StaffDto>();
+        created.Should().NotBeNull();
+        created!.OfficeIds.Should().Contain(office.OfficeId);
+
+        var updateStaff = await adminClient.PutAsJsonAsync($"/api/staff/{created.StaffUserId}", new
+        {
+            name = "Counter Agent Updated",
+            phone = "0722222222",
+            officeIds = Array.Empty<Guid>(),
+            counterName = "Counter B",
+            shiftStart = "10:00",
+            shiftEnd = "18:00"
+        });
+
+        updateStaff.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updated = await updateStaff.Content.ReadFromJsonAsync<StaffDto>();
+        updated.Should().NotBeNull();
+        updated!.Name.Should().Be("Counter Agent Updated");
+        updated.OfficeIds.Should().BeEmpty();
+
+        var deactivate = await adminClient.PatchAsync($"/api/staff/{created.StaffUserId}/deactivate", null);
+        deactivate.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listed = await adminClient.GetFromJsonAsync<ListStaffResult>("/api/staff?pageNumber=1&pageSize=20");
+        listed.Should().NotBeNull();
+
+        var deactivated = listed!.Items.Single(x => x.StaffUserId == created.StaffUserId);
+        deactivated.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StaffEndpoints_WithUserRole_ReturnForbidden()
+    {
+        var userClient = AuthenticatedClient(UserRole.User, Guid.NewGuid(), _tenantId);
+
+        var response = await userClient.GetAsync("/api/staff?pageNumber=1&pageSize=20");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private HttpClient AuthenticatedClient(UserRole role, Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(role, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private sealed record OfficeDto(Guid OfficeId, string Name);
+
+    private sealed record StaffDto(
+        Guid StaffUserId,
+        string Name,
+        string Email,
+        string? Phone,
+        bool IsActive,
+        string? CounterName,
+        string? ShiftStart,
+        string? ShiftEnd,
+        IReadOnlyList<Guid> OfficeIds,
+        DateTimeOffset CreatedAt);
+
+    private sealed record ListStaffResult(
+        IReadOnlyList<StaffDto> Items,
+        int PageNumber,
+        int PageSize,
+        int TotalCount);
+}

--- a/tests/NextTurn.UnitTests/Application/Staff/CreateStaffCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Staff/CreateStaffCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Staff.Commands.CreateStaff;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.Repositories;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.UnitTests.Application.Staff;
+
+public sealed class CreateStaffCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock = new();
+    private readonly Mock<ITenantContext> _tenantContextMock = new();
+
+    private readonly CreateStaffCommandHandler _handler;
+
+    private static readonly Guid TenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public CreateStaffCommandHandlerTests()
+    {
+        _tenantContextMock.Setup(x => x.TenantId).Returns(TenantId);
+        _handler = new CreateStaffCommandHandler(_userRepositoryMock.Object, _tenantContextMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_CreatesStaffAndAssignments()
+    {
+        var officeId = Guid.NewGuid();
+
+        _userRepositoryMock
+            .Setup(r => r.GetByEmailAsync(It.IsAny<EmailAddress>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        _userRepositoryMock
+            .Setup(r => r.OfficesExistAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var command = new CreateStaffCommand(
+            "Counter Agent",
+            "staff@example.com",
+            "0711111111",
+            new[] { officeId },
+            "Counter A",
+            TimeSpan.Parse("09:00"),
+            TimeSpan.Parse("17:00"));
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Name.Should().Be("Counter Agent");
+        result.Email.Should().Be("staff@example.com");
+        result.OfficeIds.Should().Contain(officeId);
+
+        _userRepositoryMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+        _userRepositoryMock.Verify(r => r.ReplaceStaffOfficeAssignmentsAsync(It.IsAny<Guid>(), It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOfficeMissing_ThrowsDomainException()
+    {
+        _userRepositoryMock
+            .Setup(r => r.GetByEmailAsync(It.IsAny<EmailAddress>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        _userRepositoryMock
+            .Setup(r => r.OfficesExistAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var command = new CreateStaffCommand(
+            "Counter Agent",
+            "staff@example.com",
+            null,
+            new[] { Guid.NewGuid() },
+            null,
+            null,
+            null);
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("One or more offices were not found for this tenant.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Staff/CreateStaffCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Staff/CreateStaffCommandValidatorTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using NextTurn.Application.Staff.Commands.CreateStaff;
+
+namespace NextTurn.UnitTests.Application.Staff;
+
+public sealed class CreateStaffCommandValidatorTests
+{
+    private readonly CreateStaffCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithValidCommand_HasNoErrors()
+    {
+        var command = new CreateStaffCommand(
+            "Counter Agent",
+            "staff@example.com",
+            "0711111111",
+            new[] { Guid.NewGuid() },
+            "Counter A",
+            TimeSpan.Parse("09:00"),
+            TimeSpan.Parse("17:00"));
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithoutOffices_ReturnsError()
+    {
+        var command = new CreateStaffCommand(
+            "Counter Agent",
+            "staff@example.com",
+            null,
+            Array.Empty<Guid>(),
+            null,
+            null,
+            null);
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(CreateStaffCommand.OfficeIds));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Staff/DeactivateStaffCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Staff/DeactivateStaffCommandHandlerTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Staff.Commands.DeactivateStaff;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.Repositories;
+using NextTurn.Domain.Auth.ValueObjects;
+
+namespace NextTurn.UnitTests.Application.Staff;
+
+public sealed class DeactivateStaffCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock = new();
+    private readonly DeactivateStaffCommandHandler _handler;
+
+    public DeactivateStaffCommandHandlerTests()
+    {
+        _handler = new DeactivateStaffCommandHandler(_userRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithStaffUser_DeactivatesAndDowngradesRole()
+    {
+        var staff = User.Create(Guid.NewGuid(), "Staff", new EmailAddress("staff@example.com"), null, "hash", UserRole.Staff);
+
+        _userRepositoryMock.Setup(r => r.GetByIdAsync(staff.Id, It.IsAny<CancellationToken>())).ReturnsAsync(staff);
+
+        await _handler.Handle(new DeactivateStaffCommand(staff.Id), CancellationToken.None);
+
+        staff.IsActive.Should().BeFalse();
+        staff.Role.Should().Be(UserRole.User);
+        _userRepositoryMock.Verify(r => r.UpdateAsync(staff, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Staff/UpdateStaffCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Staff/UpdateStaffCommandHandlerTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Staff.Commands.UpdateStaff;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.Repositories;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.UnitTests.Application.Staff;
+
+public sealed class UpdateStaffCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock = new();
+    private readonly UpdateStaffCommandHandler _handler;
+
+    public UpdateStaffCommandHandlerTests()
+    {
+        _handler = new UpdateStaffCommandHandler(_userRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_UpdatesStaffAndAssignments()
+    {
+        var staff = User.Create(Guid.NewGuid(), "Staff", new EmailAddress("staff@example.com"), "0771234567", "hash", UserRole.Staff);
+
+        _userRepositoryMock.Setup(r => r.GetByIdAsync(staff.Id, It.IsAny<CancellationToken>())).ReturnsAsync(staff);
+        _userRepositoryMock.Setup(r => r.OfficesExistAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var officeId = Guid.NewGuid();
+        var command = new UpdateStaffCommand(staff.Id, "Updated", "0711111111", new[] { officeId }, "Counter B", TimeSpan.Parse("10:00"), TimeSpan.Parse("18:00"));
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Name.Should().Be("Updated");
+        result.OfficeIds.Should().Contain(officeId);
+
+        _userRepositoryMock.Verify(r => r.UpdateAsync(staff, It.IsAny<CancellationToken>()), Times.Once);
+        _userRepositoryMock.Verify(r => r.ReplaceStaffOfficeAssignmentsAsync(staff.Id, It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNotStaff_ThrowsDomainException()
+    {
+        var user = User.Create(Guid.NewGuid(), "User", new EmailAddress("user@example.com"), null, "hash", UserRole.User);
+        _userRepositoryMock.Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var command = new UpdateStaffCommand(user.Id, "Updated", null, new[] { Guid.NewGuid() }, null, null, null);
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Only staff accounts can be updated from this endpoint.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Staff/UpdateStaffCommandValidatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Staff/UpdateStaffCommandValidatorTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using NextTurn.Application.Staff.Commands.UpdateStaff;
+
+namespace NextTurn.UnitTests.Application.Staff;
+
+public sealed class UpdateStaffCommandValidatorTests
+{
+    private readonly UpdateStaffCommandValidator _validator = new();
+
+    [Fact]
+    public async Task ValidateAsync_WithInvalidShiftWindow_ReturnsError()
+    {
+        var command = new UpdateStaffCommand(
+            Guid.NewGuid(),
+            "Counter Agent",
+            "0711111111",
+            new[] { Guid.NewGuid() },
+            "Counter A",
+            TimeSpan.Parse("18:00"),
+            TimeSpan.Parse("09:00"));
+
+        var result = await _validator.ValidateAsync(command);
+
+        result.IsValid.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
This PR delivers full staff account management for organization and system administrators, including backend APIs, domain/application/infrastructure updates, admin UI, test coverage, and database migration support.

The implementation introduces a dedicated staff management flow under the staff API surface, with tenant-aware behavior and role-guarded access.

## User Story
As an organization or system admin, I want to create and manage staff accounts so counters can be operated.

## What This PR Implements

### 1. Staff Management API
- Added POST /api/staff to create a staff account with:
- name, email, phone
- officeIds
- counterName
- shiftStart, shiftEnd
- Added GET /api/staff with pagination for current tenant:
- pageNumber
- pageSize
- totalCount
- Added PUT /api/staff/{id} to update:
- name
- phone
- shift details
- office assignments
- Added PATCH /api/staff/{id}/deactivate to:
- remove Staff role (downgrade to User)
- set IsActive = false
- preserve history
- Authorization enforced so only OrgAdmin and SystemAdmin can call these endpoints.

### 2. Domain + Persistence Enhancements
- Extended User aggregate with staff profile fields:
- CounterName
- ShiftStart
- ShiftEnd
- Added staff-specific domain behavior for:
- profile updates with validation
- staff deactivation semantics (role + active status)
- Added StaffOfficeAssignment relation for tenant staff-office mapping.
- Added EF Core configuration for new relation and fields.
- Added tenant query filtering and DbContext exposure for staff-office assignment data.

### 3. Application Layer (Clean Architecture)
- Added dedicated Staff vertical slice in application layer:
- create command + validator + handler
- update command + validator + handler
- deactivate command + validator + handler
- paginated list query + validator + handler
- Added DTO/result models to support staff API responses and paging.
- Added repository contract + implementation support for:
- paginated staff listing
- office existence checks
- assignment reads
- assignment replacement writes

### 4. Admin Frontend
- Added new staff management API client for:
- create, list, update, deactivate
- Added new Staff Management page in admin UI:
- create and edit staff accounts
- assign/unassign offices
- set counter and shift information
- deactivate staff accounts
- Added routing and admin dashboard navigation entry to access the page.

### 5. Database Migration
- Added migration for:
- User table staff profile columns
- StaffOfficeAssignments table and constraints
- Updated model snapshot accordingly.

## Acceptance Criteria Mapping

- POST /api/staff create with requested fields: Completed
- GET /api/staff paginated list for current tenant: Completed
- PUT /api/staff/{id} update fields/assignments: Completed
- PATCH /api/staff/{id}/deactivate role + IsActive change: Completed
- Only OrgAdmin/SystemAdmin can call: Completed
- Implemented via User aggregate + app layer role logic: Completed
- Unit tests for command/validation: Completed
- Integration tests for role + office assignment persistence: Added
- Demo flow support (create -> assign -> staff visibility path): Backend and UI support included
- Confluence SRS update: Not included in codebase, to be updated manually

## Testing and Validation

### Build
- Full solution build: Passed
- Frontend build: Passed

### Unit Tests
- Staff-focused unit tests added and passing:
- create command handler and validator
- update command handler and validator
- deactivate command handler

### Integration Tests
- Staff management integration tests added for:
- create/update/deactivate flow
- office assignment persistence checks
- role-based access checks
- Local execution is environment-blocked when Docker/Testcontainers is unavailable, consistent with existing integration test constraints.

## Granular Commits
- feat(staff): add tenant staff management APIs and office assignments
- test(staff): add unit and integration tests for staff management
- feat(web): add admin staff management page

## Notes / Known Constraints
- Confluence update cannot be automated from this repository workflow and should be done as a manual documentation task.
- Integration tests require Docker runtime for Testcontainers-backed SQL environment.

## Demo Script
1. Login as OrgAdmin.
2. Open Admin dashboard and navigate to Staff Management.
3. Create staff with office assignment and shift details.
4. Edit staff profile and office assignments.
5. Deactivate staff and confirm account no longer active.
6. Verify list endpoint reflects updates and role/status transitions correctly.