### PR TITLE
NT-26: Add event-driven appointment notifications with user preferences and delivery audit logging

### DIFF
--- a/src/NextTurn.API/Controllers/AuthController.cs
+++ b/src/NextTurn.API/Controllers/AuthController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 using NextTurn.API.Models.Auth;
 using NextTurn.Application.Auth;
+using NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
 using NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
 using NextTurn.Application.Auth.Commands.CreateStaffUser;
 using NextTurn.Application.Auth.Commands.InviteStaffUser;
@@ -16,6 +17,7 @@ using NextTurn.Application.Auth.Commands.ReactivateStaffUser;
 using NextTurn.Application.Auth.Commands.RegisterGlobalUser;
 using NextTurn.Application.Auth.Commands.RegisterUser;
 using NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
+using NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
 using NextTurn.Application.Auth.Queries.ListStaffUsers;
 
 namespace NextTurn.API.Controllers;
@@ -343,6 +345,48 @@ public sealed class AuthController : ControllerBase
             new UpdateQueueNotificationPreferenceCommand(
                 userId,
                 request.QueueTurnApproachingNotificationsEnabled),
+            cancellationToken);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets the authenticated user's appointment notification preferences.
+    /// </summary>
+    [HttpGet("appointment-notification-preferences")]
+    [Authorize]
+    [ProducesResponseType(typeof(AppointmentNotificationPreferencesResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetAppointmentNotificationPreferences(CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(out var userId))
+            return Unauthorized();
+
+        var result = await _sender.Send(new GetAppointmentNotificationPreferencesQuery(userId), cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Updates the authenticated user's appointment notification preferences.
+    /// </summary>
+    [HttpPut("appointment-notification-preferences")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> UpdateAppointmentNotificationPreferences(
+        [FromBody] UpdateAppointmentNotificationPreferencesRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(out var userId))
+            return Unauthorized();
+
+        await _sender.Send(
+            new UpdateAppointmentNotificationPreferencesCommand(
+                userId,
+                request.AppointmentBookedNotificationsEnabled,
+                request.AppointmentRescheduledNotificationsEnabled,
+                request.AppointmentCancelledNotificationsEnabled),
             cancellationToken);
 
         return NoContent();

--- a/src/NextTurn.API/Models/Auth/UpdateAppointmentNotificationPreferencesRequest.cs
+++ b/src/NextTurn.API/Models/Auth/UpdateAppointmentNotificationPreferencesRequest.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.API.Models.Auth;
+
+public sealed record UpdateAppointmentNotificationPreferencesRequest(
+    bool AppointmentBookedNotificationsEnabled,
+    bool AppointmentRescheduledNotificationsEnabled,
+    bool AppointmentCancelledNotificationsEnabled);

--- a/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotification.cs
+++ b/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotification.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace NextTurn.Application.Appointment.Commands.BookAppointment;
+
+/// <summary>
+/// In-process event published after an appointment is successfully booked.
+/// </summary>
+public sealed record AppointmentBookedNotification(Guid AppointmentId) : INotification;

--- a/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotificationHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using NextTurn.Application.Appointment.Notifications;
+
+namespace NextTurn.Application.Appointment.Commands.BookAppointment;
+
+public sealed class AppointmentBookedNotificationHandler
+    : INotificationHandler<AppointmentBookedNotification>
+{
+    private readonly IAppointmentNotificationService _appointmentNotificationService;
+
+    public AppointmentBookedNotificationHandler(IAppointmentNotificationService appointmentNotificationService)
+    {
+        _appointmentNotificationService = appointmentNotificationService;
+    }
+
+    public Task Handle(AppointmentBookedNotification notification, CancellationToken cancellationToken)
+    {
+        return _appointmentNotificationService.SendBookingConfirmationAsync(notification.AppointmentId, cancellationToken);
+    }
+}

--- a/src/NextTurn.Application/Appointment/Commands/BookAppointment/BookAppointmentCommandHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/BookAppointment/BookAppointmentCommandHandler.cs
@@ -14,13 +14,16 @@ public sealed class BookAppointmentCommandHandler : IRequestHandler<BookAppointm
 {
     private readonly IAppointmentRepository _appointmentRepository;
     private readonly IApplicationDbContext _context;
+    private readonly IPublisher _publisher;
 
     public BookAppointmentCommandHandler(
         IAppointmentRepository appointmentRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        IPublisher publisher)
     {
         _appointmentRepository = appointmentRepository;
         _context = context;
+        _publisher = publisher;
     }
 
     public async Task<BookAppointmentResult> Handle(
@@ -64,6 +67,8 @@ public sealed class BookAppointmentCommandHandler : IRequestHandler<BookAppointm
         {
             throw new ConflictDomainException("This time slot is already booked.");
         }
+
+        await _publisher.Publish(new AppointmentBookedNotification(appointment.Id), cancellationToken);
 
         return new BookAppointmentResult(appointment.Id);
     }

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotificationHandler.cs
@@ -1,5 +1,5 @@
 using MediatR;
-using Microsoft.Extensions.Logging;
+using NextTurn.Application.Appointment.Notifications;
 
 namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
 
@@ -9,27 +9,20 @@ namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
 public sealed class AppointmentCancelledNotificationHandler
     : INotificationHandler<AppointmentCancelledNotification>
 {
-    private readonly ILogger<AppointmentCancelledNotificationHandler> _logger;
+    private readonly IAppointmentNotificationService _appointmentNotificationService;
 
     public AppointmentCancelledNotificationHandler(
-        ILogger<AppointmentCancelledNotificationHandler> logger)
+        IAppointmentNotificationService appointmentNotificationService)
     {
-        _logger = logger;
+        _appointmentNotificationService = appointmentNotificationService;
     }
 
     public Task Handle(
         AppointmentCancelledNotification notification,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation(
-            "Appointment cancelled. AppointmentId: {AppointmentId}, UserId: {UserId}, OrgId: {OrgId}, Slot: {SlotStart}->{SlotEnd}, LateCancellation: {LateCancellation}.",
+        return _appointmentNotificationService.SendCancellationUpdateAsync(
             notification.AppointmentId,
-            notification.UserId,
-            notification.OrganisationId,
-            notification.SlotStart,
-            notification.SlotEnd,
-            notification.LateCancellation);
-
-        return Task.CompletedTask;
+            cancellationToken);
     }
 }

--- a/src/NextTurn.Application/Appointment/Commands/RescheduleAppointment/AppointmentRescheduledNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/RescheduleAppointment/AppointmentRescheduledNotificationHandler.cs
@@ -1,5 +1,5 @@
 using MediatR;
-using Microsoft.Extensions.Logging;
+using NextTurn.Application.Appointment.Notifications;
 
 namespace NextTurn.Application.Appointment.Commands.RescheduleAppointment;
 
@@ -10,29 +10,20 @@ namespace NextTurn.Application.Appointment.Commands.RescheduleAppointment;
 public sealed class AppointmentRescheduledNotificationHandler
     : INotificationHandler<AppointmentRescheduledNotification>
 {
-    private readonly ILogger<AppointmentRescheduledNotificationHandler> _logger;
+    private readonly IAppointmentNotificationService _appointmentNotificationService;
 
     public AppointmentRescheduledNotificationHandler(
-        ILogger<AppointmentRescheduledNotificationHandler> logger)
+        IAppointmentNotificationService appointmentNotificationService)
     {
-        _logger = logger;
+        _appointmentNotificationService = appointmentNotificationService;
     }
 
     public Task Handle(
         AppointmentRescheduledNotification notification,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation(
-            "Appointment rescheduled. OldId: {OldId}, NewId: {NewId}, UserId: {UserId}, OrgId: {OrgId}, OldSlot: {OldStart}->{OldEnd}, NewSlot: {NewStart}->{NewEnd}.",
-            notification.PreviousAppointmentId,
+        return _appointmentNotificationService.SendRescheduleUpdateAsync(
             notification.NewAppointmentId,
-            notification.UserId,
-            notification.OrganisationId,
-            notification.PreviousSlotStart,
-            notification.PreviousSlotEnd,
-            notification.NewSlotStart,
-            notification.NewSlotEnd);
-
-        return Task.CompletedTask;
+            cancellationToken);
     }
 }

--- a/src/NextTurn.Application/Appointment/Notifications/AppointmentNotificationService.cs
+++ b/src/NextTurn.Application/Appointment/Notifications/AppointmentNotificationService.cs
@@ -1,0 +1,140 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NextTurn.Application.Common.Interfaces;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
+
+namespace NextTurn.Application.Appointment.Notifications;
+
+public sealed class AppointmentNotificationService : IAppointmentNotificationService
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<AppointmentNotificationService> _logger;
+
+    public AppointmentNotificationService(
+        IApplicationDbContext context,
+        IEmailService emailService,
+        ILogger<AppointmentNotificationService> logger)
+    {
+        _context = context;
+        _emailService = emailService;
+        _logger = logger;
+    }
+
+    public Task SendBookingConfirmationAsync(Guid appointmentId, CancellationToken cancellationToken)
+    {
+        return SendAsync(appointmentId, "Booked", cancellationToken);
+    }
+
+    public Task SendRescheduleUpdateAsync(Guid appointmentId, CancellationToken cancellationToken)
+    {
+        return SendAsync(appointmentId, "Rescheduled", cancellationToken);
+    }
+
+    public Task SendCancellationUpdateAsync(Guid appointmentId, CancellationToken cancellationToken)
+    {
+        return SendAsync(appointmentId, "Cancelled", cancellationToken);
+    }
+
+    private async Task SendAsync(Guid appointmentId, string notificationType, CancellationToken cancellationToken)
+    {
+        var appointment = await _context.Appointments
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == appointmentId, cancellationToken);
+
+        if (appointment is null)
+        {
+            _logger.LogWarning("Appointment notification skipped. Appointment {AppointmentId} not found.", appointmentId);
+            return;
+        }
+
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == appointment.UserId, cancellationToken);
+
+        if (user is null || !user.IsActive)
+        {
+            _logger.LogWarning("Appointment notification skipped. User {UserId} missing or inactive.", appointment.UserId);
+            return;
+        }
+
+        if (!IsNotificationEnabled(user, notificationType))
+            return;
+
+        var profile = await _context.AppointmentProfiles
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == appointment.AppointmentProfileId, cancellationToken);
+
+        var organisation = await _context.Organisations
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == appointment.OrganisationId, cancellationToken);
+
+        var officeName = organisation?.Name ?? "Unknown office";
+        var serviceName = profile?.Name ?? "General appointment";
+
+        try
+        {
+            await _emailService.SendAppointmentStatusEmailAsync(
+                toEmail: user.Email.Value,
+                userName: user.Name,
+                notificationType: notificationType,
+                slotStart: appointment.SlotStart,
+                slotEnd: appointment.SlotEnd,
+                officeName: officeName,
+                serviceName: serviceName,
+                cancellationToken: cancellationToken);
+
+            _context.AppointmentNotificationAuditLogs.Add(
+                AppointmentNotificationAuditLog.Sent(
+                    organisationId: appointment.OrganisationId,
+                    appointmentId: appointment.Id,
+                    userId: user.Id,
+                    notificationType: notificationType,
+                    recipientEmail: user.Email.Value,
+                    slotStart: appointment.SlotStart,
+                    slotEnd: appointment.SlotEnd,
+                    officeName: officeName,
+                    serviceName: serviceName));
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to send appointment {NotificationType} notification for appointment {AppointmentId}.",
+                notificationType,
+                appointment.Id);
+
+            _context.AppointmentNotificationAuditLogs.Add(
+                AppointmentNotificationAuditLog.Failed(
+                    organisationId: appointment.OrganisationId,
+                    appointmentId: appointment.Id,
+                    userId: user.Id,
+                    notificationType: notificationType,
+                    recipientEmail: user.Email.Value,
+                    slotStart: appointment.SlotStart,
+                    slotEnd: appointment.SlotEnd,
+                    officeName: officeName,
+                    serviceName: serviceName,
+                    errorMessage: ex.Message));
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static bool IsNotificationEnabled(Domain.Auth.Entities.User user, string notificationType)
+    {
+        return notificationType switch
+        {
+            "Booked" => user.AppointmentBookedNotificationsEnabled,
+            "Rescheduled" => user.AppointmentRescheduledNotificationsEnabled,
+            "Cancelled" => user.AppointmentCancelledNotificationsEnabled,
+            _ => false,
+        };
+    }
+}

