### PR TITLE
fix(web): add vercel spa fallback routes for deep links

### DIFF
--- a/src/web/vercel.json
+++ b/src/web/vercel.json
@@ -1,0 +1,11 @@
+{
+  "routes": [
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/.*",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Vercel was not configured to fallback deep links to index.html, so direct link opens returned Vercel 404 NOT_FOUND.

Added SPA fallback routing config in vercel.json:
- Serve real files first.
- Rewrite all other paths to index.html.