--- a/src/NextTurn.Application/Appointment/Notifications/IAppointmentNotificationService.cs
+++ b/src/NextTurn.Application/Appointment/Notifications/IAppointmentNotificationService.cs
@@ -1,0 +1,10 @@
+namespace NextTurn.Application.Appointment.Notifications;
+
+public interface IAppointmentNotificationService
+{
+    Task SendBookingConfirmationAsync(Guid appointmentId, CancellationToken cancellationToken);
+
+    Task SendRescheduleUpdateAsync(Guid appointmentId, CancellationToken cancellationToken);
+
+    Task SendCancellationUpdateAsync(Guid appointmentId, CancellationToken cancellationToken);
+}

--- a/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommand.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+
+public sealed record UpdateAppointmentNotificationPreferencesCommand(
+    Guid UserId,
+    bool AppointmentBookedNotificationsEnabled,
+    bool AppointmentRescheduledNotificationsEnabled,
+    bool AppointmentCancelledNotificationsEnabled) : IRequest<Unit>;

--- a/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandHandler.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandHandler.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+
+public sealed class UpdateAppointmentNotificationPreferencesCommandHandler
+    : IRequestHandler<UpdateAppointmentNotificationPreferencesCommand, Unit>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdateAppointmentNotificationPreferencesCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(
+        UpdateAppointmentNotificationPreferencesCommand request,
+        CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+        if (user is null)
+            throw new DomainException("User not found.");
+
+        user.SetAppointmentNotificationPreferences(
+            request.AppointmentBookedNotificationsEnabled,
+            request.AppointmentRescheduledNotificationsEnabled,
+            request.AppointmentCancelledNotificationsEnabled);
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandValidator.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+
+public sealed class UpdateAppointmentNotificationPreferencesCommandValidator
+    : AbstractValidator<UpdateAppointmentNotificationPreferencesCommand>
+{
+    public UpdateAppointmentNotificationPreferencesCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/AppointmentNotificationPreferencesResult.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/AppointmentNotificationPreferencesResult.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+
+public sealed record AppointmentNotificationPreferencesResult(
+    bool AppointmentBookedNotificationsEnabled,
+    bool AppointmentRescheduledNotificationsEnabled,
+    bool AppointmentCancelledNotificationsEnabled);

--- a/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQuery.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+
+public sealed record GetAppointmentNotificationPreferencesQuery(Guid UserId)
+    : IRequest<AppointmentNotificationPreferencesResult>;

--- a/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQueryHandler.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQueryHandler.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+
+public sealed class GetAppointmentNotificationPreferencesQueryHandler
+    : IRequestHandler<GetAppointmentNotificationPreferencesQuery, AppointmentNotificationPreferencesResult>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetAppointmentNotificationPreferencesQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<AppointmentNotificationPreferencesResult> Handle(
+        GetAppointmentNotificationPreferencesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+        if (user is null)
+            throw new DomainException("User not found.");
+
+        return new AppointmentNotificationPreferencesResult(
+            user.AppointmentBookedNotificationsEnabled,
+            user.AppointmentRescheduledNotificationsEnabled,
+            user.AppointmentCancelledNotificationsEnabled);
+    }
+}

--- a/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
 using AppointmentProfile = NextTurn.Domain.Appointment.Entities.AppointmentProfile;
 using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.AppointmentScheduleRule;
 using NextTurn.Domain.Auth.Entities;
@@ -28,6 +29,7 @@ public interface IApplicationDbContext
     DbSet<QueueActionAuditLog> QueueActionAuditLogs { get; }
     DbSet<QueueTurnNotificationAuditLog> QueueTurnNotificationAuditLogs { get; }
     DbSet<AppointmentEntity> Appointments { get; }
+    DbSet<AppointmentNotificationAuditLog> AppointmentNotificationAuditLogs { get; }
     DbSet<AppointmentProfile> AppointmentProfiles { get; }
     DbSet<AppointmentScheduleRule> AppointmentScheduleRules { get; }
     DbSet<StaffOfficeAssignment> StaffOfficeAssignments { get; }

--- a/src/NextTurn.Application/Common/Interfaces/IEmailService.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IEmailService.cs
@@ -36,4 +36,17 @@ public interface IEmailService
         int ticketNumber,
         int positionInQueue,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends appointment status updates (booked, rescheduled, cancelled) with slot and context details.
+    /// </summary>
+    Task SendAppointmentStatusEmailAsync(
+        string toEmail,
+        string userName,
+        string notificationType,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        CancellationToken cancellationToken);
 }

--- a/src/NextTurn.Application/DependencyInjection.cs
+++ b/src/NextTurn.Application/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Application.Appointment.Notifications;
 using NextTurn.Application.Auth.Commands.RegisterUser;
 using NextTurn.Application.Common.Behaviours;
 
@@ -38,6 +39,8 @@ public static class DependencyInjection
         services.AddTransient(
             typeof(IPipelineBehavior<,>),
             typeof(ValidationBehavior<,>));
+
+        services.AddScoped<IAppointmentNotificationService, AppointmentNotificationService>();
 
         return services;
     }

--- a/src/NextTurn.Domain/Appointment/Entities/AppointmentNotificationAuditLog.cs
+++ b/src/NextTurn.Domain/Appointment/Entities/AppointmentNotificationAuditLog.cs
@@ -1,0 +1,119 @@
+namespace NextTurn.Domain.Appointment.Entities;
+
+/// <summary>
+/// Immutable audit row for appointment notification delivery attempts.
+/// </summary>
+public sealed class AppointmentNotificationAuditLog
+{
+    public Guid Id { get; }
+    public Guid OrganisationId { get; private set; }
+    public Guid AppointmentId { get; private set; }
+    public Guid UserId { get; private set; }
+    public string NotificationType { get; private set; }
+    public string DeliveryStatus { get; private set; }
+    public string RecipientEmail { get; private set; }
+    public DateTimeOffset SlotStart { get; private set; }
+    public DateTimeOffset SlotEnd { get; private set; }
+    public string OfficeName { get; private set; }
+    public string ServiceName { get; private set; }
+    public string? ErrorMessage { get; private set; }
+    public DateTimeOffset CreatedAt { get; }
+
+    private AppointmentNotificationAuditLog()
+    {
+        NotificationType = default!;
+        DeliveryStatus = default!;
+        RecipientEmail = default!;
+        OfficeName = default!;
+        ServiceName = default!;
+    }
+
+    private AppointmentNotificationAuditLog(
+        Guid id,
+        Guid organisationId,
+        Guid appointmentId,
+        Guid userId,
+        string notificationType,
+        string deliveryStatus,
+        string recipientEmail,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        string? errorMessage,
+        DateTimeOffset createdAt)
+    {
+        Id = id;
+        OrganisationId = organisationId;
+        AppointmentId = appointmentId;
+        UserId = userId;
+        NotificationType = notificationType;
+        DeliveryStatus = deliveryStatus;
+        RecipientEmail = recipientEmail;
+        SlotStart = slotStart;
+        SlotEnd = slotEnd;
+        OfficeName = officeName;
+        ServiceName = serviceName;
+        ErrorMessage = errorMessage;
+        CreatedAt = createdAt;
+    }
+
+    public static AppointmentNotificationAuditLog Sent(
+        Guid organisationId,
+        Guid appointmentId,
+        Guid userId,
+        string notificationType,
+        string recipientEmail,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName)
+    {
+        return new AppointmentNotificationAuditLog(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            appointmentId: appointmentId,
+            userId: userId,
+            notificationType: notificationType,
+            deliveryStatus: "Sent",
+            recipientEmail: recipientEmail,
+            slotStart: slotStart,
+            slotEnd: slotEnd,
+            officeName: officeName,
+            serviceName: serviceName,
+            errorMessage: null,
+            createdAt: DateTimeOffset.UtcNow);
+    }
+
+    public static AppointmentNotificationAuditLog Failed(
+        Guid organisationId,
+        Guid appointmentId,
+        Guid userId,
+        string notificationType,
+        string recipientEmail,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        string errorMessage)
+    {
+        var normalizedError = string.IsNullOrWhiteSpace(errorMessage)
+            ? "Appointment notification delivery failed."
+            : errorMessage.Trim();
+
+        return new AppointmentNotificationAuditLog(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            appointmentId: appointmentId,
+            userId: userId,
+            notificationType: notificationType,
+            deliveryStatus: "Failed",
+            recipientEmail: recipientEmail,
+            slotStart: slotStart,
+            slotEnd: slotEnd,
+            officeName: officeName,
+            serviceName: serviceName,
+            errorMessage: normalizedError.Length > 500 ? normalizedError[..500] : normalizedError,
+            createdAt: DateTimeOffset.UtcNow);
+    }
+}

--- a/src/NextTurn.Domain/Auth/Entities/User.cs
+++ b/src/NextTurn.Domain/Auth/Entities/User.cs
@@ -33,6 +33,9 @@ public class User {
   /// </summary>
   public bool MfaEnabled { get; private set; }
   public bool QueueTurnApproachingNotificationsEnabled { get; private set; }
+  public bool AppointmentBookedNotificationsEnabled { get; private set; }
+  public bool AppointmentRescheduledNotificationsEnabled { get; private set; }
+  public bool AppointmentCancelledNotificationsEnabled { get; private set; }
 
   // ── Staff invite onboarding ──────────────────────────────────────────────
   public string? StaffInviteTokenHash { get; private set; }
@@ -65,6 +68,9 @@ public class User {
     LockoutUntil = null;
     MfaEnabled = false;
     QueueTurnApproachingNotificationsEnabled = true;
+    AppointmentBookedNotificationsEnabled = true;
+    AppointmentRescheduledNotificationsEnabled = true;
+    AppointmentCancelledNotificationsEnabled = true;
   }
 
   public static User Create(Guid tenantId, string name, EmailAddress email, string? phone, string passwordHash, UserRole role = UserRole.User)
@@ -220,6 +226,16 @@ public class User {
   public void SetQueueTurnApproachingNotificationsEnabled(bool enabled)
   {
     QueueTurnApproachingNotificationsEnabled = enabled;
+  }
+
+  public void SetAppointmentNotificationPreferences(
+    bool bookedEnabled,
+    bool rescheduledEnabled,
+    bool cancelledEnabled)
+  {
+    AppointmentBookedNotificationsEnabled = bookedEnabled;
+    AppointmentRescheduledNotificationsEnabled = rescheduledEnabled;
+    AppointmentCancelledNotificationsEnabled = cancelledEnabled;
   }
   
 }

--- a/src/NextTurn.Infrastructure/Email/StubEmailService.cs
+++ b/src/NextTurn.Infrastructure/Email/StubEmailService.cs
@@ -67,4 +67,27 @@ public sealed class StubEmailService : IEmailService
 
         return Task.CompletedTask;
     }
+
+    public Task SendAppointmentStatusEmailAsync(
+        string toEmail,
+        string userName,
+        string notificationType,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "[STUB] Appointment {NotificationType} email would be sent to {Email} ({UserName}). Slot: {SlotStart}->{SlotEnd}, Office: {OfficeName}, Service: {ServiceName}",
+            notificationType,
+            toEmail,
+            userName,
+            slotStart,
+            slotEnd,
+            officeName,
+            serviceName);
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NextTurn.Application.Common.Interfaces;
 using AppointmentEntity  = NextTurn.Domain.Appointment.Entities.Appointment;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
 using AppointmentProfile = NextTurn.Domain.Appointment.Entities.AppointmentProfile;
 using AppointmentProfileStaffAssignment = NextTurn.Domain.Appointment.Entities.AppointmentProfileStaffAssignment;
 using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.AppointmentScheduleRule;
@@ -55,6 +56,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
     // Appointment module (NT-19).
     public DbSet<AppointmentEntity> Appointments => Set<AppointmentEntity>();
+    public DbSet<AppointmentNotificationAuditLog> AppointmentNotificationAuditLogs => Set<AppointmentNotificationAuditLog>();
     public DbSet<AppointmentProfile> AppointmentProfiles => Set<AppointmentProfile>();
     public DbSet<AppointmentProfileStaffAssignment> AppointmentProfileStaffAssignments => Set<AppointmentProfileStaffAssignment>();
     public DbSet<AppointmentScheduleRule> AppointmentScheduleRules => Set<AppointmentScheduleRule>();
@@ -112,6 +114,9 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
         // Appointments: scoped by organisation (tenant).
         modelBuilder.Entity<AppointmentEntity>()
+            .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<AppointmentNotificationAuditLog>()
             .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
 
         modelBuilder.Entity<AppointmentProfile>()

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Appointment/AppointmentNotificationAuditLogConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Appointment/AppointmentNotificationAuditLogConfiguration.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
+using UserEntity = NextTurn.Domain.Auth.Entities.User;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Appointment;
+
+public sealed class AppointmentNotificationAuditLogConfiguration : IEntityTypeConfiguration<AppointmentNotificationAuditLog>
+{
+    public void Configure(EntityTypeBuilder<AppointmentNotificationAuditLog> builder)
+    {
+        builder.ToTable("AppointmentNotificationAuditLogs");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(x => x.OrganisationId)
+            .IsRequired();
+
+        builder.Property(x => x.AppointmentId)
+            .IsRequired();
+
+        builder.Property(x => x.UserId)
+            .IsRequired();
+
+        builder.Property(x => x.NotificationType)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(x => x.DeliveryStatus)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(x => x.RecipientEmail)
+            .IsRequired()
+            .HasMaxLength(254);
+
+        builder.Property(x => x.SlotStart)
+            .IsRequired();
+
+        builder.Property(x => x.SlotEnd)
+            .IsRequired();
+
+        builder.Property(x => x.OfficeName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(x => x.ServiceName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(x => x.ErrorMessage)
+            .HasMaxLength(500);
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne<AppointmentEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.AppointmentId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<UserEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.AppointmentId, x.NotificationType, x.DeliveryStatus })
+            .HasDatabaseName("IX_AppointmentNotificationAuditLogs_Appointment_Type_Status");
+
+        builder.HasIndex(x => new { x.OrganisationId, x.CreatedAt })
+            .HasDatabaseName("IX_AppointmentNotificationAuditLogs_Organisation_CreatedAt");
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
@@ -105,6 +105,18 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .IsRequired()
             .HasDefaultValue(true);
 
+        builder.Property(u => u.AppointmentBookedNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(u => u.AppointmentRescheduledNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(u => u.AppointmentCancelledNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
         builder.Property(u => u.StaffInviteTokenHash)
             .HasMaxLength(128);
 

--- a/src/web/src/api/auth.ts
+++ b/src/web/src/api/auth.ts
@@ -44,6 +44,12 @@ export interface QueueNotificationPreferenceResult {
   queueTurnApproachingNotificationsEnabled: boolean
 }
 
+export interface AppointmentNotificationPreferencesResult {
+  appointmentBookedNotificationsEnabled: boolean
+  appointmentRescheduledNotificationsEnabled: boolean
+  appointmentCancelledNotificationsEnabled: boolean
+}
+
 /**
  * Shape returned by POST /api/auth/login on HTTP 200.
  * Mirrors NextTurn.API.Models.Auth.LoginResponse on the backend.
@@ -303,6 +309,58 @@ export async function updateQueueNotificationPreference(
       { queueTurnApproachingNotificationsEnabled },
       { headers },
     )
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+/**
+ * GET /api/auth/appointment-notification-preferences
+ */
+export async function getAppointmentNotificationPreferences(
+  tenantId?: string,
+): Promise<AppointmentNotificationPreferencesResult> {
+  try {
+    const token = getToken()
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    if (tenantId) {
+      headers['X-Tenant-Id'] = tenantId
+    }
+
+    const { data } = await apiClient.get<AppointmentNotificationPreferencesResult>(
+      '/auth/appointment-notification-preferences',
+      { headers },
+    )
+
+    return data
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+/**
+ * PUT /api/auth/appointment-notification-preferences
+ */
+export async function updateAppointmentNotificationPreferences(
+  tenantId: string | undefined,
+  preferences: AppointmentNotificationPreferencesResult,
+): Promise<void> {
+  try {
+    const token = getToken()
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    if (tenantId) {
+      headers['X-Tenant-Id'] = tenantId
+    }
+
+    await apiClient.put('/auth/appointment-notification-preferences', preferences, { headers })
   } catch (err) {
     const parsed: ApiError = parseApiError(err)
     throw parsed

--- a/src/web/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/web/src/pages/Dashboard/DashboardPage.tsx
@@ -22,7 +22,12 @@ import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { clearToken } from '../../utils/authToken'
 import { getTokenPayload } from '../../utils/authToken'
-import { getQueueNotificationPreference, updateQueueNotificationPreference } from '../../api/auth'
+import {
+  getAppointmentNotificationPreferences,
+  getQueueNotificationPreference,
+  updateAppointmentNotificationPreferences,
+  updateQueueNotificationPreference,
+} from '../../api/auth'
 import { getMyQueues, type MyQueueEntry } from '../../api/queues'
 import { cancelAppointment, getMyAppointmentBookings, type MyAppointmentBooking } from '../../api/appointments'
 import type { ApiError } from '../../types/api'
@@ -69,6 +74,14 @@ export function DashboardPage() {
   const [notificationsMessage, setNotificationsMessage] = useState<string | null>(null)
   const [notificationsError, setNotificationsError] = useState<string | null>(null)
 
+  const [appointmentNotificationsLoading, setAppointmentNotificationsLoading] = useState(true)
+  const [appointmentNotificationsSaving, setAppointmentNotificationsSaving] = useState(false)
+  const [appointmentNotificationsMessage, setAppointmentNotificationsMessage] = useState<string | null>(null)
+  const [appointmentNotificationsError, setAppointmentNotificationsError] = useState<string | null>(null)
+  const [appointmentBookedNotificationsEnabled, setAppointmentBookedNotificationsEnabled] = useState(true)
+  const [appointmentRescheduledNotificationsEnabled, setAppointmentRescheduledNotificationsEnabled] = useState(true)
+  const [appointmentCancelledNotificationsEnabled, setAppointmentCancelledNotificationsEnabled] = useState(true)
+
   const tenantId = payload.tid === '00000000-0000-0000-0000-000000000000' ? undefined : payload.tid
 
   useEffect(() => {
@@ -88,6 +101,18 @@ export function DashboardPage() {
       .catch(() => {
         setNotificationsError('Could not load your queue notification setting.')
         setNotificationsLoading(false)
+      })
+
+    getAppointmentNotificationPreferences(tenantId)
+      .then(data => {
+        setAppointmentBookedNotificationsEnabled(data.appointmentBookedNotificationsEnabled)
+        setAppointmentRescheduledNotificationsEnabled(data.appointmentRescheduledNotificationsEnabled)
+        setAppointmentCancelledNotificationsEnabled(data.appointmentCancelledNotificationsEnabled)
+        setAppointmentNotificationsLoading(false)
+      })
+      .catch(() => {
+        setAppointmentNotificationsError('Could not load your appointment notification settings.')
+        setAppointmentNotificationsLoading(false)
       })
   }, [tenantId])
 
@@ -155,6 +180,26 @@ export function DashboardPage() {
       setNotificationsError(apiErr.detail ?? 'Could not save queue notification setting.')
     } finally {
       setNotificationsSaving(false)
+    }
+  }
+
+  async function handleSaveAppointmentNotificationPreferences() {
+    setAppointmentNotificationsError(null)
+    setAppointmentNotificationsMessage(null)
+    setAppointmentNotificationsSaving(true)
+
+    try {
+      await updateAppointmentNotificationPreferences(tenantId, {
+        appointmentBookedNotificationsEnabled,
+        appointmentRescheduledNotificationsEnabled,
+        appointmentCancelledNotificationsEnabled,
+      })
+      setAppointmentNotificationsMessage('Appointment notification preferences saved.')
+    } catch (err) {
+      const apiErr = err as ApiError
+      setAppointmentNotificationsError(apiErr.detail ?? 'Could not save appointment notification settings.')
+    } finally {
+      setAppointmentNotificationsSaving(false)
     }
   }
 
@@ -254,6 +299,70 @@ export function DashboardPage() {
 
                 {notificationsMessage && <p className={styles.queueSuccess}>{notificationsMessage}</p>}
                 {notificationsError && <p className={styles.queueError}>{notificationsError}</p>}
+              </>
+            )}
+          </section>
+
+          <section className={styles.settingsSection} aria-label="Appointment notification settings">
+            <div className={styles.sectionHeader}>
+              <CalendarIcon />
+              <h2 className={styles.sectionTitle}>Appointment Notifications</h2>
+            </div>
+
+            {appointmentNotificationsLoading && <p className={styles.queueEmpty}>Loading settings…</p>}
+
+            {!appointmentNotificationsLoading && (
+              <>
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={appointmentBookedNotificationsEnabled}
+                    onChange={e => {
+                      setAppointmentBookedNotificationsEnabled(e.target.checked)
+                      setAppointmentNotificationsMessage(null)
+                      setAppointmentNotificationsError(null)
+                    }}
+                  />
+                  <span>Email me booking confirmations.</span>
+                </label>
+
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={appointmentRescheduledNotificationsEnabled}
+                    onChange={e => {
+                      setAppointmentRescheduledNotificationsEnabled(e.target.checked)
+                      setAppointmentNotificationsMessage(null)
+                      setAppointmentNotificationsError(null)
+                    }}
+                  />
+                  <span>Email me when appointments are rescheduled.</span>
+                </label>
+
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={appointmentCancelledNotificationsEnabled}
+                    onChange={e => {
+                      setAppointmentCancelledNotificationsEnabled(e.target.checked)
+                      setAppointmentNotificationsMessage(null)
+                      setAppointmentNotificationsError(null)
+                    }}
+                  />
+                  <span>Email me when appointments are cancelled.</span>
+                </label>
+
+                <button
+                  type="button"
+                  className={styles.settingsSaveBtn}
+                  onClick={handleSaveAppointmentNotificationPreferences}
+                  disabled={appointmentNotificationsSaving}
+                >
+                  {appointmentNotificationsSaving ? 'Saving...' : 'Save preferences'}
+                </button>
+
+                {appointmentNotificationsMessage && <p className={styles.queueSuccess}>{appointmentNotificationsMessage}</p>}
+                {appointmentNotificationsError && <p className={styles.queueError}>{appointmentNotificationsError}</p>}
               </>
             )}
           </section>

--- a/tests/NextTurn.IntegrationTests/Appointment/AppointmentNotificationFlowIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Appointment/AppointmentNotificationFlowIntegrationTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Domain.Appointment.Entities;
+using NextTurn.Domain.Auth;
+using NextTurn.Infrastructure.Persistence;
+
+namespace NextTurn.IntegrationTests.Appointment;
+
+[Collection("Integration")]
+[Trait("Suite", "Regression")]
+[Trait("Type", "Full")]
+[Trait("Layer", "Integration")]
+public sealed class AppointmentNotificationFlowIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+    private Guid _appointmentProfileId;
+
+    public AppointmentNotificationFlowIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _) = await _factory.SeedQueueAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profile = AppointmentProfile.Create(_tenantId, "Passport Service");
+        db.AppointmentProfiles.Add(profile);
+        await db.SaveChangesAsync();
+
+        _appointmentProfileId = profile.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task BookAppointment_WritesBookedNotificationAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+        var (slotStart, slotEnd) = SlotForTomorrow(9, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart,
+            slotEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var audit = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.AppointmentId == booked!.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Booked");
+
+        audit.Should().NotBeNull();
+        audit!.DeliveryStatus.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task RescheduleAppointment_WritesRescheduledNotificationAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+
+        var (oldStart, oldEnd) = SlotForTomorrow(10, 0);
+        var (newStart, newEnd) = SlotForTomorrow(11, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart = oldStart,
+            slotEnd = oldEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        var reschedule = await client.PutAsJsonAsync($"/api/appointments/{booked!.AppointmentId}/reschedule", new
+        {
+            newSlotStart = newStart,
+            newSlotEnd = newEnd,
+        });
+
+        reschedule.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rescheduled = await reschedule.Content.ReadFromJsonAsync<RescheduleAppointmentApiResult>();
+        rescheduled.Should().NotBeNull();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var audit = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.AppointmentId == rescheduled!.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Rescheduled");
+
+        audit.Should().NotBeNull();
+        audit!.DeliveryStatus.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task CancelAppointment_WritesCancelledNotificationAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+        var (slotStart, slotEnd) = SlotForTomorrow(12, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart,
+            slotEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        var cancel = await client.PostAsync($"/api/appointments/{booked!.AppointmentId}/cancel", null);
+        cancel.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var audit = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.AppointmentId == booked.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Cancelled");
+
+        audit.Should().NotBeNull();
+        audit!.DeliveryStatus.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task BookAppointment_WhenBookedPreferenceDisabled_DoesNotWriteAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+
+        var preferencesUpdate = await client.PutAsJsonAsync("/api/auth/appointment-notification-preferences", new
+        {
+            appointmentBookedNotificationsEnabled = false,
+            appointmentRescheduledNotificationsEnabled = true,
+            appointmentCancelledNotificationsEnabled = true,
+        });
+
+        preferencesUpdate.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var (slotStart, slotEnd) = SlotForTomorrow(13, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart,
+            slotEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var exists = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .AnyAsync(a =>
+                a.AppointmentId == booked!.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Booked");
+
+        exists.Should().BeFalse();
+    }
+
+    private HttpClient AuthenticatedClient(UserRole role, Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(role, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private static (DateTimeOffset SlotStart, DateTimeOffset SlotEnd) SlotForTomorrow(int hour, int minute)
+    {
+        var date = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        var slotStart = new DateTimeOffset(date.ToDateTime(new TimeOnly(hour, minute)), TimeSpan.Zero);
+        var slotEnd = slotStart.AddMinutes(30);
+        return (slotStart, slotEnd);
+    }
+
+    private sealed record BookAppointmentApiResult(Guid AppointmentId);
+
+    private sealed record RescheduleAppointmentApiResult(Guid AppointmentId, DateTimeOffset SlotStart, DateTimeOffset SlotEnd);
+}

--- a/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationHandlersTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationHandlersTests.cs
@@ -1,0 +1,64 @@
+using MediatR;
+using Moq;
+using NextTurn.Application.Appointment.Commands.BookAppointment;
+using NextTurn.Application.Appointment.Commands.CancelAppointment;
+using NextTurn.Application.Appointment.Commands.RescheduleAppointment;
+using NextTurn.Application.Appointment.Notifications;
+
+namespace NextTurn.UnitTests.Application.Appointment;
+
+public sealed class AppointmentNotificationHandlersTests
+{
+    private readonly Mock<IAppointmentNotificationService> _notificationServiceMock = new();
+
+    [Fact]
+    public async Task AppointmentBookedNotificationHandler_DelegatesToService()
+    {
+        var appointmentId = Guid.NewGuid();
+        var handler = new AppointmentBookedNotificationHandler(_notificationServiceMock.Object);
+
+        await handler.Handle(new AppointmentBookedNotification(appointmentId), CancellationToken.None);
+
+        _notificationServiceMock.Verify(s => s.SendBookingConfirmationAsync(appointmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AppointmentRescheduledNotificationHandler_DelegatesToService()
+    {
+        var appointmentId = Guid.NewGuid();
+        var handler = new AppointmentRescheduledNotificationHandler(_notificationServiceMock.Object);
+
+        await handler.Handle(
+            new AppointmentRescheduledNotification(
+                Guid.NewGuid(),
+                appointmentId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddMinutes(30),
+                DateTimeOffset.UtcNow.AddDays(1),
+                DateTimeOffset.UtcNow.AddDays(1).AddMinutes(30)),
+            CancellationToken.None);
+
+        _notificationServiceMock.Verify(s => s.SendRescheduleUpdateAsync(appointmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AppointmentCancelledNotificationHandler_DelegatesToService()
+    {
+        var appointmentId = Guid.NewGuid();
+        var handler = new AppointmentCancelledNotificationHandler(_notificationServiceMock.Object);
+
+        await handler.Handle(
+            new AppointmentCancelledNotification(
+                appointmentId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddMinutes(30),
+                false),
+            CancellationToken.None);
+
+        _notificationServiceMock.Verify(s => s.SendCancellationUpdateAsync(appointmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationServiceTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationServiceTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NextTurn.Application.Appointment.Notifications;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Appointment.Entities;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Organisation.Enums;
+using NextTurn.Domain.Organisation.ValueObjects;
+using NextTurn.UnitTests.Helpers;
+using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
+
+namespace NextTurn.UnitTests.Application.Appointment;
+
+public sealed class AppointmentNotificationServiceTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+    private readonly Mock<ILogger<AppointmentNotificationService>> _loggerMock = new();
+
+    [Fact]
+    public async Task SendBookingConfirmationAsync_WhenEnabled_SendsEmailAndWritesSentAudit()
+    {
+        var setup = BuildSetup();
+        var addedLogs = new List<AppointmentNotificationAuditLog>();
+
+        var auditDbSetMock = AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentNotificationAuditLog>());
+        auditDbSetMock
+            .Setup(s => s.Add(It.IsAny<AppointmentNotificationAuditLog>()))
+            .Callback<AppointmentNotificationAuditLog>(log => addedLogs.Add(log));
+
+        _contextMock.Setup(c => c.Appointments).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Appointment }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.User }).Object);
+        _contextMock.Setup(c => c.AppointmentProfiles).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Profile }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Organisation }).Object);
+        _contextMock.Setup(c => c.AppointmentNotificationAuditLogs).Returns(auditDbSetMock.Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendBookingConfirmationAsync(setup.Appointment.Id, CancellationToken.None);
+
+        _emailServiceMock.Verify(
+            e => e.SendAppointmentStatusEmailAsync(
+                setup.User.Email.Value,
+                setup.User.Name,
+                "Booked",
+                setup.Appointment.SlotStart,
+                setup.Appointment.SlotEnd,
+                setup.Organisation.Name,
+                setup.Profile.Name,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        addedLogs.Should().ContainSingle();
+        addedLogs[0].DeliveryStatus.Should().Be("Sent");
+        addedLogs[0].NotificationType.Should().Be("Booked");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendBookingConfirmationAsync_WhenPreferenceDisabled_SkipsDeliveryAndAudit()
+    {
+        var setup = BuildSetup();
+        setup.User.SetAppointmentNotificationPreferences(false, true, true);
+
+        _contextMock.Setup(c => c.Appointments).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Appointment }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.User }).Object);
+        _contextMock.Setup(c => c.AppointmentProfiles).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Profile }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Organisation }).Object);
+        _contextMock.Setup(c => c.AppointmentNotificationAuditLogs)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentNotificationAuditLog>()).Object);
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendBookingConfirmationAsync(setup.Appointment.Id, CancellationToken.None);
+
+        _emailServiceMock.Verify(
+            e => e.SendAppointmentStatusEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendRescheduleUpdateAsync_WhenEmailFails_WritesFailedAudit()
+    {
+        var setup = BuildSetup();
+        var addedLogs = new List<AppointmentNotificationAuditLog>();
+
+        var auditDbSetMock = AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentNotificationAuditLog>());
+        auditDbSetMock
+            .Setup(s => s.Add(It.IsAny<AppointmentNotificationAuditLog>()))
+            .Callback<AppointmentNotificationAuditLog>(log => addedLogs.Add(log));
+
+        _contextMock.Setup(c => c.Appointments).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Appointment }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.User }).Object);
+        _contextMock.Setup(c => c.AppointmentProfiles).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Profile }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Organisation }).Object);
+        _contextMock.Setup(c => c.AppointmentNotificationAuditLogs).Returns(auditDbSetMock.Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        _emailServiceMock
+            .Setup(e => e.SendAppointmentStatusEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("smtp down"));
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendRescheduleUpdateAsync(setup.Appointment.Id, CancellationToken.None);
+
+        addedLogs.Should().ContainSingle();
+        addedLogs[0].DeliveryStatus.Should().Be("Failed");
+        addedLogs[0].NotificationType.Should().Be("Rescheduled");
+        addedLogs[0].ErrorMessage.Should().Contain("smtp down");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCancellationUpdateAsync_WhenAppointmentMissing_DoesNothing()
+    {
+        _contextMock.Setup(c => c.Appointments)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentEntity>()).Object);
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendCancellationUpdateAsync(Guid.NewGuid(), CancellationToken.None);
+
+        _emailServiceMock.Verify(
+            e => e.SendAppointmentStatusEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static (AppointmentEntity Appointment, User User, AppointmentProfile Profile, OrganisationEntity Organisation) BuildSetup()
+    {
+        var organisation = OrganisationEntity.Create(
+            "City Office",
+            "city-office",
+            new Address("1 Main", "Colombo", "10000", "LK"),
+            OrganisationType.Government,
+            new EmailAddress("admin@city.gov"));
+
+        var user = User.Create(organisation.Id, "Alice", new EmailAddress("alice@example.com"), null, "hash");
+        var profile = AppointmentProfile.Create(organisation.Id, "Passport Service");
+
+        var appointment = AppointmentEntity.Create(
+            organisation.Id,
+            profile.Id,
+            user.Id,
+            DateTimeOffset.UtcNow.AddDays(2),
+            DateTimeOffset.UtcNow.AddDays(2).AddMinutes(30));
+
+        return (appointment, user, profile, organisation);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Appointment/BookAppointmentCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/BookAppointmentCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using NextTurn.Application.Appointment.Commands.BookAppointment;
@@ -13,6 +14,7 @@ public sealed class BookAppointmentCommandHandlerTests
 {
     private readonly Mock<IAppointmentRepository> _appointmentRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<IPublisher> _publisherMock = new();
 
     private readonly BookAppointmentCommandHandler _handler;
 
@@ -45,7 +47,14 @@ public sealed class BookAppointmentCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        _handler = new BookAppointmentCommandHandler(_appointmentRepositoryMock.Object, _contextMock.Object);
+        _publisherMock
+            .Setup(p => p.Publish(It.IsAny<AppointmentBookedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new BookAppointmentCommandHandler(
+            _appointmentRepositoryMock.Object,
+            _contextMock.Object,
+            _publisherMock.Object);
     }
 
     [Fact]
@@ -73,6 +82,9 @@ public sealed class BookAppointmentCommandHandlerTests
             Times.Once);
 
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AppointmentBookedNotification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -89,6 +101,9 @@ public sealed class BookAppointmentCommandHandlerTests
 
         _appointmentRepositoryMock.Verify(r => r.AddAsync(It.IsAny<AppointmentEntity>(), It.IsAny<CancellationToken>()), Times.Never);
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AppointmentBookedNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Application/Auth/GetAppointmentNotificationPreferencesQueryHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Auth/GetAppointmentNotificationPreferencesQueryHandlerTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.UnitTests.Helpers;
+
+namespace NextTurn.UnitTests.Application.Auth;
+
+public sealed class GetAppointmentNotificationPreferencesQueryHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenUserExists_ReturnsPreferences()
+    {
+        var user = User.Create(Guid.NewGuid(), "Member", new EmailAddress("member@example.com"), null, "hash");
+        user.SetAppointmentNotificationPreferences(false, true, false);
+
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { user }).Object);
+
+        var handler = new GetAppointmentNotificationPreferencesQueryHandler(_contextMock.Object);
+        var result = await handler.Handle(new GetAppointmentNotificationPreferencesQuery(user.Id), CancellationToken.None);
+
+        result.AppointmentBookedNotificationsEnabled.Should().BeFalse();
+        result.AppointmentRescheduledNotificationsEnabled.Should().BeTrue();
+        result.AppointmentCancelledNotificationsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<User>()).Object);
+
+        var handler = new GetAppointmentNotificationPreferencesQueryHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(new GetAppointmentNotificationPreferencesQuery(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("User not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Auth/UpdateAppointmentNotificationPreferencesCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Auth/UpdateAppointmentNotificationPreferencesCommandHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using MediatR;
+using Moq;
+using NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.UnitTests.Helpers;
+
+namespace NextTurn.UnitTests.Application.Auth;
+
+public sealed class UpdateAppointmentNotificationPreferencesCommandHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenUserExists_UpdatesPreferencesAndSaves()
+    {
+        var user = User.Create(Guid.NewGuid(), "Member", new EmailAddress("member@example.com"), null, "hash");
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { user }).Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = new UpdateAppointmentNotificationPreferencesCommandHandler(_contextMock.Object);
+
+        var result = await handler.Handle(
+            new UpdateAppointmentNotificationPreferencesCommand(user.Id, false, false, true),
+            CancellationToken.None);
+
+        result.Should().Be(Unit.Value);
+        user.AppointmentBookedNotificationsEnabled.Should().BeFalse();
+        user.AppointmentRescheduledNotificationsEnabled.Should().BeFalse();
+        user.AppointmentCancelledNotificationsEnabled.Should().BeTrue();
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<User>()).Object);
+
+        var handler = new UpdateAppointmentNotificationPreferencesCommandHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(
+            new UpdateAppointmentNotificationPreferencesCommand(Guid.NewGuid(), true, true, true),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("User not found.");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/NextTurn.UnitTests/Domain/Appointment/AppointmentNotificationAuditLogTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Appointment/AppointmentNotificationAuditLogTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NextTurn.Domain.Appointment.Entities;
+
+namespace NextTurn.UnitTests.Domain.Appointment;
+
+public sealed class AppointmentNotificationAuditLogTests
+{
+    [Fact]
+    public void Sent_CreatesSuccessfulAuditRecord()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var log = AppointmentNotificationAuditLog.Sent(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Booked",
+            "user@example.com",
+            DateTimeOffset.UtcNow.AddDays(1),
+            DateTimeOffset.UtcNow.AddDays(1).AddMinutes(30),
+            "City Office",
+            "Passport Service");
+
+        var after = DateTimeOffset.UtcNow;
+
+        log.Id.Should().NotBeEmpty();
+        log.DeliveryStatus.Should().Be("Sent");
+        log.NotificationType.Should().Be("Booked");
+        log.ErrorMessage.Should().BeNull();
+        log.CreatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public void Failed_NormalizesAndTruncatesErrorMessage()
+    {
+        var longMessage = " " + new string('x', 600) + " ";
+
+        var log = AppointmentNotificationAuditLog.Failed(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Cancelled",
+            "user@example.com",
+            DateTimeOffset.UtcNow.AddDays(1),
+            DateTimeOffset.UtcNow.AddDays(1).AddMinutes(30),
+            "City Office",
+            "Passport Service",
+            longMessage);
+
+        log.DeliveryStatus.Should().Be("Failed");
+        log.NotificationType.Should().Be("Cancelled");
+        log.ErrorMessage.Should().NotBeNull();
+        log.ErrorMessage!.Length.Should().Be(500);
+    }
+}

--- a/tests/NextTurn.UnitTests/Domain/Auth/UserTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Auth/UserTests.cs
@@ -187,6 +187,16 @@ public sealed class UserTests
     }
 
     [Fact]
+    public void Create_SetsAppointmentNotificationPreferencesToTrue()
+    {
+        var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
+
+        user.AppointmentBookedNotificationsEnabled.Should().BeTrue();
+        user.AppointmentRescheduledNotificationsEnabled.Should().BeTrue();
+        user.AppointmentCancelledNotificationsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
     public void SetQueueTurnApproachingNotificationsEnabled_UpdatesPreference()
     {
         var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
@@ -194,6 +204,18 @@ public sealed class UserTests
         user.SetQueueTurnApproachingNotificationsEnabled(false);
 
         user.QueueTurnApproachingNotificationsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetAppointmentNotificationPreferences_UpdatesAllAppointmentPreferences()
+    {
+        var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
+
+        user.SetAppointmentNotificationPreferences(false, true, false);
+
+        user.AppointmentBookedNotificationsEnabled.Should().BeFalse();
+        user.AppointmentRescheduledNotificationsEnabled.Should().BeTrue();
+        user.AppointmentCancelledNotificationsEnabled.Should().BeFalse();
     }
 
     // ── RecordFailedLogin ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR implements appointment confirmation and status notifications end-to-end, including:

- Event-driven notification handling in the Application layer for booking, reschedule, and cancellation flows
- Per-notification-type user preferences (booked, rescheduled, cancelled)
- Delivery auditing in a dedicated appointment notification audit table/entity
- API endpoints + frontend settings UI to view/update appointment notification preferences
- Unit and integration test coverage for service behavior and event-to-notification flow

This work addresses the story:
As a user, I want to receive confirmation and status updates for my appointments.


## Problem Statement
Appointment workflows previously had no real outbound notification behavior and no audit history for deliveries. Reschedule/cancel events existed as logging stubs only, and users could not manage appointment-specific notification preferences.


## What Changed

### 1. Domain and Persistence: Appointment Notification Audit + Preference Fields
Implemented foundational persistence for delivery tracking and user preference state.

- Added AppointmentNotificationAuditLog domain entity with Sent and Failed factory methods
- Added EF configuration for audit table mapping/indexing
- Exposed audit DbSet in application/infrastructure DbContext abstractions
- Added user preference fields for:
  - AppointmentBookedNotificationsEnabled
  - AppointmentRescheduledNotificationsEnabled
  - AppointmentCancelledNotificationsEnabled
- Added EF configuration defaults for new user preference columns
- Added/updated domain unit tests for:
  - AppointmentNotificationAuditLog behavior
  - User defaults and preference mutation

Commit: 9916330


### 2. Application Layer: Event-Driven Notification Delivery
Implemented the notification engine and wired appointment events into it.

- Added AppointmentBookedNotification event and handler
- Updated BookAppointmentCommandHandler to publish booking notification event after successful persistence
- Replaced reschedule/cancel log-only handlers to call notification service
- Added AppointmentNotificationService (application service) to:
  - Resolve appointment, user, profile, organisation context
  - Respect user preference flags by notification type
  - Send status email through IEmailService
  - Write Sent/Failed audit records
- Extended email service contract with appointment status delivery method
- Added stub email implementation for appointment status notifications
- Registered appointment notification service in DI
- Added/updated unit tests for:
  - Booking command publishing
  - Notification handlers delegating correctly
  - Notification service behavior (success, skip, failure, missing appointment)

Commit: 22fb708


### 3. API + Frontend: User Preference Management
Added appointment notification preference endpoints and dashboard controls.

- New authenticated API endpoints:
  - GET appointment-notification-preferences
  - PUT appointment-notification-preferences
- Added request model + application query/command + validator + handlers for preference read/update
- Frontend auth API client support for preference fetch/update
- Dashboard settings UI extended with appointment notification toggles:
  - Booking confirmations
  - Reschedule updates
  - Cancellation updates

Commit: e08deb0


### 4. Integration Tests: Event-to-Notification Flow
Added integration tests validating that appointment lifecycle actions generate expected audit records.

- Added flow tests for:
  - Book -> booked notification audit row
  - Reschedule -> rescheduled notification audit row
  - Cancel -> cancelled notification audit row
  - Preference disabled -> no audit row for disabled type

Commit: 91a3910


## Acceptance Criteria Mapping

- Notification sent on successful booking with date, time, office, and service details
  - Implemented via AppointmentNotificationService and appointment status email payload/context resolution.
- Notifications also sent on reschedule and cancellation
  - Implemented via reschedule/cancel notification handlers delegating to the service.
- User can enable/disable notification types in settings
  - Implemented in User model + Auth API + Dashboard settings.
- Delivery logged in audit table
  - Implemented via AppointmentNotificationAuditLog Sent/Failed writes in service.


## Definition of Done Mapping

- Implemented as event-driven handlers in Application layer
  - Completed (booking/reschedule/cancel event handlers + notification service).
- Unit tests >=80% coverage
  - Completed.
  - CI-equivalent local run:
    - Line coverage: 83.0%
    - Branch coverage: 82.1%
- Integration tests verify event-to-notification flow
  - Test suite added and compiles.
  - Execution blocked in this environment due to Docker/Testcontainers unavailable.
- Code reviewed and merged
  - Pending PR review/merge process.
- Demo: book -> see email confirmation
  - Ready using stub sender (logs/audits delivery path).
- Confluence updated
  - Pending manual documentation update.
- No open bugs
  - No unit-test or build failures in implemented scope.


## Testing Performed

### Unit tests
- Ran unit test suite in Release configuration
- Result: 622 passed, 0 failed

### Coverage (CI-equivalent flow)
- Build solution in Release
- Run unit tests with coverlet runsettings
- Generate Cobertura + markdown + HTML report
- Parsed gate results:
  - Line coverage: 83.0%
  - Branch coverage: 82.1%
  - Gate status: PASS

### Integration tests
- Targeted notification flow integration tests executed command-wise
- Blocker encountered: Docker/Testcontainers not available in current environment
- Status: added and compile-verified, runtime execution pending in Docker-enabled CI/dev machine

### Frontend
- Built web app successfully with Vite/TypeScript production build


## Risk and Impact
- Low to medium risk in appointment flows due to new event delivery side effects
- Mitigations:
  - Audit trail for every attempted notification
  - Preference-based gating
  - Unit tests around success/failure/skip logic
  - Integration flow tests added


## Commit Breakdown
- 9916330: Add appointment notification audit model and user preference fields
- 22fb708: Implement event-driven appointment notification handlers and service
- e08deb0: Add appointment notification preference endpoints and dashboard settings
- 91a3910: Add integration tests for appointment notification event flow