### PR TITLE
NT-28: Daily Queue Summary Report with Office/Service Breakdown and Trend Analytics

### DIFF
--- a/src/NextTurn.API/Controllers/AuthController.cs
+++ b/src/NextTurn.API/Controllers/AuthController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 using NextTurn.API.Models.Auth;
 using NextTurn.Application.Auth;
+using NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
 using NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
 using NextTurn.Application.Auth.Commands.CreateStaffUser;
 using NextTurn.Application.Auth.Commands.InviteStaffUser;
@@ -16,6 +17,7 @@ using NextTurn.Application.Auth.Commands.ReactivateStaffUser;
 using NextTurn.Application.Auth.Commands.RegisterGlobalUser;
 using NextTurn.Application.Auth.Commands.RegisterUser;
 using NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
+using NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
 using NextTurn.Application.Auth.Queries.ListStaffUsers;
 
 namespace NextTurn.API.Controllers;
@@ -343,6 +345,48 @@ public sealed class AuthController : ControllerBase
             new UpdateQueueNotificationPreferenceCommand(
                 userId,
                 request.QueueTurnApproachingNotificationsEnabled),
+            cancellationToken);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets the authenticated user's appointment notification preferences.
+    /// </summary>
+    [HttpGet("appointment-notification-preferences")]
+    [Authorize]
+    [ProducesResponseType(typeof(AppointmentNotificationPreferencesResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetAppointmentNotificationPreferences(CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(out var userId))
+            return Unauthorized();
+
+        var result = await _sender.Send(new GetAppointmentNotificationPreferencesQuery(userId), cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Updates the authenticated user's appointment notification preferences.
+    /// </summary>
+    [HttpPut("appointment-notification-preferences")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> UpdateAppointmentNotificationPreferences(
+        [FromBody] UpdateAppointmentNotificationPreferencesRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(out var userId))
+            return Unauthorized();
+
+        await _sender.Send(
+            new UpdateAppointmentNotificationPreferencesCommand(
+                userId,
+                request.AppointmentBookedNotificationsEnabled,
+                request.AppointmentRescheduledNotificationsEnabled,
+                request.AppointmentCancelledNotificationsEnabled),
             cancellationToken);
 
         return NoContent();

--- a/src/NextTurn.API/Controllers/AuthController.cs
+++ b/src/NextTurn.API/Controllers/AuthController.cs
@@ -2,8 +2,10 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using System.Security.Claims;
 using NextTurn.API.Models.Auth;
 using NextTurn.Application.Auth;
+using NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
 using NextTurn.Application.Auth.Commands.CreateStaffUser;
 using NextTurn.Application.Auth.Commands.InviteStaffUser;
 using NextTurn.Application.Auth.Commands.AcceptStaffInvite;
@@ -13,6 +15,7 @@ using NextTurn.Application.Auth.Commands.LoginUser;
 using NextTurn.Application.Auth.Commands.ReactivateStaffUser;
 using NextTurn.Application.Auth.Commands.RegisterGlobalUser;
 using NextTurn.Application.Auth.Commands.RegisterUser;
+using NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
 using NextTurn.Application.Auth.Queries.ListStaffUsers;
 
 namespace NextTurn.API.Controllers;
@@ -36,6 +39,14 @@ public sealed class AuthController : ControllerBase
     public AuthController(ISender sender)
     {
         _sender = sender;
+    }
+
+    private bool TryGetUserId(out Guid userId)
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                          ?? User.FindFirstValue("sub");
+
+        return Guid.TryParse(userIdClaim, out userId);
     }
 
     /// <summary>
@@ -294,6 +305,46 @@ public sealed class AuthController : ControllerBase
         CancellationToken cancellationToken)
     {
         await _sender.Send(new ReactivateStaffUserCommand(userId), cancellationToken);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets the authenticated user's queue notification preference.
+    /// </summary>
+    [HttpGet("notification-preferences")]
+    [Authorize]
+    [ProducesResponseType(typeof(QueueNotificationPreferenceResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetNotificationPreference(CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(out var userId))
+            return Unauthorized();
+
+        var result = await _sender.Send(new GetQueueNotificationPreferenceQuery(userId), cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Updates the authenticated user's queue notification preference.
+    /// </summary>
+    [HttpPut("notification-preferences")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> UpdateNotificationPreference(
+        [FromBody] UpdateQueueNotificationPreferenceRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(out var userId))
+            return Unauthorized();
+
+        await _sender.Send(
+            new UpdateQueueNotificationPreferenceCommand(
+                userId,
+                request.QueueTurnApproachingNotificationsEnabled),
+            cancellationToken);
+
         return NoContent();
     }
 }

--- a/src/NextTurn.API/Controllers/OrganisationsController.cs
+++ b/src/NextTurn.API/Controllers/OrganisationsController.cs
@@ -1,8 +1,11 @@
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using NextTurn.API.Models.Organisations;
+using NextTurn.Application.Organisation.Commands.UpdateQueueNotificationThreshold;
 using NextTurn.Application.Organisation.Commands.RegisterOrganisation;
+using NextTurn.Application.Organisation.Queries.GetQueueNotificationThreshold;
 using NextTurn.Application.Organisation.Queries.ResolveMemberLogin;
 using NextTurn.Application.Organisation.Queries.ResolveOrganisationLogin;
 using NextTurn.Application.Organisation.Queries.ResolveOrganisationTenant;
@@ -28,6 +31,12 @@ public sealed class OrganisationsController : ControllerBase
     public OrganisationsController(ISender sender)
     {
         _sender = sender;
+    }
+
+    private bool TryGetOrganisationId(out Guid organisationId)
+    {
+        var tenantIdClaim = User.FindFirstValue("tid");
+        return Guid.TryParse(tenantIdClaim, out organisationId);
     }
 
     /// <summary>
@@ -124,5 +133,45 @@ public sealed class OrganisationsController : ControllerBase
         var query = new ResolveOrganisationTenantQuery(slug);
         var result = await _sender.Send(query, cancellationToken);
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Gets queue turn-approaching notification threshold for the authenticated organisation.
+    /// </summary>
+    [HttpGet("notification-threshold")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(typeof(QueueNotificationThresholdResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetQueueNotificationThreshold(CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var result = await _sender.Send(new GetQueueNotificationThresholdQuery(organisationId), cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Updates queue turn-approaching notification threshold for the authenticated organisation.
+    /// </summary>
+    [HttpPut("notification-threshold")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> UpdateQueueNotificationThreshold(
+        [FromBody] UpdateQueueNotificationThresholdRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        await _sender.Send(
+            new UpdateQueueNotificationThresholdCommand(organisationId, request.QueueNotificationThreshold),
+            cancellationToken);
+
+        return NoContent();
     }
 }

--- a/src/NextTurn.API/Controllers/QueuesController.cs
+++ b/src/NextTurn.API/Controllers/QueuesController.cs
@@ -15,7 +15,9 @@ using NextTurn.Application.Queue.Commands.Skip;
 using NextTurn.Application.Queue.Commands.AssignStaffToQueue;
 using NextTurn.Application.Queue.Commands.UnassignStaffFromQueue;
 using NextTurn.Application.Queue.Commands;
+using NextTurn.Application.Queue.Queries.ExportQueuePerformanceReportCsv;
 using NextTurn.Application.Queue.Queries.GetQueueDashboard;
+using NextTurn.Application.Queue.Queries.GetQueuePerformanceReport;
 using NextTurn.Application.Queue.Queries.GetMyQueues;
 using NextTurn.Application.Queue.Queries.GetQueueStatus;
 using NextTurn.Application.Queue.Queries.ListOrgQueues;
@@ -237,6 +239,58 @@ public sealed class QueuesController : ControllerBase
         var result = await _sender.Send(query, cancellationToken);
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Returns queue performance summary (average wait time and peak hours) for the tenant.
+    /// </summary>
+    [HttpGet("reports/performance")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> GetQueuePerformanceReport(
+        [FromQuery] DateOnly startDate,
+        [FromQuery] DateOnly endDate,
+        [FromQuery] Guid? serviceId,
+        [FromQuery] Guid? officeId,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var result = await _sender.Send(
+            new QueuePerformanceReportQuery(organisationId, startDate, endDate, serviceId, officeId),
+            cancellationToken);
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Exports queue performance summary as CSV.
+    /// </summary>
+    [HttpGet("reports/performance/export")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> ExportQueuePerformanceReport(
+        [FromQuery] DateOnly startDate,
+        [FromQuery] DateOnly endDate,
+        [FromQuery] Guid? serviceId,
+        [FromQuery] Guid? officeId,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var csv = await _sender.Send(
+            new ExportQueuePerformanceReportCsvQuery(organisationId, startDate, endDate, serviceId, officeId),
+            cancellationToken);
+
+        return File(csv.Content, csv.ContentType, csv.FileName);
     }
 
     /// <summary>

--- a/src/NextTurn.API/Controllers/QueuesController.cs
+++ b/src/NextTurn.API/Controllers/QueuesController.cs
@@ -16,6 +16,7 @@ using NextTurn.Application.Queue.Commands.AssignStaffToQueue;
 using NextTurn.Application.Queue.Commands.UnassignStaffFromQueue;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Application.Queue.Queries.ExportQueuePerformanceReportCsv;
+using NextTurn.Application.Queue.Queries.GetDailySummaryReport;
 using NextTurn.Application.Queue.Queries.GetQueueDashboard;
 using NextTurn.Application.Queue.Queries.GetQueuePerformanceReport;
 using NextTurn.Application.Queue.Queries.GetMyQueues;
@@ -294,6 +295,31 @@ public sealed class QueuesController : ControllerBase
     }
 
     /// <summary>
+    /// Returns daily queue summary with office/service breakdown and trend indicators.
+    /// </summary>
+    [HttpGet("reports/daily-summary")]
+    [Authorize(Roles = "OrgAdmin,SystemAdmin")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> GetDailySummaryReport(
+        [FromQuery] DateOnly? date,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetOrganisationId(out var organisationId))
+            return Unauthorized();
+
+        var reportDate = date ?? DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var result = await _sender.Send(
+            new DailySummaryReportQuery(organisationId, reportDate),
+            cancellationToken);
+
+        return Ok(result);
+    }
+
+    /// <summary>
     /// List all active queues for the authenticated user's organisation.
     /// Accessible to any authenticated role so regular users can browse
     /// available queues on their dashboard without needing OrgAdmin rights.
@@ -568,7 +594,7 @@ public sealed class QueuesController : ControllerBase
                 return Forbid();
         }
 
-        var command = new MarkNoShowCommand(queueId);
+        var command = new MarkNoShowCommand(queueId, userId);
         var result = await _sender.Send(command, cancellationToken);
         return Ok(result);
     }

--- a/src/NextTurn.API/Models/Auth/UpdateAppointmentNotificationPreferencesRequest.cs
+++ b/src/NextTurn.API/Models/Auth/UpdateAppointmentNotificationPreferencesRequest.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.API.Models.Auth;
+
+public sealed record UpdateAppointmentNotificationPreferencesRequest(
+    bool AppointmentBookedNotificationsEnabled,
+    bool AppointmentRescheduledNotificationsEnabled,
+    bool AppointmentCancelledNotificationsEnabled);

--- a/src/NextTurn.API/Models/Auth/UpdateQueueNotificationPreferenceRequest.cs
+++ b/src/NextTurn.API/Models/Auth/UpdateQueueNotificationPreferenceRequest.cs
@@ -1,0 +1,4 @@
+namespace NextTurn.API.Models.Auth;
+
+public sealed record UpdateQueueNotificationPreferenceRequest(
+    bool QueueTurnApproachingNotificationsEnabled);

--- a/src/NextTurn.API/Models/Organisations/UpdateQueueNotificationThresholdRequest.cs
+++ b/src/NextTurn.API/Models/Organisations/UpdateQueueNotificationThresholdRequest.cs
@@ -1,0 +1,3 @@
+namespace NextTurn.API.Models.Organisations;
+
+public sealed record UpdateQueueNotificationThresholdRequest(int QueueNotificationThreshold);

--- a/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotification.cs
+++ b/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotification.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace NextTurn.Application.Appointment.Commands.BookAppointment;
+
+/// <summary>
+/// In-process event published after an appointment is successfully booked.
+/// </summary>
+public sealed record AppointmentBookedNotification(Guid AppointmentId) : INotification;

--- a/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/BookAppointment/AppointmentBookedNotificationHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using NextTurn.Application.Appointment.Notifications;
+
+namespace NextTurn.Application.Appointment.Commands.BookAppointment;
+
+public sealed class AppointmentBookedNotificationHandler
+    : INotificationHandler<AppointmentBookedNotification>
+{
+    private readonly IAppointmentNotificationService _appointmentNotificationService;
+
+    public AppointmentBookedNotificationHandler(IAppointmentNotificationService appointmentNotificationService)
+    {
+        _appointmentNotificationService = appointmentNotificationService;
+    }
+
+    public Task Handle(AppointmentBookedNotification notification, CancellationToken cancellationToken)
+    {
+        return _appointmentNotificationService.SendBookingConfirmationAsync(notification.AppointmentId, cancellationToken);
+    }
+}

--- a/src/NextTurn.Application/Appointment/Commands/BookAppointment/BookAppointmentCommandHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/BookAppointment/BookAppointmentCommandHandler.cs
@@ -14,13 +14,16 @@ public sealed class BookAppointmentCommandHandler : IRequestHandler<BookAppointm
 {
     private readonly IAppointmentRepository _appointmentRepository;
     private readonly IApplicationDbContext _context;
+    private readonly IPublisher _publisher;
 
     public BookAppointmentCommandHandler(
         IAppointmentRepository appointmentRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        IPublisher publisher)
     {
         _appointmentRepository = appointmentRepository;
         _context = context;
+        _publisher = publisher;
     }
 
     public async Task<BookAppointmentResult> Handle(
@@ -64,6 +67,8 @@ public sealed class BookAppointmentCommandHandler : IRequestHandler<BookAppointm
         {
             throw new ConflictDomainException("This time slot is already booked.");
         }
+
+        await _publisher.Publish(new AppointmentBookedNotification(appointment.Id), cancellationToken);
 
         return new BookAppointmentResult(appointment.Id);
     }

--- a/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/CancelAppointment/AppointmentCancelledNotificationHandler.cs
@@ -1,5 +1,5 @@
 using MediatR;
-using Microsoft.Extensions.Logging;
+using NextTurn.Application.Appointment.Notifications;
 
 namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
 
@@ -9,27 +9,20 @@ namespace NextTurn.Application.Appointment.Commands.CancelAppointment;
 public sealed class AppointmentCancelledNotificationHandler
     : INotificationHandler<AppointmentCancelledNotification>
 {
-    private readonly ILogger<AppointmentCancelledNotificationHandler> _logger;
+    private readonly IAppointmentNotificationService _appointmentNotificationService;
 
     public AppointmentCancelledNotificationHandler(
-        ILogger<AppointmentCancelledNotificationHandler> logger)
+        IAppointmentNotificationService appointmentNotificationService)
     {
-        _logger = logger;
+        _appointmentNotificationService = appointmentNotificationService;
     }
 
     public Task Handle(
         AppointmentCancelledNotification notification,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation(
-            "Appointment cancelled. AppointmentId: {AppointmentId}, UserId: {UserId}, OrgId: {OrgId}, Slot: {SlotStart}->{SlotEnd}, LateCancellation: {LateCancellation}.",
+        return _appointmentNotificationService.SendCancellationUpdateAsync(
             notification.AppointmentId,
-            notification.UserId,
-            notification.OrganisationId,
-            notification.SlotStart,
-            notification.SlotEnd,
-            notification.LateCancellation);
-
-        return Task.CompletedTask;
+            cancellationToken);
     }
 }

--- a/src/NextTurn.Application/Appointment/Commands/RescheduleAppointment/AppointmentRescheduledNotificationHandler.cs
+++ b/src/NextTurn.Application/Appointment/Commands/RescheduleAppointment/AppointmentRescheduledNotificationHandler.cs
@@ -1,5 +1,5 @@
 using MediatR;
-using Microsoft.Extensions.Logging;
+using NextTurn.Application.Appointment.Notifications;
 
 namespace NextTurn.Application.Appointment.Commands.RescheduleAppointment;
 
@@ -10,29 +10,20 @@ namespace NextTurn.Application.Appointment.Commands.RescheduleAppointment;
 public sealed class AppointmentRescheduledNotificationHandler
     : INotificationHandler<AppointmentRescheduledNotification>
 {
-    private readonly ILogger<AppointmentRescheduledNotificationHandler> _logger;
+    private readonly IAppointmentNotificationService _appointmentNotificationService;
 
     public AppointmentRescheduledNotificationHandler(
-        ILogger<AppointmentRescheduledNotificationHandler> logger)
+        IAppointmentNotificationService appointmentNotificationService)
     {
-        _logger = logger;
+        _appointmentNotificationService = appointmentNotificationService;
     }
 
     public Task Handle(
         AppointmentRescheduledNotification notification,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation(
-            "Appointment rescheduled. OldId: {OldId}, NewId: {NewId}, UserId: {UserId}, OrgId: {OrgId}, OldSlot: {OldStart}->{OldEnd}, NewSlot: {NewStart}->{NewEnd}.",
-            notification.PreviousAppointmentId,
+        return _appointmentNotificationService.SendRescheduleUpdateAsync(
             notification.NewAppointmentId,
-            notification.UserId,
-            notification.OrganisationId,
-            notification.PreviousSlotStart,
-            notification.PreviousSlotEnd,
-            notification.NewSlotStart,
-            notification.NewSlotEnd);
-
-        return Task.CompletedTask;
+            cancellationToken);
     }
 }

--- a/src/NextTurn.Application/Appointment/Notifications/AppointmentNotificationService.cs
+++ b/src/NextTurn.Application/Appointment/Notifications/AppointmentNotificationService.cs
@@ -1,0 +1,140 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NextTurn.Application.Common.Interfaces;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
+
+namespace NextTurn.Application.Appointment.Notifications;
+
+public sealed class AppointmentNotificationService : IAppointmentNotificationService
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<AppointmentNotificationService> _logger;
+
+    public AppointmentNotificationService(
+        IApplicationDbContext context,
+        IEmailService emailService,
+        ILogger<AppointmentNotificationService> logger)
+    {
+        _context = context;
+        _emailService = emailService;
+        _logger = logger;
+    }
+
+    public Task SendBookingConfirmationAsync(Guid appointmentId, CancellationToken cancellationToken)
+    {
+        return SendAsync(appointmentId, "Booked", cancellationToken);
+    }
+
+    public Task SendRescheduleUpdateAsync(Guid appointmentId, CancellationToken cancellationToken)
+    {
+        return SendAsync(appointmentId, "Rescheduled", cancellationToken);
+    }
+
+    public Task SendCancellationUpdateAsync(Guid appointmentId, CancellationToken cancellationToken)
+    {
+        return SendAsync(appointmentId, "Cancelled", cancellationToken);
+    }
+
+    private async Task SendAsync(Guid appointmentId, string notificationType, CancellationToken cancellationToken)
+    {
+        var appointment = await _context.Appointments
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == appointmentId, cancellationToken);
+
+        if (appointment is null)
+        {
+            _logger.LogWarning("Appointment notification skipped. Appointment {AppointmentId} not found.", appointmentId);
+            return;
+        }
+
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == appointment.UserId, cancellationToken);
+
+        if (user is null || !user.IsActive)
+        {
+            _logger.LogWarning("Appointment notification skipped. User {UserId} missing or inactive.", appointment.UserId);
+            return;
+        }
+
+        if (!IsNotificationEnabled(user, notificationType))
+            return;
+
+        var profile = await _context.AppointmentProfiles
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == appointment.AppointmentProfileId, cancellationToken);
+
+        var organisation = await _context.Organisations
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == appointment.OrganisationId, cancellationToken);
+
+        var officeName = organisation?.Name ?? "Unknown office";
+        var serviceName = profile?.Name ?? "General appointment";
+
+        try
+        {
+            await _emailService.SendAppointmentStatusEmailAsync(
+                toEmail: user.Email.Value,
+                userName: user.Name,
+                notificationType: notificationType,
+                slotStart: appointment.SlotStart,
+                slotEnd: appointment.SlotEnd,
+                officeName: officeName,
+                serviceName: serviceName,
+                cancellationToken: cancellationToken);
+
+            _context.AppointmentNotificationAuditLogs.Add(
+                AppointmentNotificationAuditLog.Sent(
+                    organisationId: appointment.OrganisationId,
+                    appointmentId: appointment.Id,
+                    userId: user.Id,
+                    notificationType: notificationType,
+                    recipientEmail: user.Email.Value,
+                    slotStart: appointment.SlotStart,
+                    slotEnd: appointment.SlotEnd,
+                    officeName: officeName,
+                    serviceName: serviceName));
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to send appointment {NotificationType} notification for appointment {AppointmentId}.",
+                notificationType,
+                appointment.Id);
+
+            _context.AppointmentNotificationAuditLogs.Add(
+                AppointmentNotificationAuditLog.Failed(
+                    organisationId: appointment.OrganisationId,
+                    appointmentId: appointment.Id,
+                    userId: user.Id,
+                    notificationType: notificationType,
+                    recipientEmail: user.Email.Value,
+                    slotStart: appointment.SlotStart,
+                    slotEnd: appointment.SlotEnd,
+                    officeName: officeName,
+                    serviceName: serviceName,
+                    errorMessage: ex.Message));
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static bool IsNotificationEnabled(Domain.Auth.Entities.User user, string notificationType)
+    {
+        return notificationType switch
+        {
+            "Booked" => user.AppointmentBookedNotificationsEnabled,
+            "Rescheduled" => user.AppointmentRescheduledNotificationsEnabled,
+            "Cancelled" => user.AppointmentCancelledNotificationsEnabled,
+            _ => false,
+        };
+    }
+}

--- a/src/NextTurn.Application/Appointment/Notifications/IAppointmentNotificationService.cs
+++ b/src/NextTurn.Application/Appointment/Notifications/IAppointmentNotificationService.cs
@@ -1,0 +1,10 @@
+namespace NextTurn.Application.Appointment.Notifications;
+
+public interface IAppointmentNotificationService
+{
+    Task SendBookingConfirmationAsync(Guid appointmentId, CancellationToken cancellationToken);
+
+    Task SendRescheduleUpdateAsync(Guid appointmentId, CancellationToken cancellationToken);
+
+    Task SendCancellationUpdateAsync(Guid appointmentId, CancellationToken cancellationToken);
+}

--- a/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommand.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+
+public sealed record UpdateAppointmentNotificationPreferencesCommand(
+    Guid UserId,
+    bool AppointmentBookedNotificationsEnabled,
+    bool AppointmentRescheduledNotificationsEnabled,
+    bool AppointmentCancelledNotificationsEnabled) : IRequest<Unit>;

--- a/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandHandler.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandHandler.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+
+public sealed class UpdateAppointmentNotificationPreferencesCommandHandler
+    : IRequestHandler<UpdateAppointmentNotificationPreferencesCommand, Unit>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdateAppointmentNotificationPreferencesCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(
+        UpdateAppointmentNotificationPreferencesCommand request,
+        CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+        if (user is null)
+            throw new DomainException("User not found.");
+
+        user.SetAppointmentNotificationPreferences(
+            request.AppointmentBookedNotificationsEnabled,
+            request.AppointmentRescheduledNotificationsEnabled,
+            request.AppointmentCancelledNotificationsEnabled);
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandValidator.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateAppointmentNotificationPreferences/UpdateAppointmentNotificationPreferencesCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+
+public sealed class UpdateAppointmentNotificationPreferencesCommandValidator
+    : AbstractValidator<UpdateAppointmentNotificationPreferencesCommand>
+{
+    public UpdateAppointmentNotificationPreferencesCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Auth/Commands/UpdateQueueNotificationPreference/UpdateQueueNotificationPreferenceCommand.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateQueueNotificationPreference/UpdateQueueNotificationPreferenceCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
+
+public sealed record UpdateQueueNotificationPreferenceCommand(
+    Guid UserId,
+    bool QueueTurnApproachingNotificationsEnabled) : IRequest<Unit>;

--- a/src/NextTurn.Application/Auth/Commands/UpdateQueueNotificationPreference/UpdateQueueNotificationPreferenceCommandHandler.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateQueueNotificationPreference/UpdateQueueNotificationPreferenceCommandHandler.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
+
+public sealed class UpdateQueueNotificationPreferenceCommandHandler
+    : IRequestHandler<UpdateQueueNotificationPreferenceCommand, Unit>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdateQueueNotificationPreferenceCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(UpdateQueueNotificationPreferenceCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+        if (user is null)
+            throw new DomainException("User not found.");
+
+        user.SetQueueTurnApproachingNotificationsEnabled(request.QueueTurnApproachingNotificationsEnabled);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Auth/Commands/UpdateQueueNotificationPreference/UpdateQueueNotificationPreferenceCommandValidator.cs
+++ b/src/NextTurn.Application/Auth/Commands/UpdateQueueNotificationPreference/UpdateQueueNotificationPreferenceCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
+
+public sealed class UpdateQueueNotificationPreferenceCommandValidator : AbstractValidator<UpdateQueueNotificationPreferenceCommand>
+{
+    public UpdateQueueNotificationPreferenceCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/AppointmentNotificationPreferencesResult.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/AppointmentNotificationPreferencesResult.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+
+public sealed record AppointmentNotificationPreferencesResult(
+    bool AppointmentBookedNotificationsEnabled,
+    bool AppointmentRescheduledNotificationsEnabled,
+    bool AppointmentCancelledNotificationsEnabled);

--- a/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQuery.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+
+public sealed record GetAppointmentNotificationPreferencesQuery(Guid UserId)
+    : IRequest<AppointmentNotificationPreferencesResult>;

--- a/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQueryHandler.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetAppointmentNotificationPreferences/GetAppointmentNotificationPreferencesQueryHandler.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+
+public sealed class GetAppointmentNotificationPreferencesQueryHandler
+    : IRequestHandler<GetAppointmentNotificationPreferencesQuery, AppointmentNotificationPreferencesResult>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetAppointmentNotificationPreferencesQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<AppointmentNotificationPreferencesResult> Handle(
+        GetAppointmentNotificationPreferencesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+        if (user is null)
+            throw new DomainException("User not found.");
+
+        return new AppointmentNotificationPreferencesResult(
+            user.AppointmentBookedNotificationsEnabled,
+            user.AppointmentRescheduledNotificationsEnabled,
+            user.AppointmentCancelledNotificationsEnabled);
+    }
+}

--- a/src/NextTurn.Application/Auth/Queries/GetQueueNotificationPreference/GetQueueNotificationPreferenceQuery.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetQueueNotificationPreference/GetQueueNotificationPreferenceQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
+
+public sealed record GetQueueNotificationPreferenceQuery(Guid UserId) : IRequest<QueueNotificationPreferenceResult>;

--- a/src/NextTurn.Application/Auth/Queries/GetQueueNotificationPreference/GetQueueNotificationPreferenceQueryHandler.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetQueueNotificationPreference/GetQueueNotificationPreferenceQueryHandler.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
+
+public sealed class GetQueueNotificationPreferenceQueryHandler
+    : IRequestHandler<GetQueueNotificationPreferenceQuery, QueueNotificationPreferenceResult>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetQueueNotificationPreferenceQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<QueueNotificationPreferenceResult> Handle(
+        GetQueueNotificationPreferenceQuery request,
+        CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+        if (user is null)
+            throw new DomainException("User not found.");
+
+        return new QueueNotificationPreferenceResult(user.QueueTurnApproachingNotificationsEnabled);
+    }
+}

--- a/src/NextTurn.Application/Auth/Queries/GetQueueNotificationPreference/QueueNotificationPreferenceResult.cs
+++ b/src/NextTurn.Application/Auth/Queries/GetQueueNotificationPreference/QueueNotificationPreferenceResult.cs
@@ -1,0 +1,3 @@
+namespace NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
+
+public sealed record QueueNotificationPreferenceResult(bool QueueTurnApproachingNotificationsEnabled);

--- a/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
 using AppointmentProfile = NextTurn.Domain.Appointment.Entities.AppointmentProfile;
 using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.AppointmentScheduleRule;
 using NextTurn.Domain.Auth.Entities;
@@ -28,6 +29,7 @@ public interface IApplicationDbContext
     DbSet<QueueActionAuditLog> QueueActionAuditLogs { get; }
     DbSet<QueueTurnNotificationAuditLog> QueueTurnNotificationAuditLogs { get; }
     DbSet<AppointmentEntity> Appointments { get; }
+    DbSet<AppointmentNotificationAuditLog> AppointmentNotificationAuditLogs { get; }
     DbSet<AppointmentProfile> AppointmentProfiles { get; }
     DbSet<AppointmentScheduleRule> AppointmentScheduleRules { get; }
     DbSet<StaffOfficeAssignment> StaffOfficeAssignments { get; }

--- a/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -6,6 +6,7 @@ using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.Appointment
 using NextTurn.Domain.Auth.Entities;
 using StaffOfficeAssignment = NextTurn.Domain.Auth.Entities.StaffOfficeAssignment;
 using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
 using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
 using QueueActionAuditLog = NextTurn.Domain.Queue.Entities.QueueActionAuditLog;
@@ -24,6 +25,7 @@ public interface IApplicationDbContext
 {
     DbSet<User>             Users        { get; }
     DbSet<OrganisationEntity> Organisations { get; }
+    DbSet<OfficeEntity> Offices { get; }
     DbSet<QueueEntity>      Queues       { get; }
     DbSet<QueueEntry>       QueueEntries { get; }
     DbSet<QueueActionAuditLog> QueueActionAuditLogs { get; }

--- a/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -8,6 +8,7 @@ using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
 using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
 using QueueActionAuditLog = NextTurn.Domain.Queue.Entities.QueueActionAuditLog;
+using QueueTurnNotificationAuditLog = NextTurn.Domain.Queue.Entities.QueueTurnNotificationAuditLog;
 using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
 using ServiceOfficeAssignment = NextTurn.Domain.Service.Entities.ServiceOfficeAssignment;
 
@@ -25,6 +26,7 @@ public interface IApplicationDbContext
     DbSet<QueueEntity>      Queues       { get; }
     DbSet<QueueEntry>       QueueEntries { get; }
     DbSet<QueueActionAuditLog> QueueActionAuditLogs { get; }
+    DbSet<QueueTurnNotificationAuditLog> QueueTurnNotificationAuditLogs { get; }
     DbSet<AppointmentEntity> Appointments { get; }
     DbSet<AppointmentProfile> AppointmentProfiles { get; }
     DbSet<AppointmentScheduleRule> AppointmentScheduleRules { get; }

--- a/src/NextTurn.Application/Common/Interfaces/IEmailService.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IEmailService.cs
@@ -36,4 +36,17 @@ public interface IEmailService
         int ticketNumber,
         int positionInQueue,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends appointment status updates (booked, rescheduled, cancelled) with slot and context details.
+    /// </summary>
+    Task SendAppointmentStatusEmailAsync(
+        string toEmail,
+        string userName,
+        string notificationType,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        CancellationToken cancellationToken);
 }

--- a/src/NextTurn.Application/Common/Interfaces/IEmailService.cs
+++ b/src/NextTurn.Application/Common/Interfaces/IEmailService.cs
@@ -26,4 +26,14 @@ public interface IEmailService
         string invitePath,
         DateTimeOffset expiresAt,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends a queue turn-approaching notification when a user is close to being served.
+    /// </summary>
+    Task SendQueueTurnApproachingEmailAsync(
+        string toEmail,
+        string queueName,
+        int ticketNumber,
+        int positionInQueue,
+        CancellationToken cancellationToken);
 }

--- a/src/NextTurn.Application/DependencyInjection.cs
+++ b/src/NextTurn.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NextTurn.Application.Appointment.Notifications;
 using NextTurn.Application.Auth.Commands.RegisterUser;
 using NextTurn.Application.Common.Behaviours;
+using NextTurn.Application.Queue.Reports;
 
 namespace NextTurn.Application;
 
@@ -41,6 +42,7 @@ public static class DependencyInjection
             typeof(ValidationBehavior<,>));
 
         services.AddScoped<IAppointmentNotificationService, AppointmentNotificationService>();
+        services.AddSingleton<QueuePerformanceCalculator>();
 
         return services;
     }

--- a/src/NextTurn.Application/DependencyInjection.cs
+++ b/src/NextTurn.Application/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Application.Appointment.Notifications;
 using NextTurn.Application.Auth.Commands.RegisterUser;
 using NextTurn.Application.Common.Behaviours;
 
@@ -38,6 +39,8 @@ public static class DependencyInjection
         services.AddTransient(
             typeof(IPipelineBehavior<,>),
             typeof(ValidationBehavior<,>));
+
+        services.AddScoped<IAppointmentNotificationService, AppointmentNotificationService>();
 
         return services;
     }

--- a/src/NextTurn.Application/DependencyInjection.cs
+++ b/src/NextTurn.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NextTurn.Application.Appointment.Notifications;
 using NextTurn.Application.Auth.Commands.RegisterUser;
 using NextTurn.Application.Common.Behaviours;
+using NextTurn.Application.Queue.DailySummary;
 using NextTurn.Application.Queue.Reports;
 
 namespace NextTurn.Application;
@@ -42,6 +43,7 @@ public static class DependencyInjection
             typeof(ValidationBehavior<,>));
 
         services.AddScoped<IAppointmentNotificationService, AppointmentNotificationService>();
+        services.AddSingleton<DailyQueueSummaryCalculator>();
         services.AddSingleton<QueuePerformanceCalculator>();
 
         return services;

--- a/src/NextTurn.Application/Organisation/Commands/UpdateQueueNotificationThreshold/UpdateQueueNotificationThresholdCommand.cs
+++ b/src/NextTurn.Application/Organisation/Commands/UpdateQueueNotificationThreshold/UpdateQueueNotificationThresholdCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace NextTurn.Application.Organisation.Commands.UpdateQueueNotificationThreshold;
+
+public sealed record UpdateQueueNotificationThresholdCommand(
+    Guid OrganisationId,
+    int QueueNotificationThreshold) : IRequest<Unit>;

--- a/src/NextTurn.Application/Organisation/Commands/UpdateQueueNotificationThreshold/UpdateQueueNotificationThresholdCommandHandler.cs
+++ b/src/NextTurn.Application/Organisation/Commands/UpdateQueueNotificationThreshold/UpdateQueueNotificationThresholdCommandHandler.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Organisation.Commands.UpdateQueueNotificationThreshold;
+
+public sealed class UpdateQueueNotificationThresholdCommandHandler
+    : IRequestHandler<UpdateQueueNotificationThresholdCommand, Unit>
+{
+    private readonly IApplicationDbContext _context;
+
+    public UpdateQueueNotificationThresholdCommandHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Unit> Handle(UpdateQueueNotificationThresholdCommand request, CancellationToken cancellationToken)
+    {
+        var organisation = await _context.Organisations
+            .FirstOrDefaultAsync(o => o.Id == request.OrganisationId, cancellationToken);
+
+        if (organisation is null)
+            throw new DomainException("Organisation not found.");
+
+        organisation.SetQueueNotificationThreshold(request.QueueNotificationThreshold);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/NextTurn.Application/Organisation/Commands/UpdateQueueNotificationThreshold/UpdateQueueNotificationThresholdCommandValidator.cs
+++ b/src/NextTurn.Application/Organisation/Commands/UpdateQueueNotificationThreshold/UpdateQueueNotificationThresholdCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Organisation.Commands.UpdateQueueNotificationThreshold;
+
+public sealed class UpdateQueueNotificationThresholdCommandValidator : AbstractValidator<UpdateQueueNotificationThresholdCommand>
+{
+    public UpdateQueueNotificationThresholdCommandValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty().WithMessage("Organisation ID is required.");
+
+        RuleFor(x => x.QueueNotificationThreshold)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Queue notification threshold must be between 1 and 50.");
+    }
+}

--- a/src/NextTurn.Application/Organisation/Queries/GetQueueNotificationThreshold/GetQueueNotificationThresholdQuery.cs
+++ b/src/NextTurn.Application/Organisation/Queries/GetQueueNotificationThreshold/GetQueueNotificationThresholdQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Organisation.Queries.GetQueueNotificationThreshold;
+
+public sealed record GetQueueNotificationThresholdQuery(Guid OrganisationId) : IRequest<QueueNotificationThresholdResult>;

--- a/src/NextTurn.Application/Organisation/Queries/GetQueueNotificationThreshold/GetQueueNotificationThresholdQueryHandler.cs
+++ b/src/NextTurn.Application/Organisation/Queries/GetQueueNotificationThreshold/GetQueueNotificationThresholdQueryHandler.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Organisation.Queries.GetQueueNotificationThreshold;
+
+public sealed class GetQueueNotificationThresholdQueryHandler
+    : IRequestHandler<GetQueueNotificationThresholdQuery, QueueNotificationThresholdResult>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetQueueNotificationThresholdQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<QueueNotificationThresholdResult> Handle(
+        GetQueueNotificationThresholdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var organisation = await _context.Organisations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == request.OrganisationId, cancellationToken);
+
+        if (organisation is null)
+            throw new DomainException("Organisation not found.");
+
+        return new QueueNotificationThresholdResult(organisation.QueueNotificationThreshold);
+    }
+}

--- a/src/NextTurn.Application/Organisation/Queries/GetQueueNotificationThreshold/QueueNotificationThresholdResult.cs
+++ b/src/NextTurn.Application/Organisation/Queries/GetQueueNotificationThreshold/QueueNotificationThresholdResult.cs
@@ -1,0 +1,3 @@
+namespace NextTurn.Application.Organisation.Queries.GetQueueNotificationThreshold;
+
+public sealed record QueueNotificationThresholdResult(int QueueNotificationThreshold);

--- a/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/CallNext/CallNextCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
@@ -13,13 +14,16 @@ public sealed class CallNextCommandHandler : IRequestHandler<CallNextCommand, Qu
 
     private readonly IQueueRepository _queueRepository;
     private readonly IApplicationDbContext _context;
+    private readonly ISender _sender;
 
     public CallNextCommandHandler(
         IQueueRepository queueRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ISender sender)
     {
         _queueRepository = queueRepository;
         _context = context;
+        _sender = sender;
     }
 
     public async Task<QueueEntryActionResult> Handle(
@@ -48,6 +52,8 @@ public sealed class CallNextCommandHandler : IRequestHandler<CallNextCommand, Qu
         {
             throw new ConflictDomainException("A ticket is already being served.");
         }
+
+        await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 
         return new QueueEntryActionResult(nextWaiting.Id, nextWaiting.TicketNumber, nextWaiting.Status.ToString());
     }

--- a/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/LeaveQueue/LeaveQueueCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
 
@@ -23,13 +24,16 @@ public class LeaveQueueCommandHandler : IRequestHandler<LeaveQueueCommand, Unit>
 {
     private readonly IQueueRepository _queueRepository;
     private readonly IApplicationDbContext _context;
+    private readonly ISender _sender;
 
     public LeaveQueueCommandHandler(
         IQueueRepository queueRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ISender sender)
     {
         _queueRepository = queueRepository;
         _context = context;
+        _sender = sender;
     }
 
     public async Task<Unit> Handle(
@@ -45,6 +49,7 @@ public class LeaveQueueCommandHandler : IRequestHandler<LeaveQueueCommand, Unit>
 
         // Step 2 — persist the state transition
         await _context.SaveChangesAsync(cancellationToken);
+        await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 
         return Unit.Value;
     }

--- a/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommand.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommand.cs
@@ -3,4 +3,4 @@ using NextTurn.Application.Queue.Commands;
 
 namespace NextTurn.Application.Queue.Commands.MarkNoShow;
 
-public sealed record MarkNoShowCommand(Guid QueueId) : IRequest<QueueEntryActionResult>;
+public sealed record MarkNoShowCommand(Guid QueueId, Guid PerformedByUserId) : IRequest<QueueEntryActionResult>;

--- a/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
@@ -10,13 +11,16 @@ public sealed class MarkNoShowCommandHandler : IRequestHandler<MarkNoShowCommand
 {
     private readonly IQueueRepository _queueRepository;
     private readonly IApplicationDbContext _context;
+    private readonly ISender _sender;
 
     public MarkNoShowCommandHandler(
         IQueueRepository queueRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ISender sender)
     {
         _queueRepository = queueRepository;
         _context = context;
+        _sender = sender;
     }
 
     public async Task<QueueEntryActionResult> Handle(
@@ -33,6 +37,7 @@ public sealed class MarkNoShowCommandHandler : IRequestHandler<MarkNoShowCommand
 
         servingEntry.MarkNoShow();
         await _context.SaveChangesAsync(cancellationToken);
+        await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 
         return new QueueEntryActionResult(servingEntry.Id, servingEntry.TicketNumber, servingEntry.Status.ToString());
     }

--- a/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkNoShow/MarkNoShowCommandHandler.cs
@@ -3,6 +3,8 @@ using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Entities;
+using NextTurn.Domain.Queue.Enums;
 using NextTurn.Domain.Queue.Repositories;
 
 namespace NextTurn.Application.Queue.Commands.MarkNoShow;
@@ -36,6 +38,16 @@ public sealed class MarkNoShowCommandHandler : IRequestHandler<MarkNoShowCommand
             throw new DomainException("No entry is currently being served.");
 
         servingEntry.MarkNoShow();
+
+        _context.QueueActionAuditLogs.Add(
+            QueueActionAuditLog.Create(
+                organisationId: queue.OrganisationId,
+                queueId: queue.Id,
+                queueEntryId: servingEntry.Id,
+                performedByUserId: command.PerformedByUserId,
+                actionType: QueueActionType.NoShow,
+                reason: null));
+
         await _context.SaveChangesAsync(cancellationToken);
         await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 

--- a/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/MarkServed/MarkServedCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
@@ -10,13 +11,16 @@ public sealed class MarkServedCommandHandler : IRequestHandler<MarkServedCommand
 {
     private readonly IQueueRepository _queueRepository;
     private readonly IApplicationDbContext _context;
+    private readonly ISender _sender;
 
     public MarkServedCommandHandler(
         IQueueRepository queueRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ISender sender)
     {
         _queueRepository = queueRepository;
         _context = context;
+        _sender = sender;
     }
 
     public async Task<QueueEntryActionResult> Handle(
@@ -33,6 +37,7 @@ public sealed class MarkServedCommandHandler : IRequestHandler<MarkServedCommand
 
         servingEntry.MarkServed();
         await _context.SaveChangesAsync(cancellationToken);
+        await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 
         return new QueueEntryActionResult(servingEntry.Id, servingEntry.TicketNumber, servingEntry.Status.ToString());
     }

--- a/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnCommand.cs
+++ b/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
+
+public sealed record NotifyApproachingTurnCommand(Guid QueueId) : IRequest<NotifyApproachingTurnResult>;

--- a/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnCommandHandler.cs
@@ -1,0 +1,133 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Common;
+
+namespace NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
+
+public sealed class NotifyApproachingTurnCommandHandler
+    : IRequestHandler<NotifyApproachingTurnCommand, NotifyApproachingTurnResult>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IEmailService _emailService;
+
+    public NotifyApproachingTurnCommandHandler(
+        IApplicationDbContext context,
+        IEmailService emailService)
+    {
+        _context = context;
+        _emailService = emailService;
+    }
+
+    public async Task<NotifyApproachingTurnResult> Handle(
+        NotifyApproachingTurnCommand request,
+        CancellationToken cancellationToken)
+    {
+        var queue = await _context.Queues
+            .AsNoTracking()
+            .FirstOrDefaultAsync(q => q.Id == request.QueueId, cancellationToken);
+
+        if (queue is null)
+            throw new DomainException("Queue not found.");
+
+        var organisation = await _context.Organisations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == queue.OrganisationId, cancellationToken);
+
+        if (organisation is null)
+            throw new DomainException("Organisation not found.");
+
+        var threshold = organisation.QueueNotificationThreshold;
+
+        var waitingEntries = await _context.QueueEntries
+            .AsNoTracking()
+            .Where(e => e.QueueId == request.QueueId && e.Status == Domain.Queue.Enums.QueueEntryStatus.Waiting)
+            .OrderBy(e => e.TicketNumber)
+            .ThenBy(e => e.JoinedAt)
+            .Select(e => new CandidateEntry(e.Id, e.UserId, e.TicketNumber))
+            .ToListAsync(cancellationToken);
+
+        if (waitingEntries.Count == 0)
+            return new NotifyApproachingTurnResult(0, 0);
+
+        var thresholdEntries = waitingEntries
+            .Select((entry, index) => new CandidateWithPosition(entry, index + 1))
+            .Where(x => x.PositionInQueue <= threshold)
+            .ToList();
+
+        if (thresholdEntries.Count == 0)
+            return new NotifyApproachingTurnResult(0, 0);
+
+        var candidateEntryIds = thresholdEntries.Select(x => x.Entry.Id).ToList();
+
+        var alreadySentIds = await _context.QueueTurnNotificationAuditLogs
+            .AsNoTracking()
+            .Where(l => candidateEntryIds.Contains(l.QueueEntryId) && l.DeliveryStatus == "Sent")
+            .Select(l => l.QueueEntryId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        int sentCount = 0;
+        int failedCount = 0;
+
+        foreach (var candidate in thresholdEntries)
+        {
+            if (alreadySentIds.Contains(candidate.Entry.Id))
+                continue;
+
+            var user = await _context.Users
+                .IgnoreQueryFilters()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    u => u.Id == candidate.Entry.UserId,
+                    cancellationToken);
+
+            if (user is null || !user.IsActive || !user.QueueTurnApproachingNotificationsEnabled)
+                continue;
+
+            try
+            {
+                await _emailService.SendQueueTurnApproachingEmailAsync(
+                    toEmail: user.Email.Value,
+                    queueName: queue.Name,
+                    ticketNumber: candidate.Entry.TicketNumber,
+                    positionInQueue: candidate.PositionInQueue,
+                    cancellationToken: cancellationToken);
+
+                _context.QueueTurnNotificationAuditLogs.Add(
+                    Domain.Queue.Entities.QueueTurnNotificationAuditLog.Sent(
+                        organisationId: queue.OrganisationId,
+                        queueId: queue.Id,
+                        queueEntryId: candidate.Entry.Id,
+                        userId: user.Id,
+                        positionInQueue: candidate.PositionInQueue,
+                        threshold: threshold));
+
+                sentCount++;
+            }
+            catch (Exception ex)
+            {
+                _context.QueueTurnNotificationAuditLogs.Add(
+                    Domain.Queue.Entities.QueueTurnNotificationAuditLog.Failed(
+                        organisationId: queue.OrganisationId,
+                        queueId: queue.Id,
+                        queueEntryId: candidate.Entry.Id,
+                        userId: candidate.Entry.UserId,
+                        positionInQueue: candidate.PositionInQueue,
+                        threshold: threshold,
+                        errorMessage: ex.Message));
+
+                failedCount++;
+            }
+        }
+
+        if (sentCount > 0 || failedCount > 0)
+            await _context.SaveChangesAsync(cancellationToken);
+
+        return new NotifyApproachingTurnResult(sentCount, failedCount);
+    }
+
+    private sealed record CandidateEntry(Guid Id, Guid UserId, int TicketNumber);
+
+    private sealed record CandidateWithPosition(CandidateEntry Entry, int PositionInQueue);
+}

--- a/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnCommandValidator.cs
+++ b/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
+
+public sealed class NotifyApproachingTurnCommandValidator : AbstractValidator<NotifyApproachingTurnCommand>
+{
+    public NotifyApproachingTurnCommandValidator()
+    {
+        RuleFor(x => x.QueueId)
+            .NotEmpty().WithMessage("Queue ID is required.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnResult.cs
+++ b/src/NextTurn.Application/Queue/Commands/NotifyApproachingTurn/NotifyApproachingTurnResult.cs
@@ -1,0 +1,3 @@
+namespace NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
+
+public sealed record NotifyApproachingTurnResult(int NotificationsSent, int NotificationsFailed);

--- a/src/NextTurn.Application/Queue/Commands/ServeNext/ServeNextCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/ServeNext/ServeNextCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Entities;
@@ -12,13 +13,16 @@ public sealed class ServeNextCommandHandler : IRequestHandler<ServeNextCommand, 
 {
     private readonly IQueueRepository _queueRepository;
     private readonly IApplicationDbContext _context;
+    private readonly ISender _sender;
 
     public ServeNextCommandHandler(
         IQueueRepository queueRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ISender sender)
     {
         _queueRepository = queueRepository;
         _context = context;
+        _sender = sender;
     }
 
     public async Task<QueueEntryActionResult> Handle(
@@ -50,6 +54,7 @@ public sealed class ServeNextCommandHandler : IRequestHandler<ServeNextCommand, 
                 reason: null));
 
         await _context.SaveChangesAsync(cancellationToken);
+        await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 
         return new QueueEntryActionResult(entry.Id, entry.TicketNumber, entry.Status.ToString());
     }

--- a/src/NextTurn.Application/Queue/Commands/Skip/SkipCommandHandler.cs
+++ b/src/NextTurn.Application/Queue/Commands/Skip/SkipCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Entities;
@@ -12,13 +13,16 @@ public sealed class SkipCommandHandler : IRequestHandler<SkipCommand, QueueEntry
 {
     private readonly IQueueRepository _queueRepository;
     private readonly IApplicationDbContext _context;
+    private readonly ISender _sender;
 
     public SkipCommandHandler(
         IQueueRepository queueRepository,
-        IApplicationDbContext context)
+        IApplicationDbContext context,
+        ISender sender)
     {
         _queueRepository = queueRepository;
         _context = context;
+        _sender = sender;
     }
 
     public async Task<QueueEntryActionResult> Handle(
@@ -50,6 +54,7 @@ public sealed class SkipCommandHandler : IRequestHandler<SkipCommand, QueueEntry
                 reason: command.Reason));
 
         await _context.SaveChangesAsync(cancellationToken);
+        await _sender.Send(new NotifyApproachingTurnCommand(command.QueueId), cancellationToken);
 
         return new QueueEntryActionResult(entry.Id, entry.TicketNumber, entry.Status.ToString());
     }

--- a/src/NextTurn.Application/Queue/DailySummary/DailyQueueMetricTrend.cs
+++ b/src/NextTurn.Application/Queue/DailySummary/DailyQueueMetricTrend.cs
@@ -1,0 +1,9 @@
+namespace NextTurn.Application.Queue.DailySummary;
+
+public sealed record DailyQueueMetricTrend(
+    int PreviousDay,
+    int PreviousWeek,
+    int DeltaFromPreviousDay,
+    int DeltaFromPreviousWeek,
+    double ChangePercentFromPreviousDay,
+    double ChangePercentFromPreviousWeek);

--- a/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryAggregationPoint.cs
+++ b/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryAggregationPoint.cs
@@ -1,0 +1,12 @@
+using NextTurn.Domain.Queue.Enums;
+
+namespace NextTurn.Application.Queue.DailySummary;
+
+public sealed record DailyQueueSummaryAggregationPoint(
+    DateOnly Date,
+    Guid OfficeId,
+    string OfficeName,
+    Guid ServiceId,
+    string ServiceName,
+    QueueActionType ActionType,
+    int Count);

--- a/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryCalculator.cs
+++ b/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryCalculator.cs
@@ -1,0 +1,126 @@
+using NextTurn.Domain.Queue.Enums;
+
+namespace NextTurn.Application.Queue.DailySummary;
+
+public sealed class DailyQueueSummaryCalculator
+{
+    public DailyQueueSummaryReportResult Calculate(
+        DateOnly date,
+        IReadOnlyList<DailyQueueSummaryAggregationPoint> points)
+    {
+        var previousDayDate = date.AddDays(-1);
+        var previousWeekDate = date.AddDays(-7);
+
+        var grouped = points
+            .GroupBy(x => (x.Date, x.OfficeId, x.OfficeName, x.ServiceId, x.ServiceName))
+            .ToDictionary(
+                g => g.Key,
+                g => new MetricBucket(
+                    Served: g.Where(x => x.ActionType == QueueActionType.Serve).Sum(x => x.Count),
+                    Skipped: g.Where(x => x.ActionType == QueueActionType.Skip).Sum(x => x.Count),
+                    NoShows: g.Where(x => x.ActionType == QueueActionType.NoShow).Sum(x => x.Count)));
+
+        var currentRows = grouped
+            .Where(x => x.Key.Date == date)
+            .OrderBy(x => x.Key.OfficeName)
+            .ThenBy(x => x.Key.ServiceName)
+            .ToList();
+
+        var rows = currentRows
+            .Select(x =>
+            {
+                var previousDay = GetBucket(grouped, previousDayDate, x.Key.OfficeId, x.Key.OfficeName, x.Key.ServiceId, x.Key.ServiceName);
+                var previousWeek = GetBucket(grouped, previousWeekDate, x.Key.OfficeId, x.Key.OfficeName, x.Key.ServiceId, x.Key.ServiceName);
+
+                return new DailyQueueSummaryRow(
+                    OfficeId: x.Key.OfficeId,
+                    OfficeName: x.Key.OfficeName,
+                    ServiceId: x.Key.ServiceId,
+                    ServiceName: x.Key.ServiceName,
+                    Served: x.Value.Served,
+                    Skipped: x.Value.Skipped,
+                    NoShows: x.Value.NoShows,
+                    ServedTrend: BuildTrend(x.Value.Served, previousDay.Served, previousWeek.Served),
+                    SkippedTrend: BuildTrend(x.Value.Skipped, previousDay.Skipped, previousWeek.Skipped),
+                    NoShowsTrend: BuildTrend(x.Value.NoShows, previousDay.NoShows, previousWeek.NoShows));
+            })
+            .ToList();
+
+        var currentTotals = Sum(rows.Select(x => new MetricBucket(x.Served, x.Skipped, x.NoShows)));
+
+        var previousDayTotals = Sum(grouped
+            .Where(x => x.Key.Date == previousDayDate)
+            .Select(x => x.Value));
+
+        var previousWeekTotals = Sum(grouped
+            .Where(x => x.Key.Date == previousWeekDate)
+            .Select(x => x.Value));
+
+        return new DailyQueueSummaryReportResult(
+            Date: date,
+            PreviousDayDate: previousDayDate,
+            PreviousWeekDate: previousWeekDate,
+            TotalServed: currentTotals.Served,
+            TotalSkipped: currentTotals.Skipped,
+            TotalNoShows: currentTotals.NoShows,
+            TotalServedTrend: BuildTrend(currentTotals.Served, previousDayTotals.Served, previousWeekTotals.Served),
+            TotalSkippedTrend: BuildTrend(currentTotals.Skipped, previousDayTotals.Skipped, previousWeekTotals.Skipped),
+            TotalNoShowsTrend: BuildTrend(currentTotals.NoShows, previousDayTotals.NoShows, previousWeekTotals.NoShows),
+            Rows: rows);
+    }
+
+    private static MetricBucket GetBucket(
+        IReadOnlyDictionary<(DateOnly Date, Guid OfficeId, string OfficeName, Guid ServiceId, string ServiceName), MetricBucket> grouped,
+        DateOnly date,
+        Guid officeId,
+        string officeName,
+        Guid serviceId,
+        string serviceName)
+    {
+        return grouped.TryGetValue((date, officeId, officeName, serviceId, serviceName), out var bucket)
+            ? bucket
+            : MetricBucket.Empty;
+    }
+
+    private static MetricBucket Sum(IEnumerable<MetricBucket> buckets)
+    {
+        var result = MetricBucket.Empty;
+
+        foreach (var bucket in buckets)
+        {
+            result = new MetricBucket(
+                result.Served + bucket.Served,
+                result.Skipped + bucket.Skipped,
+                result.NoShows + bucket.NoShows);
+        }
+
+        return result;
+    }
+
+    private static DailyQueueMetricTrend BuildTrend(int current, int previousDay, int previousWeek)
+    {
+        var dayDelta = current - previousDay;
+        var weekDelta = current - previousWeek;
+
+        return new DailyQueueMetricTrend(
+            PreviousDay: previousDay,
+            PreviousWeek: previousWeek,
+            DeltaFromPreviousDay: dayDelta,
+            DeltaFromPreviousWeek: weekDelta,
+            ChangePercentFromPreviousDay: CalculateChangePercent(current, previousDay),
+            ChangePercentFromPreviousWeek: CalculateChangePercent(current, previousWeek));
+    }
+
+    private static double CalculateChangePercent(int current, int baseline)
+    {
+        if (baseline == 0)
+            return current == 0 ? 0 : 100;
+
+        return Math.Round(((double)(current - baseline) / baseline) * 100, 2);
+    }
+
+    private sealed record MetricBucket(int Served, int Skipped, int NoShows)
+    {
+        public static MetricBucket Empty => new(0, 0, 0);
+    }
+}

--- a/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryReportResult.cs
+++ b/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryReportResult.cs
@@ -1,0 +1,13 @@
+namespace NextTurn.Application.Queue.DailySummary;
+
+public sealed record DailyQueueSummaryReportResult(
+    DateOnly Date,
+    DateOnly PreviousDayDate,
+    DateOnly PreviousWeekDate,
+    int TotalServed,
+    int TotalSkipped,
+    int TotalNoShows,
+    DailyQueueMetricTrend TotalServedTrend,
+    DailyQueueMetricTrend TotalSkippedTrend,
+    DailyQueueMetricTrend TotalNoShowsTrend,
+    IReadOnlyList<DailyQueueSummaryRow> Rows);

--- a/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryRow.cs
+++ b/src/NextTurn.Application/Queue/DailySummary/DailyQueueSummaryRow.cs
@@ -1,0 +1,13 @@
+namespace NextTurn.Application.Queue.DailySummary;
+
+public sealed record DailyQueueSummaryRow(
+    Guid OfficeId,
+    string OfficeName,
+    Guid ServiceId,
+    string ServiceName,
+    int Served,
+    int Skipped,
+    int NoShows,
+    DailyQueueMetricTrend ServedTrend,
+    DailyQueueMetricTrend SkippedTrend,
+    DailyQueueMetricTrend NoShowsTrend);

--- a/src/NextTurn.Application/Queue/DailySummary/IDailyQueueSummaryReportService.cs
+++ b/src/NextTurn.Application/Queue/DailySummary/IDailyQueueSummaryReportService.cs
@@ -1,0 +1,9 @@
+namespace NextTurn.Application.Queue.DailySummary;
+
+public interface IDailyQueueSummaryReportService
+{
+    Task<DailyQueueSummaryReportResult> GenerateAsync(
+        Guid organisationId,
+        DateOnly date,
+        CancellationToken cancellationToken);
+}

--- a/src/NextTurn.Application/Queue/Queries/ExportQueuePerformanceReportCsv/ExportQueuePerformanceReportCsvQuery.cs
+++ b/src/NextTurn.Application/Queue/Queries/ExportQueuePerformanceReportCsv/ExportQueuePerformanceReportCsvQuery.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using NextTurn.Application.Queue.Reports;
+
+namespace NextTurn.Application.Queue.Queries.ExportQueuePerformanceReportCsv;
+
+public sealed record ExportQueuePerformanceReportCsvQuery(
+    Guid OrganisationId,
+    DateOnly StartDate,
+    DateOnly EndDate,
+    Guid? ServiceId,
+    Guid? OfficeId) : IRequest<QueuePerformanceCsvExportResult>;

--- a/src/NextTurn.Application/Queue/Queries/ExportQueuePerformanceReportCsv/ExportQueuePerformanceReportCsvQueryHandler.cs
+++ b/src/NextTurn.Application/Queue/Queries/ExportQueuePerformanceReportCsv/ExportQueuePerformanceReportCsvQueryHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using NextTurn.Application.Queue.Reports;
+
+namespace NextTurn.Application.Queue.Queries.ExportQueuePerformanceReportCsv;
+
+public sealed class ExportQueuePerformanceReportCsvQueryHandler
+    : IRequestHandler<ExportQueuePerformanceReportCsvQuery, QueuePerformanceCsvExportResult>
+{
+    private readonly IQueuePerformanceReportService _reportService;
+    private readonly IQueuePerformanceExportService _exportService;
+
+    public ExportQueuePerformanceReportCsvQueryHandler(
+        IQueuePerformanceReportService reportService,
+        IQueuePerformanceExportService exportService)
+    {
+        _reportService = reportService;
+        _exportService = exportService;
+    }
+
+    public async Task<QueuePerformanceCsvExportResult> Handle(
+        ExportQueuePerformanceReportCsvQuery request,
+        CancellationToken cancellationToken)
+    {
+        var filter = new QueuePerformanceFilter(
+            request.OrganisationId,
+            request.StartDate,
+            request.EndDate,
+            request.ServiceId,
+            request.OfficeId);
+
+        var report = await _reportService.GenerateAsync(filter, cancellationToken);
+        var content = _exportService.ExportCsv(report);
+        var fileName = $"queue-performance-{request.StartDate:yyyyMMdd}-{request.EndDate:yyyyMMdd}.csv";
+
+        return new QueuePerformanceCsvExportResult(fileName, "text/csv", content);
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/ExportQueuePerformanceReportCsv/ExportQueuePerformanceReportCsvQueryValidator.cs
+++ b/src/NextTurn.Application/Queue/Queries/ExportQueuePerformanceReportCsv/ExportQueuePerformanceReportCsvQueryValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Queries.ExportQueuePerformanceReportCsv;
+
+public sealed class ExportQueuePerformanceReportCsvQueryValidator : AbstractValidator<ExportQueuePerformanceReportCsvQuery>
+{
+    public ExportQueuePerformanceReportCsvQueryValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty();
+
+        RuleFor(x => x.StartDate)
+            .LessThanOrEqualTo(x => x.EndDate)
+            .WithMessage("Start date must be on or before end date.");
+
+        RuleFor(x => x)
+            .Must(x => x.EndDate.DayNumber - x.StartDate.DayNumber <= 366)
+            .WithMessage("Date range must be 366 days or less.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/GetDailySummaryReport/DailySummaryReportQuery.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetDailySummaryReport/DailySummaryReportQuery.cs
@@ -1,0 +1,8 @@
+using MediatR;
+using NextTurn.Application.Queue.DailySummary;
+
+namespace NextTurn.Application.Queue.Queries.GetDailySummaryReport;
+
+public sealed record DailySummaryReportQuery(
+    Guid OrganisationId,
+    DateOnly Date) : IRequest<DailyQueueSummaryReportResult>;

--- a/src/NextTurn.Application/Queue/Queries/GetDailySummaryReport/DailySummaryReportQueryHandler.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetDailySummaryReport/DailySummaryReportQueryHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using NextTurn.Application.Queue.DailySummary;
+
+namespace NextTurn.Application.Queue.Queries.GetDailySummaryReport;
+
+public sealed class DailySummaryReportQueryHandler : IRequestHandler<DailySummaryReportQuery, DailyQueueSummaryReportResult>
+{
+    private readonly IDailyQueueSummaryReportService _dailySummaryService;
+
+    public DailySummaryReportQueryHandler(IDailyQueueSummaryReportService dailySummaryService)
+    {
+        _dailySummaryService = dailySummaryService;
+    }
+
+    public Task<DailyQueueSummaryReportResult> Handle(
+        DailySummaryReportQuery request,
+        CancellationToken cancellationToken)
+    {
+        return _dailySummaryService.GenerateAsync(
+            request.OrganisationId,
+            request.Date,
+            cancellationToken);
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/GetDailySummaryReport/DailySummaryReportQueryValidator.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetDailySummaryReport/DailySummaryReportQueryValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Queries.GetDailySummaryReport;
+
+public sealed class DailySummaryReportQueryValidator : AbstractValidator<DailySummaryReportQuery>
+{
+    public DailySummaryReportQueryValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty();
+
+        RuleFor(x => x.Date)
+            .Must(d => d <= DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)))
+            .WithMessage("Date cannot be far in the future.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/GetQueuePerformanceReport/QueuePerformanceReportQuery.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueuePerformanceReport/QueuePerformanceReportQuery.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using NextTurn.Application.Queue.Reports;
+
+namespace NextTurn.Application.Queue.Queries.GetQueuePerformanceReport;
+
+public sealed record QueuePerformanceReportQuery(
+    Guid OrganisationId,
+    DateOnly StartDate,
+    DateOnly EndDate,
+    Guid? ServiceId,
+    Guid? OfficeId) : IRequest<QueuePerformanceReportResult>;

--- a/src/NextTurn.Application/Queue/Queries/GetQueuePerformanceReport/QueuePerformanceReportQueryHandler.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueuePerformanceReport/QueuePerformanceReportQueryHandler.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using NextTurn.Application.Queue.Reports;
+
+namespace NextTurn.Application.Queue.Queries.GetQueuePerformanceReport;
+
+public sealed class QueuePerformanceReportQueryHandler
+    : IRequestHandler<QueuePerformanceReportQuery, QueuePerformanceReportResult>
+{
+    private readonly IQueuePerformanceReportService _reportService;
+
+    public QueuePerformanceReportQueryHandler(IQueuePerformanceReportService reportService)
+    {
+        _reportService = reportService;
+    }
+
+    public Task<QueuePerformanceReportResult> Handle(
+        QueuePerformanceReportQuery request,
+        CancellationToken cancellationToken)
+    {
+        var filter = new QueuePerformanceFilter(
+            request.OrganisationId,
+            request.StartDate,
+            request.EndDate,
+            request.ServiceId,
+            request.OfficeId);
+
+        return _reportService.GenerateAsync(filter, cancellationToken);
+    }
+}

--- a/src/NextTurn.Application/Queue/Queries/GetQueuePerformanceReport/QueuePerformanceReportQueryValidator.cs
+++ b/src/NextTurn.Application/Queue/Queries/GetQueuePerformanceReport/QueuePerformanceReportQueryValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace NextTurn.Application.Queue.Queries.GetQueuePerformanceReport;
+
+public sealed class QueuePerformanceReportQueryValidator : AbstractValidator<QueuePerformanceReportQuery>
+{
+    public QueuePerformanceReportQueryValidator()
+    {
+        RuleFor(x => x.OrganisationId)
+            .NotEmpty();
+
+        RuleFor(x => x.StartDate)
+            .LessThanOrEqualTo(x => x.EndDate)
+            .WithMessage("Start date must be on or before end date.");
+
+        RuleFor(x => x)
+            .Must(x => x.EndDate.DayNumber - x.StartDate.DayNumber <= 366)
+            .WithMessage("Date range must be 366 days or less.");
+    }
+}

--- a/src/NextTurn.Application/Queue/Reports/IQueuePerformanceExportService.cs
+++ b/src/NextTurn.Application/Queue/Reports/IQueuePerformanceExportService.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public interface IQueuePerformanceExportService
+{
+    byte[] ExportCsv(QueuePerformanceReportResult report);
+}

--- a/src/NextTurn.Application/Queue/Reports/IQueuePerformanceReportService.cs
+++ b/src/NextTurn.Application/Queue/Reports/IQueuePerformanceReportService.cs
@@ -1,0 +1,8 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public interface IQueuePerformanceReportService
+{
+    Task<QueuePerformanceReportResult> GenerateAsync(
+        QueuePerformanceFilter filter,
+        CancellationToken cancellationToken);
+}

--- a/src/NextTurn.Application/Queue/Reports/PeakHourSummary.cs
+++ b/src/NextTurn.Application/Queue/Reports/PeakHourSummary.cs
@@ -1,0 +1,5 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public sealed record PeakHourSummary(
+    int HourOfDay,
+    int ServedCount);

--- a/src/NextTurn.Application/Queue/Reports/QueuePerformanceCalculator.cs
+++ b/src/NextTurn.Application/Queue/Reports/QueuePerformanceCalculator.cs
@@ -1,0 +1,45 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public sealed class QueuePerformanceCalculator
+{
+    public QueuePerformanceReportResult Calculate(
+        QueuePerformanceFilter filter,
+        IReadOnlyList<QueuePerformanceDataPoint> dataPoints)
+    {
+        if (dataPoints.Count == 0)
+        {
+            return new QueuePerformanceReportResult(
+                filter.StartDate,
+                filter.EndDate,
+                filter.ServiceId,
+                filter.OfficeId,
+                TotalServed: 0,
+                AverageWaitMinutes: 0,
+                PeakHours: Array.Empty<PeakHourSummary>());
+        }
+
+        var averageWaitMinutes = Math.Round(
+            dataPoints
+                .Select(p => (p.ServedAt - p.JoinedAt).TotalMinutes)
+                .Select(m => m < 0 ? 0 : m)
+                .Average(),
+            2);
+
+        var peakHours = dataPoints
+            .GroupBy(x => x.HourOfDay)
+            .Select(g => new PeakHourSummary(g.Key, g.Count()))
+            .OrderByDescending(x => x.ServedCount)
+            .ThenBy(x => x.HourOfDay)
+            .Take(3)
+            .ToList();
+
+        return new QueuePerformanceReportResult(
+            filter.StartDate,
+            filter.EndDate,
+            filter.ServiceId,
+            filter.OfficeId,
+            TotalServed: dataPoints.Count,
+            AverageWaitMinutes: averageWaitMinutes,
+            PeakHours: peakHours);
+    }
+}

--- a/src/NextTurn.Application/Queue/Reports/QueuePerformanceCsvExportResult.cs
+++ b/src/NextTurn.Application/Queue/Reports/QueuePerformanceCsvExportResult.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public sealed record QueuePerformanceCsvExportResult(
+    string FileName,
+    string ContentType,
+    byte[] Content);

--- a/src/NextTurn.Application/Queue/Reports/QueuePerformanceDataPoint.cs
+++ b/src/NextTurn.Application/Queue/Reports/QueuePerformanceDataPoint.cs
@@ -1,0 +1,6 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public sealed record QueuePerformanceDataPoint(
+    DateTimeOffset JoinedAt,
+    DateTimeOffset ServedAt,
+    int HourOfDay);

--- a/src/NextTurn.Application/Queue/Reports/QueuePerformanceFilter.cs
+++ b/src/NextTurn.Application/Queue/Reports/QueuePerformanceFilter.cs
@@ -1,0 +1,8 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public sealed record QueuePerformanceFilter(
+    Guid OrganisationId,
+    DateOnly StartDate,
+    DateOnly EndDate,
+    Guid? ServiceId,
+    Guid? OfficeId);

--- a/src/NextTurn.Application/Queue/Reports/QueuePerformanceReportResult.cs
+++ b/src/NextTurn.Application/Queue/Reports/QueuePerformanceReportResult.cs
@@ -1,0 +1,10 @@
+namespace NextTurn.Application.Queue.Reports;
+
+public sealed record QueuePerformanceReportResult(
+    DateOnly StartDate,
+    DateOnly EndDate,
+    Guid? ServiceId,
+    Guid? OfficeId,
+    int TotalServed,
+    double AverageWaitMinutes,
+    IReadOnlyList<PeakHourSummary> PeakHours);

--- a/src/NextTurn.Domain/Appointment/Entities/AppointmentNotificationAuditLog.cs
+++ b/src/NextTurn.Domain/Appointment/Entities/AppointmentNotificationAuditLog.cs
@@ -1,0 +1,119 @@
+namespace NextTurn.Domain.Appointment.Entities;
+
+/// <summary>
+/// Immutable audit row for appointment notification delivery attempts.
+/// </summary>
+public sealed class AppointmentNotificationAuditLog
+{
+    public Guid Id { get; }
+    public Guid OrganisationId { get; private set; }
+    public Guid AppointmentId { get; private set; }
+    public Guid UserId { get; private set; }
+    public string NotificationType { get; private set; }
+    public string DeliveryStatus { get; private set; }
+    public string RecipientEmail { get; private set; }
+    public DateTimeOffset SlotStart { get; private set; }
+    public DateTimeOffset SlotEnd { get; private set; }
+    public string OfficeName { get; private set; }
+    public string ServiceName { get; private set; }
+    public string? ErrorMessage { get; private set; }
+    public DateTimeOffset CreatedAt { get; }
+
+    private AppointmentNotificationAuditLog()
+    {
+        NotificationType = default!;
+        DeliveryStatus = default!;
+        RecipientEmail = default!;
+        OfficeName = default!;
+        ServiceName = default!;
+    }
+
+    private AppointmentNotificationAuditLog(
+        Guid id,
+        Guid organisationId,
+        Guid appointmentId,
+        Guid userId,
+        string notificationType,
+        string deliveryStatus,
+        string recipientEmail,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        string? errorMessage,
+        DateTimeOffset createdAt)
+    {
+        Id = id;
+        OrganisationId = organisationId;
+        AppointmentId = appointmentId;
+        UserId = userId;
+        NotificationType = notificationType;
+        DeliveryStatus = deliveryStatus;
+        RecipientEmail = recipientEmail;
+        SlotStart = slotStart;
+        SlotEnd = slotEnd;
+        OfficeName = officeName;
+        ServiceName = serviceName;
+        ErrorMessage = errorMessage;
+        CreatedAt = createdAt;
+    }
+
+    public static AppointmentNotificationAuditLog Sent(
+        Guid organisationId,
+        Guid appointmentId,
+        Guid userId,
+        string notificationType,
+        string recipientEmail,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName)
+    {
+        return new AppointmentNotificationAuditLog(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            appointmentId: appointmentId,
+            userId: userId,
+            notificationType: notificationType,
+            deliveryStatus: "Sent",
+            recipientEmail: recipientEmail,
+            slotStart: slotStart,
+            slotEnd: slotEnd,
+            officeName: officeName,
+            serviceName: serviceName,
+            errorMessage: null,
+            createdAt: DateTimeOffset.UtcNow);
+    }
+
+    public static AppointmentNotificationAuditLog Failed(
+        Guid organisationId,
+        Guid appointmentId,
+        Guid userId,
+        string notificationType,
+        string recipientEmail,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        string errorMessage)
+    {
+        var normalizedError = string.IsNullOrWhiteSpace(errorMessage)
+            ? "Appointment notification delivery failed."
+            : errorMessage.Trim();
+
+        return new AppointmentNotificationAuditLog(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            appointmentId: appointmentId,
+            userId: userId,
+            notificationType: notificationType,
+            deliveryStatus: "Failed",
+            recipientEmail: recipientEmail,
+            slotStart: slotStart,
+            slotEnd: slotEnd,
+            officeName: officeName,
+            serviceName: serviceName,
+            errorMessage: normalizedError.Length > 500 ? normalizedError[..500] : normalizedError,
+            createdAt: DateTimeOffset.UtcNow);
+    }
+}

--- a/src/NextTurn.Domain/Auth/Entities/User.cs
+++ b/src/NextTurn.Domain/Auth/Entities/User.cs
@@ -33,6 +33,9 @@ public class User {
   /// </summary>
   public bool MfaEnabled { get; private set; }
   public bool QueueTurnApproachingNotificationsEnabled { get; private set; }
+  public bool AppointmentBookedNotificationsEnabled { get; private set; }
+  public bool AppointmentRescheduledNotificationsEnabled { get; private set; }
+  public bool AppointmentCancelledNotificationsEnabled { get; private set; }
 
   // ── Staff invite onboarding ──────────────────────────────────────────────
   public string? StaffInviteTokenHash { get; private set; }
@@ -65,6 +68,9 @@ public class User {
     LockoutUntil = null;
     MfaEnabled = false;
     QueueTurnApproachingNotificationsEnabled = true;
+    AppointmentBookedNotificationsEnabled = true;
+    AppointmentRescheduledNotificationsEnabled = true;
+    AppointmentCancelledNotificationsEnabled = true;
   }
 
   public static User Create(Guid tenantId, string name, EmailAddress email, string? phone, string passwordHash, UserRole role = UserRole.User)
@@ -220,6 +226,16 @@ public class User {
   public void SetQueueTurnApproachingNotificationsEnabled(bool enabled)
   {
     QueueTurnApproachingNotificationsEnabled = enabled;
+  }
+
+  public void SetAppointmentNotificationPreferences(
+    bool bookedEnabled,
+    bool rescheduledEnabled,
+    bool cancelledEnabled)
+  {
+    AppointmentBookedNotificationsEnabled = bookedEnabled;
+    AppointmentRescheduledNotificationsEnabled = rescheduledEnabled;
+    AppointmentCancelledNotificationsEnabled = cancelledEnabled;
   }
   
 }

--- a/src/NextTurn.Domain/Auth/Entities/User.cs
+++ b/src/NextTurn.Domain/Auth/Entities/User.cs
@@ -32,6 +32,7 @@ public class User {
   /// Stored on the entity now so the column exists in the DB schema before we need it.
   /// </summary>
   public bool MfaEnabled { get; private set; }
+  public bool QueueTurnApproachingNotificationsEnabled { get; private set; }
 
   // ── Staff invite onboarding ──────────────────────────────────────────────
   public string? StaffInviteTokenHash { get; private set; }
@@ -63,6 +64,7 @@ public class User {
     FailedLoginAttempts = 0;
     LockoutUntil = null;
     MfaEnabled = false;
+    QueueTurnApproachingNotificationsEnabled = true;
   }
 
   public static User Create(Guid tenantId, string name, EmailAddress email, string? phone, string passwordHash, UserRole role = UserRole.User)
@@ -213,6 +215,11 @@ public class User {
     return StaffInviteTokenHash == tokenHash
       && StaffInviteExpiresAt.HasValue
       && StaffInviteExpiresAt.Value > DateTimeOffset.UtcNow;
+  }
+
+  public void SetQueueTurnApproachingNotificationsEnabled(bool enabled)
+  {
+    QueueTurnApproachingNotificationsEnabled = enabled;
   }
   
 }

--- a/src/NextTurn.Domain/Organisation/Entities/Organisation.cs
+++ b/src/NextTurn.Domain/Organisation/Entities/Organisation.cs
@@ -29,6 +29,7 @@ public class Organisation
     public OrganisationType    Type        { get; private set; }
     public OrganisationStatus  Status      { get; private set; }
     public EmailAddress        AdminEmail  { get; private set; }
+    public int                 QueueNotificationThreshold { get; private set; }
     public DateTimeOffset      CreatedAt   { get; }
 
     // Required by EF Core for entity materialisation — prevents direct construction.
@@ -49,6 +50,7 @@ public class Organisation
         OrganisationType   type,
         OrganisationStatus status,
         EmailAddress       adminEmail,
+        int                queueNotificationThreshold,
         DateTimeOffset     createdAt)
     {
         Id         = id;
@@ -58,6 +60,7 @@ public class Organisation
         Type       = type;
         Status     = status;
         AdminEmail = adminEmail;
+        QueueNotificationThreshold = queueNotificationThreshold;
         CreatedAt  = createdAt;
     }
 
@@ -91,6 +94,7 @@ public class Organisation
             type:       type,
             status:     OrganisationStatus.PendingApproval,
             adminEmail: adminEmail,
+            queueNotificationThreshold: 3,
             createdAt:  DateTimeOffset.UtcNow);
     }
 
@@ -167,5 +171,13 @@ public class Organisation
             throw new DomainException("Only a suspended organisation can be reinstated.");
 
         Status = OrganisationStatus.Active;
+    }
+
+    public void SetQueueNotificationThreshold(int threshold)
+    {
+        if (threshold < 1 || threshold > 50)
+            throw new DomainException("Queue notification threshold must be between 1 and 50.");
+
+        QueueNotificationThreshold = threshold;
     }
 }

--- a/src/NextTurn.Domain/Queue/Entities/QueueTurnNotificationAuditLog.cs
+++ b/src/NextTurn.Domain/Queue/Entities/QueueTurnNotificationAuditLog.cs
@@ -1,0 +1,94 @@
+namespace NextTurn.Domain.Queue.Entities;
+
+/// <summary>
+/// Immutable audit record for queue turn-approaching notification delivery attempts.
+/// </summary>
+public sealed class QueueTurnNotificationAuditLog
+{
+    public Guid Id { get; }
+    public Guid OrganisationId { get; private set; }
+    public Guid QueueId { get; private set; }
+    public Guid QueueEntryId { get; private set; }
+    public Guid UserId { get; private set; }
+    public int PositionInQueue { get; private set; }
+    public int Threshold { get; private set; }
+    public string DeliveryStatus { get; private set; }
+    public string? ErrorMessage { get; private set; }
+    public DateTimeOffset CreatedAt { get; }
+
+    private QueueTurnNotificationAuditLog()
+    {
+        DeliveryStatus = default!;
+    }
+
+    private QueueTurnNotificationAuditLog(
+        Guid id,
+        Guid organisationId,
+        Guid queueId,
+        Guid queueEntryId,
+        Guid userId,
+        int positionInQueue,
+        int threshold,
+        string deliveryStatus,
+        string? errorMessage,
+        DateTimeOffset createdAt)
+    {
+        Id = id;
+        OrganisationId = organisationId;
+        QueueId = queueId;
+        QueueEntryId = queueEntryId;
+        UserId = userId;
+        PositionInQueue = positionInQueue;
+        Threshold = threshold;
+        DeliveryStatus = deliveryStatus;
+        ErrorMessage = errorMessage;
+        CreatedAt = createdAt;
+    }
+
+    public static QueueTurnNotificationAuditLog Sent(
+        Guid organisationId,
+        Guid queueId,
+        Guid queueEntryId,
+        Guid userId,
+        int positionInQueue,
+        int threshold)
+    {
+        return new QueueTurnNotificationAuditLog(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            queueId: queueId,
+            queueEntryId: queueEntryId,
+            userId: userId,
+            positionInQueue: positionInQueue,
+            threshold: threshold,
+            deliveryStatus: "Sent",
+            errorMessage: null,
+            createdAt: DateTimeOffset.UtcNow);
+    }
+
+    public static QueueTurnNotificationAuditLog Failed(
+        Guid organisationId,
+        Guid queueId,
+        Guid queueEntryId,
+        Guid userId,
+        int positionInQueue,
+        int threshold,
+        string errorMessage)
+    {
+        var normalizedError = string.IsNullOrWhiteSpace(errorMessage)
+            ? "Notification delivery failed."
+            : errorMessage.Trim();
+
+        return new QueueTurnNotificationAuditLog(
+            id: Guid.NewGuid(),
+            organisationId: organisationId,
+            queueId: queueId,
+            queueEntryId: queueEntryId,
+            userId: userId,
+            positionInQueue: positionInQueue,
+            threshold: threshold,
+            deliveryStatus: "Failed",
+            errorMessage: normalizedError.Length > 500 ? normalizedError[..500] : normalizedError,
+            createdAt: DateTimeOffset.UtcNow);
+    }
+}

--- a/src/NextTurn.Domain/Queue/Enums/QueueActionType.cs
+++ b/src/NextTurn.Domain/Queue/Enums/QueueActionType.cs
@@ -7,4 +7,5 @@ public enum QueueActionType
 {
     Serve,
     Skip,
+    NoShow,
 }

--- a/src/NextTurn.Infrastructure/DependencyInjection.cs
+++ b/src/NextTurn.Infrastructure/DependencyInjection.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Reports;
 using NextTurn.Domain.Appointment.Repositories;
 using NextTurn.Domain.Auth.Repositories;
 using NextTurn.Domain.Organisation.Repositories;
@@ -88,6 +89,8 @@ public static class DependencyInjection
         // StubQueueStateService derives position from SQL COUNT queries.
         // Sprint 2+: swap for a Redis-backed implementation — no caller changes needed.
         services.AddScoped<IQueueStateService, StubQueueStateService>();
+        services.AddScoped<IQueuePerformanceReportService, QueuePerformanceReportService>();
+        services.AddScoped<IQueuePerformanceExportService, QueuePerformanceExportService>();
 
         return services;
     }

--- a/src/NextTurn.Infrastructure/DependencyInjection.cs
+++ b/src/NextTurn.Infrastructure/DependencyInjection.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.DailySummary;
 using NextTurn.Application.Queue.Reports;
 using NextTurn.Domain.Appointment.Repositories;
 using NextTurn.Domain.Auth.Repositories;
@@ -89,6 +90,7 @@ public static class DependencyInjection
         // StubQueueStateService derives position from SQL COUNT queries.
         // Sprint 2+: swap for a Redis-backed implementation — no caller changes needed.
         services.AddScoped<IQueueStateService, StubQueueStateService>();
+        services.AddScoped<IDailyQueueSummaryReportService, DailyQueueSummaryReportService>();
         services.AddScoped<IQueuePerformanceReportService, QueuePerformanceReportService>();
         services.AddScoped<IQueuePerformanceExportService, QueuePerformanceExportService>();
 

--- a/src/NextTurn.Infrastructure/Email/StubEmailService.cs
+++ b/src/NextTurn.Infrastructure/Email/StubEmailService.cs
@@ -67,4 +67,27 @@ public sealed class StubEmailService : IEmailService
 
         return Task.CompletedTask;
     }
+
+    public Task SendAppointmentStatusEmailAsync(
+        string toEmail,
+        string userName,
+        string notificationType,
+        DateTimeOffset slotStart,
+        DateTimeOffset slotEnd,
+        string officeName,
+        string serviceName,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "[STUB] Appointment {NotificationType} email would be sent to {Email} ({UserName}). Slot: {SlotStart}->{SlotEnd}, Office: {OfficeName}, Service: {ServiceName}",
+            notificationType,
+            toEmail,
+            userName,
+            slotStart,
+            slotEnd,
+            officeName,
+            serviceName);
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/NextTurn.Infrastructure/Email/StubEmailService.cs
+++ b/src/NextTurn.Infrastructure/Email/StubEmailService.cs
@@ -50,4 +50,21 @@ public sealed class StubEmailService : IEmailService
 
         return Task.CompletedTask;
     }
+
+    public Task SendQueueTurnApproachingEmailAsync(
+        string toEmail,
+        string queueName,
+        int ticketNumber,
+        int positionInQueue,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "[STUB] Queue approaching notification would be sent to {Email}. Queue: {QueueName}, Ticket: {TicketNumber}, Position: {PositionInQueue}",
+            toEmail,
+            queueName,
+            ticketNumber,
+            positionInQueue);
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/NextTurn.Infrastructure/Migrations/20260408103000_AddQueueTurnNotificationSettings.cs
+++ b/src/NextTurn.Infrastructure/Migrations/20260408103000_AddQueueTurnNotificationSettings.cs
@@ -1,0 +1,103 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NextTurn.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQueueTurnNotificationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "QueueTurnApproachingNotificationsEnabled",
+                table: "Users",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "QueueNotificationThreshold",
+                table: "Organisations",
+                type: "int",
+                nullable: false,
+                defaultValue: 3);
+
+            migrationBuilder.CreateTable(
+                name: "QueueTurnNotificationAuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrganisationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    QueueId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    QueueEntryId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PositionInQueue = table.Column<int>(type: "int", nullable: false),
+                    Threshold = table.Column<int>(type: "int", nullable: false),
+                    DeliveryStatus = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    ErrorMessage = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QueueTurnNotificationAuditLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_QueueTurnNotificationAuditLogs_QueueEntries_QueueEntryId",
+                        column: x => x.QueueEntryId,
+                        principalTable: "QueueEntries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_QueueTurnNotificationAuditLogs_Queues_QueueId",
+                        column: x => x.QueueId,
+                        principalTable: "Queues",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_QueueTurnNotificationAuditLogs_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueTurnNotificationAuditLogs_QueueId_CreatedAt",
+                table: "QueueTurnNotificationAuditLogs",
+                columns: new[] { "QueueId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueTurnNotificationAuditLogs_QueueEntryId",
+                table: "QueueTurnNotificationAuditLogs",
+                column: "QueueEntryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QueueTurnNotificationAuditLogs_UserId",
+                table: "QueueTurnNotificationAuditLogs",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_QueueTurnNotificationAuditLogs_QueueEntry_User_Status",
+                table: "QueueTurnNotificationAuditLogs",
+                columns: new[] { "QueueEntryId", "UserId", "DeliveryStatus" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "QueueTurnNotificationAuditLogs");
+
+            migrationBuilder.DropColumn(
+                name: "QueueTurnApproachingNotificationsEnabled",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "QueueNotificationThreshold",
+                table: "Organisations");
+        }
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NextTurn.Application.Common.Interfaces;
 using AppointmentEntity  = NextTurn.Domain.Appointment.Entities.Appointment;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
 using AppointmentProfile = NextTurn.Domain.Appointment.Entities.AppointmentProfile;
 using AppointmentProfileStaffAssignment = NextTurn.Domain.Appointment.Entities.AppointmentProfileStaffAssignment;
 using AppointmentScheduleRule = NextTurn.Domain.Appointment.Entities.AppointmentScheduleRule;
@@ -55,6 +56,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
     // Appointment module (NT-19).
     public DbSet<AppointmentEntity> Appointments => Set<AppointmentEntity>();
+    public DbSet<AppointmentNotificationAuditLog> AppointmentNotificationAuditLogs => Set<AppointmentNotificationAuditLog>();
     public DbSet<AppointmentProfile> AppointmentProfiles => Set<AppointmentProfile>();
     public DbSet<AppointmentProfileStaffAssignment> AppointmentProfileStaffAssignments => Set<AppointmentProfileStaffAssignment>();
     public DbSet<AppointmentScheduleRule> AppointmentScheduleRules => Set<AppointmentScheduleRule>();
@@ -112,6 +114,9 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
 
         // Appointments: scoped by organisation (tenant).
         modelBuilder.Entity<AppointmentEntity>()
+            .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<AppointmentNotificationAuditLog>()
             .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
 
         modelBuilder.Entity<AppointmentProfile>()

--- a/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/NextTurn.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -12,6 +12,7 @@ using QueueEntity        = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry         = NextTurn.Domain.Queue.Entities.QueueEntry;
 using QueueStaffAssignment = NextTurn.Domain.Queue.Entities.QueueStaffAssignment;
 using QueueActionAuditLog = NextTurn.Domain.Queue.Entities.QueueActionAuditLog;
+using QueueTurnNotificationAuditLog = NextTurn.Domain.Queue.Entities.QueueTurnNotificationAuditLog;
 using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
 using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
 using ServiceOfficeAssignment = NextTurn.Domain.Service.Entities.ServiceOfficeAssignment;
@@ -50,6 +51,7 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<QueueEntry>  QueueEntries => Set<QueueEntry>();
     public DbSet<QueueStaffAssignment> QueueStaffAssignments => Set<QueueStaffAssignment>();
     public DbSet<QueueActionAuditLog> QueueActionAuditLogs => Set<QueueActionAuditLog>();
+    public DbSet<QueueTurnNotificationAuditLog> QueueTurnNotificationAuditLogs => Set<QueueTurnNotificationAuditLog>();
 
     // Appointment module (NT-19).
     public DbSet<AppointmentEntity> Appointments => Set<AppointmentEntity>();
@@ -100,6 +102,9 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
             .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
 
         modelBuilder.Entity<QueueActionAuditLog>()
+            .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
+
+        modelBuilder.Entity<QueueTurnNotificationAuditLog>()
             .HasQueryFilter(a => a.OrganisationId == _tenantContext.TenantId);
 
         modelBuilder.Entity<OfficeEntity>()

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Appointment/AppointmentNotificationAuditLogConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Appointment/AppointmentNotificationAuditLogConfiguration.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+using AppointmentNotificationAuditLog = NextTurn.Domain.Appointment.Entities.AppointmentNotificationAuditLog;
+using UserEntity = NextTurn.Domain.Auth.Entities.User;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Appointment;
+
+public sealed class AppointmentNotificationAuditLogConfiguration : IEntityTypeConfiguration<AppointmentNotificationAuditLog>
+{
+    public void Configure(EntityTypeBuilder<AppointmentNotificationAuditLog> builder)
+    {
+        builder.ToTable("AppointmentNotificationAuditLogs");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(x => x.OrganisationId)
+            .IsRequired();
+
+        builder.Property(x => x.AppointmentId)
+            .IsRequired();
+
+        builder.Property(x => x.UserId)
+            .IsRequired();
+
+        builder.Property(x => x.NotificationType)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(x => x.DeliveryStatus)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(x => x.RecipientEmail)
+            .IsRequired()
+            .HasMaxLength(254);
+
+        builder.Property(x => x.SlotStart)
+            .IsRequired();
+
+        builder.Property(x => x.SlotEnd)
+            .IsRequired();
+
+        builder.Property(x => x.OfficeName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(x => x.ServiceName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(x => x.ErrorMessage)
+            .HasMaxLength(500);
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne<AppointmentEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.AppointmentId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<UserEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.AppointmentId, x.NotificationType, x.DeliveryStatus })
+            .HasDatabaseName("IX_AppointmentNotificationAuditLogs_Appointment_Type_Status");
+
+        builder.HasIndex(x => new { x.OrganisationId, x.CreatedAt })
+            .HasDatabaseName("IX_AppointmentNotificationAuditLogs_Organisation_CreatedAt");
+    }
+}

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
@@ -101,6 +101,10 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .IsRequired()
             .HasDefaultValue(false);
 
+        builder.Property(u => u.QueueTurnApproachingNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
         builder.Property(u => u.StaffInviteTokenHash)
             .HasMaxLength(128);
 

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Auth/UserConfiguration.cs
@@ -105,6 +105,18 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .IsRequired()
             .HasDefaultValue(true);
 
+        builder.Property(u => u.AppointmentBookedNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(u => u.AppointmentRescheduledNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(u => u.AppointmentCancelledNotificationsEnabled)
+            .IsRequired()
+            .HasDefaultValue(true);
+
         builder.Property(u => u.StaffInviteTokenHash)
             .HasMaxLength(128);
 

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Organisation/OrganisationConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Organisation/OrganisationConfiguration.cs
@@ -87,5 +87,9 @@ public class OrganisationConfiguration : IEntityTypeConfiguration<OrganisationEn
 
         builder.Property(o => o.CreatedAt)
             .IsRequired();
+
+        builder.Property(o => o.QueueNotificationThreshold)
+            .IsRequired()
+            .HasDefaultValue(3);
     }
 }

--- a/src/NextTurn.Infrastructure/Persistence/Configurations/Queue/QueueTurnNotificationAuditLogConfiguration.cs
+++ b/src/NextTurn.Infrastructure/Persistence/Configurations/Queue/QueueTurnNotificationAuditLogConfiguration.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QueueTurnNotificationAuditLog = NextTurn.Domain.Queue.Entities.QueueTurnNotificationAuditLog;
+using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+using UserEntity = NextTurn.Domain.Auth.Entities.User;
+
+namespace NextTurn.Infrastructure.Persistence.Configurations.Queue;
+
+public sealed class QueueTurnNotificationAuditLogConfiguration : IEntityTypeConfiguration<QueueTurnNotificationAuditLog>
+{
+    public void Configure(EntityTypeBuilder<QueueTurnNotificationAuditLog> builder)
+    {
+        builder.ToTable("QueueTurnNotificationAuditLogs");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(x => x.OrganisationId)
+            .IsRequired();
+
+        builder.Property(x => x.QueueId)
+            .IsRequired();
+
+        builder.Property(x => x.QueueEntryId)
+            .IsRequired();
+
+        builder.Property(x => x.UserId)
+            .IsRequired();
+
+        builder.Property(x => x.PositionInQueue)
+            .IsRequired();
+
+        builder.Property(x => x.Threshold)
+            .IsRequired();
+
+        builder.Property(x => x.DeliveryStatus)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(x => x.ErrorMessage)
+            .HasMaxLength(500);
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne<QueueEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.QueueId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<QueueEntry>()
+            .WithMany()
+            .HasForeignKey(x => x.QueueEntryId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<UserEntity>()
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.QueueEntryId, x.UserId, x.DeliveryStatus })
+            .HasDatabaseName("UX_QueueTurnNotificationAuditLogs_QueueEntry_User_Status")
+            .IsUnique();
+
+        builder.HasIndex(x => new { x.QueueId, x.CreatedAt })
+            .HasDatabaseName("IX_QueueTurnNotificationAuditLogs_QueueId_CreatedAt");
+    }
+}

--- a/src/NextTurn.Infrastructure/Queue/DailyQueueSummaryReportService.cs
+++ b/src/NextTurn.Infrastructure/Queue/DailyQueueSummaryReportService.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.DailySummary;
+using NextTurn.Domain.Queue.Enums;
+
+namespace NextTurn.Infrastructure.Queue;
+
+public sealed class DailyQueueSummaryReportService : IDailyQueueSummaryReportService
+{
+    private readonly IApplicationDbContext _context;
+    private readonly DailyQueueSummaryCalculator _calculator;
+
+    public DailyQueueSummaryReportService(
+        IApplicationDbContext context,
+        DailyQueueSummaryCalculator calculator)
+    {
+        _context = context;
+        _calculator = calculator;
+    }
+
+    public async Task<DailyQueueSummaryReportResult> GenerateAsync(
+        Guid organisationId,
+        DateOnly date,
+        CancellationToken cancellationToken)
+    {
+        var previousWeekDate = date.AddDays(-7);
+        var rangeStart = previousWeekDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var rangeEndExclusive = date.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var raw = await (
+            from log in _context.QueueActionAuditLogs.AsNoTracking()
+            join staffOffice in _context.StaffOfficeAssignments.AsNoTracking()
+                on new { log.OrganisationId, StaffUserId = log.PerformedByUserId }
+                equals new { staffOffice.OrganisationId, staffOffice.StaffUserId }
+            join serviceOffice in _context.ServiceOfficeAssignments.AsNoTracking()
+                on new { staffOffice.OrganisationId, staffOffice.OfficeId }
+                equals new { serviceOffice.OrganisationId, serviceOffice.OfficeId }
+            join office in _context.Offices.AsNoTracking()
+                on staffOffice.OfficeId equals office.Id
+            join service in _context.Services.AsNoTracking()
+                on serviceOffice.ServiceId equals service.Id
+            where log.OrganisationId == organisationId
+                  && log.CreatedAt >= rangeStart
+                  && log.CreatedAt < rangeEndExclusive
+                  && (log.ActionType == QueueActionType.Serve
+                      || log.ActionType == QueueActionType.Skip
+                      || log.ActionType == QueueActionType.NoShow)
+            select new
+            {
+                log.CreatedAt,
+                log.ActionType,
+                OfficeId = office.Id,
+                OfficeName = office.Name,
+                ServiceId = service.Id,
+                ServiceName = service.Name,
+            })
+            .ToListAsync(cancellationToken);
+
+        var points = raw
+            .GroupBy(x => new
+            {
+                Date = DateOnly.FromDateTime(x.CreatedAt.UtcDateTime),
+                x.OfficeId,
+                x.OfficeName,
+                x.ServiceId,
+                x.ServiceName,
+                x.ActionType,
+            })
+            .Select(g => new DailyQueueSummaryAggregationPoint(
+                Date: g.Key.Date,
+                OfficeId: g.Key.OfficeId,
+                OfficeName: g.Key.OfficeName,
+                ServiceId: g.Key.ServiceId,
+                ServiceName: g.Key.ServiceName,
+                ActionType: g.Key.ActionType,
+                Count: g.Count()))
+            .ToList();
+
+        return _calculator.Calculate(date, points);
+    }
+}

--- a/src/NextTurn.Infrastructure/Queue/QueuePerformanceExportService.cs
+++ b/src/NextTurn.Infrastructure/Queue/QueuePerformanceExportService.cs
@@ -1,0 +1,29 @@
+using System.Text;
+using NextTurn.Application.Queue.Reports;
+
+namespace NextTurn.Infrastructure.Queue;
+
+public sealed class QueuePerformanceExportService : IQueuePerformanceExportService
+{
+    public byte[] ExportCsv(QueuePerformanceReportResult report)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("Metric,Value");
+        sb.AppendLine($"StartDate,{report.StartDate:yyyy-MM-dd}");
+        sb.AppendLine($"EndDate,{report.EndDate:yyyy-MM-dd}");
+        sb.AppendLine($"ServiceId,{report.ServiceId?.ToString() ?? "All"}");
+        sb.AppendLine($"OfficeId,{report.OfficeId?.ToString() ?? "All"}");
+        sb.AppendLine($"TotalServed,{report.TotalServed}");
+        sb.AppendLine($"AverageWaitMinutes,{report.AverageWaitMinutes:F2}");
+        sb.AppendLine();
+        sb.AppendLine("PeakHour,ServedCount");
+
+        foreach (var peakHour in report.PeakHours)
+        {
+            sb.AppendLine($"{peakHour.HourOfDay:00}:00-{peakHour.HourOfDay:00}:59,{peakHour.ServedCount}");
+        }
+
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+}

--- a/src/NextTurn.Infrastructure/Queue/QueuePerformanceReportService.cs
+++ b/src/NextTurn.Infrastructure/Queue/QueuePerformanceReportService.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Reports;
+using NextTurn.Domain.Queue.Enums;
+
+namespace NextTurn.Infrastructure.Queue;
+
+public sealed class QueuePerformanceReportService : IQueuePerformanceReportService
+{
+    private readonly IApplicationDbContext _context;
+    private readonly QueuePerformanceCalculator _calculator;
+
+    public QueuePerformanceReportService(
+        IApplicationDbContext context,
+        QueuePerformanceCalculator calculator)
+    {
+        _context = context;
+        _calculator = calculator;
+    }
+
+    public async Task<QueuePerformanceReportResult> GenerateAsync(
+        QueuePerformanceFilter filter,
+        CancellationToken cancellationToken)
+    {
+        var rangeStart = filter.StartDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var rangeEndExclusive = filter.EndDate.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var baseQuery =
+            from log in _context.QueueActionAuditLogs.AsNoTracking()
+            join entry in _context.QueueEntries.AsNoTracking()
+                on log.QueueEntryId equals entry.Id
+            join queue in _context.Queues.AsNoTracking()
+                on entry.QueueId equals queue.Id
+            where log.ActionType == QueueActionType.Serve
+                  && queue.OrganisationId == filter.OrganisationId
+                  && log.CreatedAt >= rangeStart
+                  && log.CreatedAt < rangeEndExclusive
+            select new
+            {
+                log.CreatedAt,
+                log.PerformedByUserId,
+                entry.JoinedAt,
+            };
+
+        if (filter.OfficeId.HasValue)
+        {
+            var officeId = filter.OfficeId.Value;
+            baseQuery = baseQuery.Where(x =>
+                _context.StaffOfficeAssignments.Any(a =>
+                    a.StaffUserId == x.PerformedByUserId &&
+                    a.OfficeId == officeId));
+        }
+
+        if (filter.ServiceId.HasValue)
+        {
+            var serviceId = filter.ServiceId.Value;
+            baseQuery = baseQuery.Where(x =>
+                (from staffOffice in _context.StaffOfficeAssignments
+                 join serviceOffice in _context.ServiceOfficeAssignments
+                     on staffOffice.OfficeId equals serviceOffice.OfficeId
+                 where staffOffice.StaffUserId == x.PerformedByUserId
+                       && serviceOffice.ServiceId == serviceId
+                 select staffOffice.OfficeId).Any());
+        }
+
+        var dataPoints = await baseQuery
+            .Select(x => new QueuePerformanceDataPoint(
+                x.JoinedAt,
+                x.CreatedAt,
+                x.CreatedAt.UtcDateTime.Hour))
+            .ToListAsync(cancellationToken);
+
+        return _calculator.Calculate(filter, dataPoints);
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -34,6 +34,7 @@ import { StaffDashboardPage }   from './pages/Staff'
 import { OfficeManagementPage } from './pages/Offices'
 import { ServiceManagementPage } from './pages/Services'
 import { QueuePerformanceReportPage } from './pages/QueuePerformanceReport'
+import { DailyQueueSummaryPage } from './pages/DailyQueueSummary'
 import { StaffInviteAcceptPage } from './pages/StaffInviteAccept'
 import { OrgLoginLookupPage }   from './pages/OrgLoginLookup'
 import { TermsPage, PrivacyPage } from './pages/Legal'
@@ -117,6 +118,15 @@ function App() {
         element={
           <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
             <QueuePerformanceReportPage />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/:tenantId/reports/daily-summary"
+        element={
+          <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
+            <DailyQueueSummaryPage />
           </ProtectedRoute>
         }
       />

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -33,6 +33,7 @@ import { AdminDashboardPage }   from './pages/Admin'
 import { StaffDashboardPage }   from './pages/Staff'
 import { OfficeManagementPage } from './pages/Offices'
 import { ServiceManagementPage } from './pages/Services'
+import { QueuePerformanceReportPage } from './pages/QueuePerformanceReport'
 import { StaffInviteAcceptPage } from './pages/StaffInviteAccept'
 import { OrgLoginLookupPage }   from './pages/OrgLoginLookup'
 import { TermsPage, PrivacyPage } from './pages/Legal'
@@ -107,6 +108,15 @@ function App() {
         element={
           <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
             <ServiceManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/:tenantId/reports"
+        element={
+          <ProtectedRoute allowedRoles={['OrgAdmin', 'SystemAdmin']}>
+            <QueuePerformanceReportPage />
           </ProtectedRoute>
         }
       />

--- a/src/web/src/api/auth.ts
+++ b/src/web/src/api/auth.ts
@@ -44,6 +44,12 @@ export interface QueueNotificationPreferenceResult {
   queueTurnApproachingNotificationsEnabled: boolean
 }
 
+export interface AppointmentNotificationPreferencesResult {
+  appointmentBookedNotificationsEnabled: boolean
+  appointmentRescheduledNotificationsEnabled: boolean
+  appointmentCancelledNotificationsEnabled: boolean
+}
+
 /**
  * Shape returned by POST /api/auth/login on HTTP 200.
  * Mirrors NextTurn.API.Models.Auth.LoginResponse on the backend.
@@ -303,6 +309,58 @@ export async function updateQueueNotificationPreference(
       { queueTurnApproachingNotificationsEnabled },
       { headers },
     )
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+/**
+ * GET /api/auth/appointment-notification-preferences
+ */
+export async function getAppointmentNotificationPreferences(
+  tenantId?: string,
+): Promise<AppointmentNotificationPreferencesResult> {
+  try {
+    const token = getToken()
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    if (tenantId) {
+      headers['X-Tenant-Id'] = tenantId
+    }
+
+    const { data } = await apiClient.get<AppointmentNotificationPreferencesResult>(
+      '/auth/appointment-notification-preferences',
+      { headers },
+    )
+
+    return data
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+/**
+ * PUT /api/auth/appointment-notification-preferences
+ */
+export async function updateAppointmentNotificationPreferences(
+  tenantId: string | undefined,
+  preferences: AppointmentNotificationPreferencesResult,
+): Promise<void> {
+  try {
+    const token = getToken()
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    if (tenantId) {
+      headers['X-Tenant-Id'] = tenantId
+    }
+
+    await apiClient.put('/auth/appointment-notification-preferences', preferences, { headers })
   } catch (err) {
     const parsed: ApiError = parseApiError(err)
     throw parsed

--- a/src/web/src/api/auth.ts
+++ b/src/web/src/api/auth.ts
@@ -40,6 +40,10 @@ export interface StaffUserSummary {
   createdAt: string
 }
 
+export interface QueueNotificationPreferenceResult {
+  queueTurnApproachingNotificationsEnabled: boolean
+}
+
 /**
  * Shape returned by POST /api/auth/login on HTTP 200.
  * Mirrors NextTurn.API.Models.Auth.LoginResponse on the backend.
@@ -247,6 +251,58 @@ export async function reactivateStaffUser(tenantId: string, userId: string): Pro
         'X-Tenant-Id': tenantId,
       },
     })
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+/**
+ * GET /api/auth/notification-preferences
+ */
+export async function getQueueNotificationPreference(tenantId?: string): Promise<QueueNotificationPreferenceResult> {
+  try {
+    const token = getToken()
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    if (tenantId) {
+      headers['X-Tenant-Id'] = tenantId
+    }
+
+    const { data } = await apiClient.get<QueueNotificationPreferenceResult>('/auth/notification-preferences', {
+      headers,
+    })
+    return data
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+/**
+ * PUT /api/auth/notification-preferences
+ */
+export async function updateQueueNotificationPreference(
+  tenantId: string | undefined,
+  queueTurnApproachingNotificationsEnabled: boolean,
+): Promise<void> {
+  try {
+    const token = getToken()
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    if (tenantId) {
+      headers['X-Tenant-Id'] = tenantId
+    }
+
+    await apiClient.put(
+      '/auth/notification-preferences',
+      { queueTurnApproachingNotificationsEnabled },
+      { headers },
+    )
   } catch (err) {
     const parsed: ApiError = parseApiError(err)
     throw parsed

--- a/src/web/src/api/organisations.ts
+++ b/src/web/src/api/organisations.ts
@@ -5,6 +5,7 @@
 import { apiClient, parseApiError } from './client'
 import type { OrgRegistrationFormValues } from '../schemas/orgRegistrationSchema'
 import type { ApiError } from '../types/api'
+import { getToken } from '../utils/authToken'
 
 export interface OrgRegistrationPayload {
   orgName: string
@@ -41,6 +42,10 @@ export interface MemberWorkspaceOption {
   slug: string
   loginPath: string
   role: string
+}
+
+export interface QueueNotificationThresholdResult {
+  queueNotificationThreshold: number
 }
 
 /**
@@ -129,6 +134,49 @@ export async function resolveMemberLogin(
       { email },
     )
     return data
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+export async function getQueueNotificationThreshold(
+  tenantId: string,
+): Promise<QueueNotificationThresholdResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<QueueNotificationThresholdResult>(
+      '/organisations/notification-threshold',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      },
+    )
+    return data
+  } catch (err) {
+    const parsed: ApiError = parseApiError(err)
+    throw parsed
+  }
+}
+
+export async function updateQueueNotificationThreshold(
+  tenantId: string,
+  queueNotificationThreshold: number,
+): Promise<void> {
+  try {
+    const token = getToken()
+    await apiClient.put(
+      '/organisations/notification-threshold',
+      { queueNotificationThreshold },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      },
+    )
   } catch (err) {
     const parsed: ApiError = parseApiError(err)
     throw parsed

--- a/src/web/src/api/queues.ts
+++ b/src/web/src/api/queues.ts
@@ -48,6 +48,28 @@ export interface CreateQueueBody {
   averageServiceTimeSeconds: number
 }
 
+export interface QueuePerformanceFilterParams {
+  startDate: string
+  endDate: string
+  serviceId?: string
+  officeId?: string
+}
+
+export interface PeakHourSummary {
+  hourOfDay: number
+  servedCount: number
+}
+
+export interface QueuePerformanceReportResult {
+  startDate: string
+  endDate: string
+  serviceId: string | null
+  officeId: string | null
+  totalServed: number
+  averageWaitMinutes: number
+  peakHours: PeakHourSummary[]
+}
+
 /**
  * POST /api/queues/{queueId}/join
  *
@@ -172,6 +194,69 @@ export async function getOrgQueues(
         },
       }
     )
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+/**
+ * GET /api/queues/reports/performance
+ */
+export async function getQueuePerformanceReport(
+  tenantId: string,
+  filter: QueuePerformanceFilterParams,
+): Promise<QueuePerformanceReportResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<QueuePerformanceReportResult>(
+      '/queues/reports/performance',
+      {
+        params: {
+          startDate: filter.startDate,
+          endDate: filter.endDate,
+          serviceId: filter.serviceId,
+          officeId: filter.officeId,
+        },
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      },
+    )
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+/**
+ * GET /api/queues/reports/performance/export
+ */
+export async function exportQueuePerformanceReportCsv(
+  tenantId: string,
+  filter: QueuePerformanceFilterParams,
+): Promise<Blob> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<Blob>(
+      '/queues/reports/performance/export',
+      {
+        params: {
+          startDate: filter.startDate,
+          endDate: filter.endDate,
+          serviceId: filter.serviceId,
+          officeId: filter.officeId,
+        },
+        responseType: 'blob',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      },
+    )
+
     return data
   } catch (err) {
     throw parseApiError(err)

--- a/src/web/src/api/queues.ts
+++ b/src/web/src/api/queues.ts
@@ -70,6 +70,41 @@ export interface QueuePerformanceReportResult {
   peakHours: PeakHourSummary[]
 }
 
+export interface DailyQueueMetricTrend {
+  previousDay: number
+  previousWeek: number
+  deltaFromPreviousDay: number
+  deltaFromPreviousWeek: number
+  changePercentFromPreviousDay: number
+  changePercentFromPreviousWeek: number
+}
+
+export interface DailyQueueSummaryRow {
+  officeId: string
+  officeName: string
+  serviceId: string
+  serviceName: string
+  served: number
+  skipped: number
+  noShows: number
+  servedTrend: DailyQueueMetricTrend
+  skippedTrend: DailyQueueMetricTrend
+  noShowsTrend: DailyQueueMetricTrend
+}
+
+export interface DailyQueueSummaryReportResult {
+  date: string
+  previousDayDate: string
+  previousWeekDate: string
+  totalServed: number
+  totalSkipped: number
+  totalNoShows: number
+  totalServedTrend: DailyQueueMetricTrend
+  totalSkippedTrend: DailyQueueMetricTrend
+  totalNoShowsTrend: DailyQueueMetricTrend
+  rows: DailyQueueSummaryRow[]
+}
+
 /**
  * POST /api/queues/{queueId}/join
  *
@@ -218,6 +253,32 @@ export async function getQueuePerformanceReport(
           serviceId: filter.serviceId,
           officeId: filter.officeId,
         },
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+        },
+      },
+    )
+
+    return data
+  } catch (err) {
+    throw parseApiError(err)
+  }
+}
+
+/**
+ * GET /api/queues/reports/daily-summary
+ */
+export async function getDailyQueueSummaryReport(
+  tenantId: string,
+  date: string,
+): Promise<DailyQueueSummaryReportResult> {
+  try {
+    const token = getToken()
+    const { data } = await apiClient.get<DailyQueueSummaryReportResult>(
+      '/queues/reports/daily-summary',
+      {
+        params: { date },
         headers: {
           Authorization: `Bearer ${token}`,
           'X-Tenant-Id': tenantId,

--- a/src/web/src/pages/Admin/AdminDashboardPage.tsx
+++ b/src/web/src/pages/Admin/AdminDashboardPage.tsx
@@ -264,6 +264,11 @@ export function AdminDashboardPage() {
     navigate('/', { replace: true })
   }
 
+  function openQueueReports() {
+    if (!tenantId) return
+    navigate(`/admin/${tenantId}/reports`)
+  }
+
   function validate(): boolean {
     const errors: Partial<CreateForm> = {}
     if (!form.name.trim()) errors.name = 'Queue name is required.'
@@ -779,6 +784,13 @@ export function AdminDashboardPage() {
           <div className={styles.toolbarHeader}>
             <h1 className={styles.pageTitle}>Operations Control Center</h1>
             <p className={styles.pageSubtitle}>Manage queues and appointment capacity from one place.</p>
+            <button
+              type="button"
+              className={styles.createBtn}
+              onClick={openQueueReports}
+            >
+              View Queue Performance Reports
+            </button>
           </div>
           <div className={styles.tabs} role="tablist" aria-label="Admin sections">
             <button

--- a/src/web/src/pages/DailyQueueSummary/DailyQueueSummaryPage.module.css
+++ b/src/web/src/pages/DailyQueueSummary/DailyQueueSummaryPage.module.css
@@ -5,7 +5,7 @@
 }
 
 .topNav {
-  max-width: 1100px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 1.5rem 1.25rem 0;
   display: flex;
@@ -23,18 +23,8 @@
   gap: 0.6rem;
 }
 
-.backBtn {
-  border: 1px solid #2f4f4f;
-  background: #fff;
-  color: #2f4f4f;
-  border-radius: 999px;
-  padding: 0.55rem 1rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
 .main {
-  max-width: 1100px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 1rem 1.25rem 2rem;
 }
@@ -49,43 +39,31 @@
 }
 
 .subtitle {
-  margin-top: 0.5rem;
+  margin-top: 0.4rem;
   color: #4f5f70;
 }
 
-.filtersCard {
+.controls {
   background: #fff;
-  border-radius: 16px;
-  padding: 1rem;
+  border-radius: 14px;
   box-shadow: 0 8px 24px rgba(24, 39, 75, 0.08);
-}
-
-.filtersGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  align-items: end;
+  gap: 0.8rem;
+  flex-wrap: wrap;
 }
 
 .field {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.92rem;
-  color: #304052;
 }
 
 .input {
   border: 1px solid #c8d0d8;
   border-radius: 10px;
   padding: 0.55rem 0.7rem;
-  font-size: 0.95rem;
-}
-
-.actions {
-  margin-top: 0.9rem;
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
 }
 
 .primaryBtn,
@@ -119,64 +97,85 @@
 
 .results {
   margin-top: 1rem;
-  display: grid;
-  gap: 1rem;
 }
 
-.summaryGrid {
+.summaryCards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.8rem;
 }
 
-.metricCard {
+.card {
   background: #fff;
-  border-radius: 14px;
+  border-radius: 12px;
   padding: 0.9rem;
   box-shadow: 0 8px 24px rgba(24, 39, 75, 0.08);
 }
 
-.metricLabel {
+.cardLabel {
   color: #4f5f70;
   font-size: 0.85rem;
 }
 
-.metricValue {
+.cardValue {
   display: block;
   margin-top: 0.2rem;
-  font-size: 1.25rem;
+  font-size: 1.4rem;
 }
 
-.peakCard {
+.cardTrend {
+  display: inline-block;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.tableWrap {
+  margin-top: 1rem;
   background: #fff;
-  border-radius: 14px;
-  padding: 1rem;
+  border-radius: 12px;
   box-shadow: 0 8px 24px rgba(24, 39, 75, 0.08);
+  overflow-x: auto;
 }
 
-.sectionTitle {
-  margin: 0 0 0.7rem;
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.7rem;
+  border-bottom: 1px solid #eceff2;
+  text-align: left;
+}
+
+.table th {
+  font-size: 0.82rem;
+  color: #44576a;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.metricCell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.trendUp {
+  color: #0f766e;
+}
+
+.trendDown {
+  color: #be123c;
+}
+
+.trendNeutral {
+  color: #475569;
 }
 
 .emptyText {
-  margin: 0;
-  color: #4f5f70;
-}
-
-.peakList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.peakRow {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.6rem 0;
-  border-bottom: 1px solid #eceff2;
-}
-
-.peakRow:last-child {
-  border-bottom: none;
+  margin-top: 1rem;
+  color: #475569;
 }

--- a/src/web/src/pages/DailyQueueSummary/DailyQueueSummaryPage.tsx
+++ b/src/web/src/pages/DailyQueueSummary/DailyQueueSummaryPage.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { getDailyQueueSummaryReport, type DailyQueueMetricTrend, type DailyQueueSummaryReportResult } from '../../api/queues'
+import type { ApiError } from '../../types/api'
+import { clearToken, getTokenPayload } from '../../utils/authToken'
+import logoImg from '../../assets/nextTurn-logo.png'
+import styles from './DailyQueueSummaryPage.module.css'
+
+function formatDate(value: Date): string {
+  const year = value.getFullYear()
+  const month = `${value.getMonth() + 1}`.padStart(2, '0')
+  const day = `${value.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function trendClass(value: number): string {
+  if (value > 0) return styles.trendUp
+  if (value < 0) return styles.trendDown
+  return styles.trendNeutral
+}
+
+function renderTrend(trend: DailyQueueMetricTrend): string {
+  const day = trend.deltaFromPreviousDay
+  const week = trend.deltaFromPreviousWeek
+  const dayLabel = day > 0 ? `+${day}` : `${day}`
+  const weekLabel = week > 0 ? `+${week}` : `${week}`
+  return `D ${dayLabel} | W ${weekLabel}`
+}
+
+export function DailyQueueSummaryPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const [date, setDate] = useState(() => formatDate(new Date()))
+  const [report, setReport] = useState<DailyQueueSummaryReportResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!payload) {
+    clearToken()
+    navigate('/', { replace: true })
+    return null
+  }
+
+  const hasRows = useMemo(() => (report?.rows.length ?? 0) > 0, [report])
+
+  async function loadSummary() {
+    if (!tenantId) return
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await getDailyQueueSummaryReport(tenantId, date)
+      setReport(result)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not load daily summary report.')
+      setReport(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <nav className={styles.topNav}>
+        <img src={logoImg} alt="NextTurn" className={styles.logo} />
+        <div className={styles.navActions}>
+          <button type="button" className={styles.secondaryBtn} onClick={() => navigate(`/admin/${tenantId}/reports`)}>
+            Queue Performance
+          </button>
+          <button type="button" className={styles.secondaryBtn} onClick={() => navigate(`/admin/${tenantId}`)}>
+            Back to Admin
+          </button>
+        </div>
+      </nav>
+
+      <main className={styles.main}>
+        <section className={styles.header}>
+          <h1 className={styles.title}>Daily Queue Summary</h1>
+          <p className={styles.subtitle}>Served, skipped, and no-show activity per office and service with day/week trend context.</p>
+        </section>
+
+        <section className={styles.controls}>
+          <label className={styles.field}>
+            <span>Summary date</span>
+            <input className={styles.input} type="date" value={date} onChange={e => setDate(e.target.value)} />
+          </label>
+          <button type="button" className={styles.primaryBtn} onClick={loadSummary} disabled={loading}>
+            {loading ? 'Generating...' : 'Generate summary'}
+          </button>
+        </section>
+
+        {error && <div className={styles.errorBanner}>{error}</div>}
+
+        {report && (
+          <section className={styles.results}>
+            <div className={styles.summaryCards}>
+              <article className={styles.card}>
+                <span className={styles.cardLabel}>Total Served</span>
+                <strong className={styles.cardValue}>{report.totalServed}</strong>
+                <span className={`${styles.cardTrend} ${trendClass(report.totalServedTrend.deltaFromPreviousDay)}`}>
+                  {renderTrend(report.totalServedTrend)}
+                </span>
+              </article>
+              <article className={styles.card}>
+                <span className={styles.cardLabel}>Total Skipped</span>
+                <strong className={styles.cardValue}>{report.totalSkipped}</strong>
+                <span className={`${styles.cardTrend} ${trendClass(report.totalSkippedTrend.deltaFromPreviousDay)}`}>
+                  {renderTrend(report.totalSkippedTrend)}
+                </span>
+              </article>
+              <article className={styles.card}>
+                <span className={styles.cardLabel}>Total No-Shows</span>
+                <strong className={styles.cardValue}>{report.totalNoShows}</strong>
+                <span className={`${styles.cardTrend} ${trendClass(report.totalNoShowsTrend.deltaFromPreviousDay)}`}>
+                  {renderTrend(report.totalNoShowsTrend)}
+                </span>
+              </article>
+            </div>
+
+            {!hasRows && <p className={styles.emptyText}>No queue activity found for this date.</p>}
+
+            {hasRows && (
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>Office</th>
+                      <th>Service</th>
+                      <th>Served</th>
+                      <th>Skipped</th>
+                      <th>No-Shows</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {report.rows.map(row => (
+                      <tr key={`${row.officeId}:${row.serviceId}`}>
+                        <td>{row.officeName}</td>
+                        <td>{row.serviceName}</td>
+                        <td>
+                          <div className={styles.metricCell}>
+                            <strong>{row.served}</strong>
+                            <span className={trendClass(row.servedTrend.deltaFromPreviousDay)}>{renderTrend(row.servedTrend)}</span>
+                          </div>
+                        </td>
+                        <td>
+                          <div className={styles.metricCell}>
+                            <strong>{row.skipped}</strong>
+                            <span className={trendClass(row.skippedTrend.deltaFromPreviousDay)}>{renderTrend(row.skippedTrend)}</span>
+                          </div>
+                        </td>
+                        <td>
+                          <div className={styles.metricCell}>
+                            <strong>{row.noShows}</strong>
+                            <span className={trendClass(row.noShowsTrend.deltaFromPreviousDay)}>{renderTrend(row.noShowsTrend)}</span>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/web/src/pages/DailyQueueSummary/index.ts
+++ b/src/web/src/pages/DailyQueueSummary/index.ts
@@ -1,0 +1,1 @@
+export { DailyQueueSummaryPage } from './DailyQueueSummaryPage'

--- a/src/web/src/pages/Dashboard/DashboardPage.module.css
+++ b/src/web/src/pages/Dashboard/DashboardPage.module.css
@@ -344,7 +344,8 @@
    ============================================================ */
 
 .queueSection,
-.joinWidget {
+.joinWidget,
+.settingsSection {
   background: var(--color-white);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -353,6 +354,42 @@
   flex-direction: column;
   gap: var(--space-4);
   box-shadow: 0 1px 6px rgba(35, 114, 39, 0.06);
+}
+
+.settingsToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.settingsToggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+}
+
+.settingsSaveBtn {
+  width: fit-content;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.settingsSaveBtn:hover:not(:disabled) {
+  background: #1b5e20;
+}
+
+.settingsSaveBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .sectionHeader {

--- a/src/web/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/web/src/pages/Dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { clearToken } from '../../utils/authToken'
 import { getTokenPayload } from '../../utils/authToken'
+import { getQueueNotificationPreference, updateQueueNotificationPreference } from '../../api/auth'
 import { getMyQueues, type MyQueueEntry } from '../../api/queues'
 import { cancelAppointment, getMyAppointmentBookings, type MyAppointmentBooking } from '../../api/appointments'
 import type { ApiError } from '../../types/api'
@@ -62,6 +63,13 @@ export function DashboardPage() {
   const [appointmentsError, setAppointmentsError] = useState<string | null>(null)
   const [appointmentsSuccess, setAppointmentsSuccess] = useState<string | null>(null)
   const [cancellingAppointmentId, setCancellingAppointmentId] = useState<string | null>(null)
+  const [queueNotificationsEnabled, setQueueNotificationsEnabled] = useState(true)
+  const [notificationsLoading, setNotificationsLoading] = useState(true)
+  const [notificationsSaving, setNotificationsSaving] = useState(false)
+  const [notificationsMessage, setNotificationsMessage] = useState<string | null>(null)
+  const [notificationsError, setNotificationsError] = useState<string | null>(null)
+
+  const tenantId = payload.tid === '00000000-0000-0000-0000-000000000000' ? undefined : payload.tid
 
   useEffect(() => {
     getMyQueues()
@@ -71,7 +79,17 @@ export function DashboardPage() {
     getMyAppointmentBookings()
       .then(data => { setAppointments(data); setAppointmentsLoading(false) })
       .catch(() => { setAppointmentsError('Could not load your appointment bookings.'); setAppointmentsLoading(false) })
-  }, [])
+
+    getQueueNotificationPreference(tenantId)
+      .then(data => {
+        setQueueNotificationsEnabled(data.queueTurnApproachingNotificationsEnabled)
+        setNotificationsLoading(false)
+      })
+      .catch(() => {
+        setNotificationsError('Could not load your queue notification setting.')
+        setNotificationsLoading(false)
+      })
+  }, [tenantId])
 
   useEffect(() => {
     if (!appointmentsSuccess) return
@@ -122,6 +140,22 @@ export function DashboardPage() {
   function handleLogout() {
     clearToken()
     navigate('/', { replace: true })
+  }
+
+  async function handleSaveNotificationPreference() {
+    setNotificationsError(null)
+    setNotificationsMessage(null)
+    setNotificationsSaving(true)
+
+    try {
+      await updateQueueNotificationPreference(tenantId, queueNotificationsEnabled)
+      setNotificationsMessage('Queue notification preference saved.')
+    } catch (err) {
+      const apiErr = err as ApiError
+      setNotificationsError(apiErr.detail ?? 'Could not save queue notification setting.')
+    } finally {
+      setNotificationsSaving(false)
+    }
   }
 
   async function handleCancelAppointment(appointment: MyAppointmentBooking) {
@@ -185,6 +219,44 @@ export function DashboardPage() {
               <p className={styles.welcomeSub}>{email}</p>
             </div>
           </div>
+
+          <section className={styles.settingsSection} aria-label="Queue notification settings">
+            <div className={styles.sectionHeader}>
+              <BellIcon />
+              <h2 className={styles.sectionTitle}>Queue Notifications</h2>
+            </div>
+
+            {notificationsLoading && <p className={styles.queueEmpty}>Loading settings…</p>}
+
+            {!notificationsLoading && (
+              <>
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={queueNotificationsEnabled}
+                    onChange={e => {
+                      setQueueNotificationsEnabled(e.target.checked)
+                      setNotificationsMessage(null)
+                      setNotificationsError(null)
+                    }}
+                  />
+                  <span>Notify me by email when my queue turn is approaching.</span>
+                </label>
+
+                <button
+                  type="button"
+                  className={styles.settingsSaveBtn}
+                  onClick={handleSaveNotificationPreference}
+                  disabled={notificationsSaving}
+                >
+                  {notificationsSaving ? 'Saving...' : 'Save preference'}
+                </button>
+
+                {notificationsMessage && <p className={styles.queueSuccess}>{notificationsMessage}</p>}
+                {notificationsError && <p className={styles.queueError}>{notificationsError}</p>}
+              </>
+            )}
+          </section>
 
           {/* ── My active queues ─────────────────────────────────── */}
           <section className={styles.queueSection} aria-label="My active queues">
@@ -443,6 +515,16 @@ function CheckCircleIcon() {
       style={{ flexShrink: 0, color: 'var(--color-primary)' }}>
       <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/>
       <polyline points="22 4 12 14.01 9 11.01"/>
+    </svg>
+  )
+}
+
+function BellIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 8a6 6 0 00-12 0c0 7-3 9-3 9h18s-3-2-3-9"/>
+      <path d="M13.73 21a2 2 0 01-3.46 0"/>
     </svg>
   )
 }

--- a/src/web/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/web/src/pages/Dashboard/DashboardPage.tsx
@@ -22,7 +22,12 @@ import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { clearToken } from '../../utils/authToken'
 import { getTokenPayload } from '../../utils/authToken'
-import { getQueueNotificationPreference, updateQueueNotificationPreference } from '../../api/auth'
+import {
+  getAppointmentNotificationPreferences,
+  getQueueNotificationPreference,
+  updateAppointmentNotificationPreferences,
+  updateQueueNotificationPreference,
+} from '../../api/auth'
 import { getMyQueues, type MyQueueEntry } from '../../api/queues'
 import { cancelAppointment, getMyAppointmentBookings, type MyAppointmentBooking } from '../../api/appointments'
 import type { ApiError } from '../../types/api'
@@ -69,6 +74,14 @@ export function DashboardPage() {
   const [notificationsMessage, setNotificationsMessage] = useState<string | null>(null)
   const [notificationsError, setNotificationsError] = useState<string | null>(null)
 
+  const [appointmentNotificationsLoading, setAppointmentNotificationsLoading] = useState(true)
+  const [appointmentNotificationsSaving, setAppointmentNotificationsSaving] = useState(false)
+  const [appointmentNotificationsMessage, setAppointmentNotificationsMessage] = useState<string | null>(null)
+  const [appointmentNotificationsError, setAppointmentNotificationsError] = useState<string | null>(null)
+  const [appointmentBookedNotificationsEnabled, setAppointmentBookedNotificationsEnabled] = useState(true)
+  const [appointmentRescheduledNotificationsEnabled, setAppointmentRescheduledNotificationsEnabled] = useState(true)
+  const [appointmentCancelledNotificationsEnabled, setAppointmentCancelledNotificationsEnabled] = useState(true)
+
   const tenantId = payload.tid === '00000000-0000-0000-0000-000000000000' ? undefined : payload.tid
 
   useEffect(() => {
@@ -88,6 +101,18 @@ export function DashboardPage() {
       .catch(() => {
         setNotificationsError('Could not load your queue notification setting.')
         setNotificationsLoading(false)
+      })
+
+    getAppointmentNotificationPreferences(tenantId)
+      .then(data => {
+        setAppointmentBookedNotificationsEnabled(data.appointmentBookedNotificationsEnabled)
+        setAppointmentRescheduledNotificationsEnabled(data.appointmentRescheduledNotificationsEnabled)
+        setAppointmentCancelledNotificationsEnabled(data.appointmentCancelledNotificationsEnabled)
+        setAppointmentNotificationsLoading(false)
+      })
+      .catch(() => {
+        setAppointmentNotificationsError('Could not load your appointment notification settings.')
+        setAppointmentNotificationsLoading(false)
       })
   }, [tenantId])
 
@@ -155,6 +180,26 @@ export function DashboardPage() {
       setNotificationsError(apiErr.detail ?? 'Could not save queue notification setting.')
     } finally {
       setNotificationsSaving(false)
+    }
+  }
+
+  async function handleSaveAppointmentNotificationPreferences() {
+    setAppointmentNotificationsError(null)
+    setAppointmentNotificationsMessage(null)
+    setAppointmentNotificationsSaving(true)
+
+    try {
+      await updateAppointmentNotificationPreferences(tenantId, {
+        appointmentBookedNotificationsEnabled,
+        appointmentRescheduledNotificationsEnabled,
+        appointmentCancelledNotificationsEnabled,
+      })
+      setAppointmentNotificationsMessage('Appointment notification preferences saved.')
+    } catch (err) {
+      const apiErr = err as ApiError
+      setAppointmentNotificationsError(apiErr.detail ?? 'Could not save appointment notification settings.')
+    } finally {
+      setAppointmentNotificationsSaving(false)
     }
   }
 
@@ -254,6 +299,70 @@ export function DashboardPage() {
 
                 {notificationsMessage && <p className={styles.queueSuccess}>{notificationsMessage}</p>}
                 {notificationsError && <p className={styles.queueError}>{notificationsError}</p>}
+              </>
+            )}
+          </section>
+
+          <section className={styles.settingsSection} aria-label="Appointment notification settings">
+            <div className={styles.sectionHeader}>
+              <CalendarIcon />
+              <h2 className={styles.sectionTitle}>Appointment Notifications</h2>
+            </div>
+
+            {appointmentNotificationsLoading && <p className={styles.queueEmpty}>Loading settings…</p>}
+
+            {!appointmentNotificationsLoading && (
+              <>
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={appointmentBookedNotificationsEnabled}
+                    onChange={e => {
+                      setAppointmentBookedNotificationsEnabled(e.target.checked)
+                      setAppointmentNotificationsMessage(null)
+                      setAppointmentNotificationsError(null)
+                    }}
+                  />
+                  <span>Email me booking confirmations.</span>
+                </label>
+
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={appointmentRescheduledNotificationsEnabled}
+                    onChange={e => {
+                      setAppointmentRescheduledNotificationsEnabled(e.target.checked)
+                      setAppointmentNotificationsMessage(null)
+                      setAppointmentNotificationsError(null)
+                    }}
+                  />
+                  <span>Email me when appointments are rescheduled.</span>
+                </label>
+
+                <label className={styles.settingsToggle}>
+                  <input
+                    type="checkbox"
+                    checked={appointmentCancelledNotificationsEnabled}
+                    onChange={e => {
+                      setAppointmentCancelledNotificationsEnabled(e.target.checked)
+                      setAppointmentNotificationsMessage(null)
+                      setAppointmentNotificationsError(null)
+                    }}
+                  />
+                  <span>Email me when appointments are cancelled.</span>
+                </label>
+
+                <button
+                  type="button"
+                  className={styles.settingsSaveBtn}
+                  onClick={handleSaveAppointmentNotificationPreferences}
+                  disabled={appointmentNotificationsSaving}
+                >
+                  {appointmentNotificationsSaving ? 'Saving...' : 'Save preferences'}
+                </button>
+
+                {appointmentNotificationsMessage && <p className={styles.queueSuccess}>{appointmentNotificationsMessage}</p>}
+                {appointmentNotificationsError && <p className={styles.queueError}>{appointmentNotificationsError}</p>}
               </>
             )}
           </section>

--- a/src/web/src/pages/QueuePerformanceReport/QueuePerformanceReportPage.module.css
+++ b/src/web/src/pages/QueuePerformanceReport/QueuePerformanceReportPage.module.css
@@ -1,0 +1,177 @@
+.page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f9f6f1 0%, #f4efe7 100%);
+  color: #1f2f3f;
+}
+
+.topNav {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  width: 120px;
+  height: auto;
+}
+
+.backBtn {
+  border: 1px solid #2f4f4f;
+  background: #fff;
+  color: #2f4f4f;
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem 1.25rem 2rem;
+}
+
+.header {
+  margin-bottom: 1rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  color: #4f5f70;
+}
+
+.filtersCard {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(24, 39, 75, 0.08);
+}
+
+.filtersGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.92rem;
+  color: #304052;
+}
+
+.input {
+  border: 1px solid #c8d0d8;
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.95rem;
+}
+
+.actions {
+  margin-top: 0.9rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.primaryBtn,
+.secondaryBtn {
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.primaryBtn {
+  border: none;
+  background: #0f766e;
+  color: #fff;
+}
+
+.secondaryBtn {
+  border: 1px solid #0f766e;
+  background: #fff;
+  color: #0f766e;
+}
+
+.errorBanner {
+  margin-top: 1rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: #ffe8e6;
+  border: 1px solid #f7b3ad;
+  color: #7b1f1f;
+}
+
+.results {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.metricCard {
+  background: #fff;
+  border-radius: 14px;
+  padding: 0.9rem;
+  box-shadow: 0 8px 24px rgba(24, 39, 75, 0.08);
+}
+
+.metricLabel {
+  color: #4f5f70;
+  font-size: 0.85rem;
+}
+
+.metricValue {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 1.25rem;
+}
+
+.peakCard {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(24, 39, 75, 0.08);
+}
+
+.sectionTitle {
+  margin: 0 0 0.7rem;
+}
+
+.emptyText {
+  margin: 0;
+  color: #4f5f70;
+}
+
+.peakList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.peakRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid #eceff2;
+}
+
+.peakRow:last-child {
+  border-bottom: none;
+}

--- a/src/web/src/pages/QueuePerformanceReport/QueuePerformanceReportPage.tsx
+++ b/src/web/src/pages/QueuePerformanceReport/QueuePerformanceReportPage.tsx
@@ -133,13 +133,22 @@ export function QueuePerformanceReportPage() {
     <div className={styles.page}>
       <nav className={styles.topNav}>
         <img src={logoImg} alt="NextTurn" className={styles.logo} />
-        <button
-          type="button"
-          className={styles.backBtn}
-          onClick={() => navigate(`/admin/${tenantId}`)}
-        >
-          Back to Admin
-        </button>
+        <div className={styles.navActions}>
+          <button
+            type="button"
+            className={styles.backBtn}
+            onClick={() => navigate(`/admin/${tenantId}/reports/daily-summary`)}
+          >
+            Daily Summary
+          </button>
+          <button
+            type="button"
+            className={styles.backBtn}
+            onClick={() => navigate(`/admin/${tenantId}`)}
+          >
+            Back to Admin
+          </button>
+        </div>
       </nav>
 
       <main className={styles.main}>

--- a/src/web/src/pages/QueuePerformanceReport/QueuePerformanceReportPage.tsx
+++ b/src/web/src/pages/QueuePerformanceReport/QueuePerformanceReportPage.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  exportQueuePerformanceReportCsv,
+  getQueuePerformanceReport,
+  type QueuePerformanceReportResult,
+} from '../../api/queues'
+import { listOffices, type OfficeDto } from '../../api/offices'
+import { listServices, type ServiceDto } from '../../api/services'
+import type { ApiError } from '../../types/api'
+import { clearToken, getTokenPayload } from '../../utils/authToken'
+import logoImg from '../../assets/nextTurn-logo.png'
+import styles from './QueuePerformanceReportPage.module.css'
+
+function formatDate(value: Date): string {
+  const year = value.getFullYear()
+  const month = `${value.getMonth() + 1}`.padStart(2, '0')
+  const day = `${value.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function defaultStartDate(): string {
+  const date = new Date()
+  date.setDate(date.getDate() - 7)
+  return formatDate(date)
+}
+
+function defaultEndDate(): string {
+  return formatDate(new Date())
+}
+
+export function QueuePerformanceReportPage() {
+  const navigate = useNavigate()
+  const { tenantId } = useParams<{ tenantId: string }>()
+  const payload = getTokenPayload()
+
+  const [startDate, setStartDate] = useState(defaultStartDate)
+  const [endDate, setEndDate] = useState(defaultEndDate)
+  const [officeId, setOfficeId] = useState('')
+  const [serviceId, setServiceId] = useState('')
+
+  const [report, setReport] = useState<QueuePerformanceReportResult | null>(null)
+  const [offices, setOffices] = useState<OfficeDto[]>([])
+  const [services, setServices] = useState<ServiceDto[]>([])
+
+  const [loading, setLoading] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!tenantId) return
+
+    listOffices(tenantId, { isActive: true, pageSize: 200 })
+      .then(result => setOffices(result.items))
+      .catch(() => setOffices([]))
+
+    listServices(tenantId, { activeOnly: true, pageSize: 200 })
+      .then(result => setServices(result.items))
+      .catch(() => setServices([]))
+  }, [tenantId])
+
+  if (!payload) {
+    clearToken()
+    navigate('/', { replace: true })
+    return null
+  }
+
+  const selectedServiceName = useMemo(
+    () => services.find(s => s.serviceId === serviceId)?.name ?? 'All services',
+    [serviceId, services],
+  )
+
+  const selectedOfficeName = useMemo(
+    () => offices.find(o => o.officeId === officeId)?.name ?? 'All offices',
+    [officeId, offices],
+  )
+
+  async function loadReport() {
+    if (!tenantId) return
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await getQueuePerformanceReport(tenantId, {
+        startDate,
+        endDate,
+        serviceId: serviceId || undefined,
+        officeId: officeId || undefined,
+      })
+      setReport(response)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not load queue performance report.')
+      setReport(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleExportCsv() {
+    if (!tenantId) return
+
+    setExporting(true)
+    setError(null)
+
+    try {
+      const blob = await exportQueuePerformanceReportCsv(tenantId, {
+        startDate,
+        endDate,
+        serviceId: serviceId || undefined,
+        officeId: officeId || undefined,
+      })
+
+      const fileName = `queue-performance-${startDate}-${endDate}.csv`
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = fileName
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      window.URL.revokeObjectURL(url)
+    } catch (err) {
+      const apiErr = err as ApiError
+      setError(apiErr.detail ?? 'Could not export queue performance report.')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <nav className={styles.topNav}>
+        <img src={logoImg} alt="NextTurn" className={styles.logo} />
+        <button
+          type="button"
+          className={styles.backBtn}
+          onClick={() => navigate(`/admin/${tenantId}`)}
+        >
+          Back to Admin
+        </button>
+      </nav>
+
+      <main className={styles.main}>
+        <section className={styles.header}>
+          <h1 className={styles.title}>Queue Performance Reports</h1>
+          <p className={styles.subtitle}>Track wait times and peak demand windows across your organisation.</p>
+        </section>
+
+        <section className={styles.filtersCard}>
+          <div className={styles.filtersGrid}>
+            <label className={styles.field}>
+              <span>Start date</span>
+              <input
+                type="date"
+                value={startDate}
+                onChange={e => setStartDate(e.target.value)}
+                className={styles.input}
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span>End date</span>
+              <input
+                type="date"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+                className={styles.input}
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span>Service</span>
+              <select
+                value={serviceId}
+                onChange={e => setServiceId(e.target.value)}
+                className={styles.input}
+              >
+                <option value="">All services</option>
+                {services.map(service => (
+                  <option key={service.serviceId} value={service.serviceId}>
+                    {service.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className={styles.field}>
+              <span>Office</span>
+              <select
+                value={officeId}
+                onChange={e => setOfficeId(e.target.value)}
+                className={styles.input}
+              >
+                <option value="">All offices</option>
+                {offices.map(office => (
+                  <option key={office.officeId} value={office.officeId}>
+                    {office.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              onClick={loadReport}
+              disabled={loading}
+            >
+              {loading ? 'Loading report...' : 'Load report'}
+            </button>
+            <button
+              type="button"
+              className={styles.secondaryBtn}
+              onClick={handleExportCsv}
+              disabled={exporting}
+            >
+              {exporting ? 'Exporting...' : 'Export CSV'}
+            </button>
+          </div>
+        </section>
+
+        {error && <div className={styles.errorBanner}>{error}</div>}
+
+        {report && (
+          <section className={styles.results}>
+            <div className={styles.summaryGrid}>
+              <article className={styles.metricCard}>
+                <span className={styles.metricLabel}>Total Served</span>
+                <strong className={styles.metricValue}>{report.totalServed}</strong>
+              </article>
+              <article className={styles.metricCard}>
+                <span className={styles.metricLabel}>Average Wait</span>
+                <strong className={styles.metricValue}>{report.averageWaitMinutes.toFixed(2)} min</strong>
+              </article>
+              <article className={styles.metricCard}>
+                <span className={styles.metricLabel}>Service Filter</span>
+                <strong className={styles.metricValue}>{selectedServiceName}</strong>
+              </article>
+              <article className={styles.metricCard}>
+                <span className={styles.metricLabel}>Office Filter</span>
+                <strong className={styles.metricValue}>{selectedOfficeName}</strong>
+              </article>
+            </div>
+
+            <div className={styles.peakCard}>
+              <h2 className={styles.sectionTitle}>Peak Hours</h2>
+              {report.peakHours.length === 0 && (
+                <p className={styles.emptyText}>No served entries in the selected range.</p>
+              )}
+
+              {report.peakHours.length > 0 && (
+                <ul className={styles.peakList}>
+                  {report.peakHours.map(item => (
+                    <li key={item.hourOfDay} className={styles.peakRow}>
+                      <span>{`${String(item.hourOfDay).padStart(2, '0')}:00 - ${String(item.hourOfDay).padStart(2, '0')}:59`}</span>
+                      <strong>{item.servedCount} served</strong>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/web/src/pages/QueuePerformanceReport/index.ts
+++ b/src/web/src/pages/QueuePerformanceReport/index.ts
@@ -1,0 +1,1 @@
+export { QueuePerformanceReportPage } from './QueuePerformanceReportPage'

--- a/tests/NextTurn.IntegrationTests/Appointment/AppointmentNotificationFlowIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Appointment/AppointmentNotificationFlowIntegrationTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Domain.Appointment.Entities;
+using NextTurn.Domain.Auth;
+using NextTurn.Infrastructure.Persistence;
+
+namespace NextTurn.IntegrationTests.Appointment;
+
+[Collection("Integration")]
+[Trait("Suite", "Regression")]
+[Trait("Type", "Full")]
+[Trait("Layer", "Integration")]
+public sealed class AppointmentNotificationFlowIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+    private Guid _appointmentProfileId;
+
+    public AppointmentNotificationFlowIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _) = await _factory.SeedQueueAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profile = AppointmentProfile.Create(_tenantId, "Passport Service");
+        db.AppointmentProfiles.Add(profile);
+        await db.SaveChangesAsync();
+
+        _appointmentProfileId = profile.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task BookAppointment_WritesBookedNotificationAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+        var (slotStart, slotEnd) = SlotForTomorrow(9, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart,
+            slotEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var audit = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.AppointmentId == booked!.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Booked");
+
+        audit.Should().NotBeNull();
+        audit!.DeliveryStatus.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task RescheduleAppointment_WritesRescheduledNotificationAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+
+        var (oldStart, oldEnd) = SlotForTomorrow(10, 0);
+        var (newStart, newEnd) = SlotForTomorrow(11, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart = oldStart,
+            slotEnd = oldEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        var reschedule = await client.PutAsJsonAsync($"/api/appointments/{booked!.AppointmentId}/reschedule", new
+        {
+            newSlotStart = newStart,
+            newSlotEnd = newEnd,
+        });
+
+        reschedule.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rescheduled = await reschedule.Content.ReadFromJsonAsync<RescheduleAppointmentApiResult>();
+        rescheduled.Should().NotBeNull();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var audit = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.AppointmentId == rescheduled!.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Rescheduled");
+
+        audit.Should().NotBeNull();
+        audit!.DeliveryStatus.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task CancelAppointment_WritesCancelledNotificationAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+        var (slotStart, slotEnd) = SlotForTomorrow(12, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart,
+            slotEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        var cancel = await client.PostAsync($"/api/appointments/{booked!.AppointmentId}/cancel", null);
+        cancel.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var audit = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.AppointmentId == booked.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Cancelled");
+
+        audit.Should().NotBeNull();
+        audit!.DeliveryStatus.Should().Be("Sent");
+    }
+
+    [Fact]
+    public async Task BookAppointment_WhenBookedPreferenceDisabled_DoesNotWriteAuditLog()
+    {
+        var userId = Guid.NewGuid();
+        var client = AuthenticatedClient(UserRole.User, userId, _tenantId);
+
+        var preferencesUpdate = await client.PutAsJsonAsync("/api/auth/appointment-notification-preferences", new
+        {
+            appointmentBookedNotificationsEnabled = false,
+            appointmentRescheduledNotificationsEnabled = true,
+            appointmentCancelledNotificationsEnabled = true,
+        });
+
+        preferencesUpdate.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var (slotStart, slotEnd) = SlotForTomorrow(13, 0);
+
+        var booking = await client.PostAsJsonAsync("/api/appointments", new
+        {
+            organisationId = _tenantId,
+            appointmentProfileId = _appointmentProfileId,
+            slotStart,
+            slotEnd,
+        });
+
+        booking.StatusCode.Should().Be(HttpStatusCode.OK);
+        var booked = await booking.Content.ReadFromJsonAsync<BookAppointmentApiResult>();
+        booked.Should().NotBeNull();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var exists = await db.AppointmentNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .AnyAsync(a =>
+                a.AppointmentId == booked!.AppointmentId &&
+                a.UserId == userId &&
+                a.NotificationType == "Booked");
+
+        exists.Should().BeFalse();
+    }
+
+    private HttpClient AuthenticatedClient(UserRole role, Guid userId, Guid tenantId)
+    {
+        var token = _factory.CreateTokenForRole(role, userId: userId, tenantId: tenantId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenantId.ToString());
+        return client;
+    }
+
+    private static (DateTimeOffset SlotStart, DateTimeOffset SlotEnd) SlotForTomorrow(int hour, int minute)
+    {
+        var date = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        var slotStart = new DateTimeOffset(date.ToDateTime(new TimeOnly(hour, minute)), TimeSpan.Zero);
+        var slotEnd = slotStart.AddMinutes(30);
+        return (slotStart, slotEnd);
+    }
+
+    private sealed record BookAppointmentApiResult(Guid AppointmentId);
+
+    private sealed record RescheduleAppointmentApiResult(Guid AppointmentId, DateTimeOffset SlotStart, DateTimeOffset SlotEnd);
+}

--- a/tests/NextTurn.IntegrationTests/Queue/DailyQueueSummaryReportIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Queue/DailyQueueSummaryReportIntegrationTests.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Queue.Entities;
+using NextTurn.Infrastructure.Persistence;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+using ServiceOfficeAssignmentEntity = NextTurn.Domain.Service.Entities.ServiceOfficeAssignment;
+
+namespace NextTurn.IntegrationTests.Queue;
+
+[Collection("Integration")]
+[Trait("Suite", "Regression")]
+[Trait("Type", "Full")]
+[Trait("Layer", "Integration")]
+public sealed class DailyQueueSummaryReportIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+    private Guid _queueId;
+    private Guid _staffUserId;
+
+    public DailyQueueSummaryReportIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _queueId) = await _factory.SeedQueueAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var staffUser = User.Create(
+            tenantId: _tenantId,
+            name: "Summary Staff",
+            email: new EmailAddress("summary.staff@nextturn.dev"),
+            phone: null,
+            passwordHash: "integration-password-hash",
+            role: UserRole.Staff);
+        staffUser.Activate();
+
+        var office = OfficeEntity.Create(
+            organisationId: _tenantId,
+            name: "Main Office",
+            address: "1 High Street",
+            latitude: null,
+            longitude: null,
+            openingHours: "Mon-Fri 09:00-17:00");
+
+        var service = ServiceEntity.Create(
+            organisationId: _tenantId,
+            name: "Citizen Service",
+            code: "CIT-001",
+            description: "General citizen requests",
+            estimatedDurationMinutes: 15,
+            isActive: true);
+
+        db.Users.Add(staffUser);
+        db.Offices.Add(office);
+        db.Services.Add(service);
+        db.QueueStaffAssignments.Add(QueueStaffAssignment.Create(_tenantId, _queueId, staffUser.Id));
+        db.StaffOfficeAssignments.Add(StaffOfficeAssignment.Create(_tenantId, staffUser.Id, office.Id));
+        db.ServiceOfficeAssignments.Add(ServiceOfficeAssignmentEntity.Create(service.Id, office.Id, _tenantId));
+
+        await db.SaveChangesAsync();
+
+        _staffUserId = staffUser.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetDailySummaryReport_ReturnsAccurateCountsAndTrends()
+    {
+        var targetDate = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // Current day: served 2, skipped 1, no-show 1.
+        await AddServedActionAsync(targetDate, Guid.NewGuid());
+        await AddServedActionAsync(targetDate, Guid.NewGuid());
+        await AddSkippedActionAsync(targetDate, Guid.NewGuid());
+        await AddNoShowActionAsync(targetDate, Guid.NewGuid());
+
+        // Previous day: served 1, skipped 1, no-show 0.
+        await AddServedActionAsync(targetDate.AddDays(-1), Guid.NewGuid());
+        await AddSkippedActionAsync(targetDate.AddDays(-1), Guid.NewGuid());
+
+        // Previous week: served 3, skipped 0, no-show 1.
+        await AddServedActionAsync(targetDate.AddDays(-7), Guid.NewGuid());
+        await AddServedActionAsync(targetDate.AddDays(-7), Guid.NewGuid());
+        await AddServedActionAsync(targetDate.AddDays(-7), Guid.NewGuid());
+        await AddNoShowActionAsync(targetDate.AddDays(-7), Guid.NewGuid());
+
+        var response = await AdminClient().GetAsync($"/api/queues/reports/daily-summary?date={targetDate:yyyy-MM-dd}");
+        var body = await ReadBodyAsync(response);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        body["totalServed"].GetInt32().Should().Be(2);
+        body["totalSkipped"].GetInt32().Should().Be(1);
+        body["totalNoShows"].GetInt32().Should().Be(1);
+
+        body["totalServedTrend"].GetProperty("deltaFromPreviousDay").GetInt32().Should().Be(1);
+        body["totalServedTrend"].GetProperty("deltaFromPreviousWeek").GetInt32().Should().Be(-1);
+        body["totalSkippedTrend"].GetProperty("deltaFromPreviousDay").GetInt32().Should().Be(0);
+        body["totalNoShowsTrend"].GetProperty("deltaFromPreviousWeek").GetInt32().Should().Be(0);
+
+        var rows = body["rows"].EnumerateArray().ToList();
+        rows.Should().ContainSingle();
+        rows[0].GetProperty("served").GetInt32().Should().Be(2);
+        rows[0].GetProperty("skipped").GetInt32().Should().Be(1);
+        rows[0].GetProperty("noShows").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDailySummaryReport_WithUserRole_ReturnsForbidden()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+        var response = await UserClient(Guid.NewGuid()).GetAsync($"/api/queues/reports/daily-summary?date={today}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private async Task AddServedActionAsync(DateOnly actionDate, Guid userId)
+    {
+        await JoinQueueAsync(userId);
+        await StaffClient().PostAsync($"/api/queues/{_queueId}/serve-next", null);
+        await ShiftLatestAuditLogDateAsync(actionDate);
+    }
+
+    private async Task AddSkippedActionAsync(DateOnly actionDate, Guid userId)
+    {
+        await JoinQueueAsync(userId);
+        var content = new StringContent("{}", Encoding.UTF8, "application/json");
+        await StaffClient().PostAsync($"/api/queues/{_queueId}/skip", content);
+        await ShiftLatestAuditLogDateAsync(actionDate);
+    }
+
+    private async Task AddNoShowActionAsync(DateOnly actionDate, Guid userId)
+    {
+        await JoinQueueAsync(userId);
+        await StaffClient().PostAsync($"/api/queues/{_queueId}/call-next", null);
+        await StaffClient().PostAsync($"/api/queues/{_queueId}/no-show", null);
+        await ShiftLatestAuditLogDateAsync(actionDate);
+    }
+
+    private Task<HttpResponseMessage> JoinQueueAsync(Guid userId)
+    {
+        return UserClient(userId).PostAsync($"/api/queues/{_queueId}/join", null);
+    }
+
+    private async Task ShiftLatestAuditLogDateAsync(DateOnly actionDate)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var latestLog = await db.QueueActionAuditLogs
+            .IgnoreQueryFilters()
+            .OrderByDescending(x => x.CreatedAt)
+            .FirstAsync(x => x.OrganisationId == _tenantId);
+
+        var shifted = new DateTimeOffset(
+            actionDate.Year,
+            actionDate.Month,
+            actionDate.Day,
+            10,
+            0,
+            0,
+            TimeSpan.Zero);
+
+        await db.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE QueueActionAuditLogs SET CreatedAt = {shifted} WHERE Id = {latestLog.Id}");
+    }
+
+    private HttpClient AdminClient()
+    {
+        var token = _factory.CreateTokenForRole(UserRole.OrgAdmin, userId: Guid.NewGuid(), tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient StaffClient()
+    {
+        var token = _factory.CreateTokenForRole(UserRole.Staff, userId: _staffUserId, tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient UserClient(Guid userId)
+    {
+        var token = _factory.CreateTokenForRole(UserRole.User, userId: userId, tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient AuthenticatedClient(string token)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", _tenantId.ToString());
+        return client;
+    }
+
+    private static async Task<Dictionary<string, JsonElement>> ReadBodyAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    }
+}

--- a/tests/NextTurn.IntegrationTests/Queue/QueuePerformanceReportIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Queue/QueuePerformanceReportIntegrationTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NextTurn.Domain.Auth;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Queue.Entities;
+using NextTurn.Infrastructure.Persistence;
+using OfficeEntity = NextTurn.Domain.Office.Entities.Office;
+using ServiceEntity = NextTurn.Domain.Service.Entities.Service;
+using ServiceOfficeAssignmentEntity = NextTurn.Domain.Service.Entities.ServiceOfficeAssignment;
+
+namespace NextTurn.IntegrationTests.Queue;
+
+[Collection("Integration")]
+[Trait("Suite", "Regression")]
+[Trait("Type", "Full")]
+[Trait("Layer", "Integration")]
+public sealed class QueuePerformanceReportIntegrationTests
+    : IClassFixture<NextTurnWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly NextTurnWebApplicationFactory _factory;
+
+    private Guid _tenantId;
+    private Guid _queueId;
+    private Guid _staffUserId;
+    private Guid _officeId;
+    private Guid _serviceId;
+
+    private static readonly Guid UserAId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000001");
+    private static readonly Guid UserBId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000002");
+
+    public QueuePerformanceReportIntegrationTests(NextTurnWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+        (_tenantId, _queueId) = await _factory.SeedQueueAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var staffUser = User.Create(
+            tenantId: _tenantId,
+            name: "Report Staff",
+            email: new EmailAddress("reports.staff@nextturn.dev"),
+            phone: null,
+            passwordHash: "integration-password-hash",
+            role: UserRole.Staff);
+        staffUser.Activate();
+
+        var office = OfficeEntity.Create(
+            organisationId: _tenantId,
+            name: "Main Office",
+            address: "1 High Street",
+            latitude: null,
+            longitude: null,
+            openingHours: "Mon-Fri 09:00-17:00");
+
+        var service = ServiceEntity.Create(
+            organisationId: _tenantId,
+            name: "Citizen Service",
+            code: "CIT-001",
+            description: "General citizen requests",
+            estimatedDurationMinutes: 15,
+            isActive: true);
+
+        db.Users.Add(staffUser);
+        db.Offices.Add(office);
+        db.Services.Add(service);
+
+        db.QueueStaffAssignments.Add(QueueStaffAssignment.Create(_tenantId, _queueId, staffUser.Id));
+        db.StaffOfficeAssignments.Add(StaffOfficeAssignment.Create(_tenantId, staffUser.Id, office.Id));
+        db.ServiceOfficeAssignments.Add(ServiceOfficeAssignmentEntity.Create(service.Id, office.Id, _tenantId));
+
+        await db.SaveChangesAsync();
+
+        _staffUserId = staffUser.Id;
+        _officeId = office.Id;
+        _serviceId = service.Id;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetQueuePerformanceReport_WithServedEntries_ReturnsAggregatedData()
+    {
+        await JoinQueueAsync(UserAId);
+        await JoinQueueAsync(UserBId);
+        await ServeNextAsync();
+        await ServeNextAsync();
+
+        var response = await AdminClient().GetAsync($"/api/queues/reports/performance?startDate={FromDate(-1)}&endDate={FromDate(1)}");
+        var body = await ReadBodyAsync(response);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body["totalServed"].GetInt32().Should().Be(2);
+        body["averageWaitMinutes"].GetDouble().Should().BeGreaterThanOrEqualTo(0);
+        body["peakHours"].EnumerateArray().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetQueuePerformanceReport_WithOfficeAndServiceFilters_ReturnsMatchingRows()
+    {
+        await JoinQueueAsync(UserAId);
+        await ServeNextAsync();
+
+        var url =
+            $"/api/queues/reports/performance?startDate={FromDate(-1)}&endDate={FromDate(1)}&serviceId={_serviceId}&officeId={_officeId}";
+        var response = await AdminClient().GetAsync(url);
+        var body = await ReadBodyAsync(response);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body["totalServed"].GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetQueuePerformanceReport_WithUnmatchedOfficeFilter_ReturnsZeroRows()
+    {
+        await JoinQueueAsync(UserAId);
+        await ServeNextAsync();
+
+        var unmatchedOfficeId = Guid.NewGuid();
+        var url =
+            $"/api/queues/reports/performance?startDate={FromDate(-1)}&endDate={FromDate(1)}&officeId={unmatchedOfficeId}";
+        var response = await AdminClient().GetAsync(url);
+        var body = await ReadBodyAsync(response);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body["totalServed"].GetInt32().Should().Be(0);
+        body["averageWaitMinutes"].GetDouble().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExportQueuePerformanceReportCsv_ReturnsCsvFile()
+    {
+        await JoinQueueAsync(UserAId);
+        await ServeNextAsync();
+
+        var response = await AdminClient().GetAsync($"/api/queues/reports/performance/export?startDate={FromDate(-1)}&endDate={FromDate(1)}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+        content.Should().Contain("Metric,Value");
+        content.Should().Contain("TotalServed,1");
+    }
+
+    [Fact]
+    public async Task GetQueuePerformanceReport_WithUserRole_ReturnsForbidden()
+    {
+        var response = await UserClient(UserAId).GetAsync($"/api/queues/reports/performance?startDate={FromDate(-1)}&endDate={FromDate(1)}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private Task<HttpResponseMessage> JoinQueueAsync(Guid userId)
+    {
+        return UserClient(userId).PostAsync($"/api/queues/{_queueId}/join", null);
+    }
+
+    private Task<HttpResponseMessage> ServeNextAsync()
+    {
+        return StaffClient().PostAsync($"/api/queues/{_queueId}/serve-next", null);
+    }
+
+    private HttpClient AdminClient()
+    {
+        var token = _factory.CreateTokenForRole(UserRole.OrgAdmin, userId: Guid.NewGuid(), tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient StaffClient()
+    {
+        var token = _factory.CreateTokenForRole(UserRole.Staff, userId: _staffUserId, tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient UserClient(Guid userId)
+    {
+        var token = _factory.CreateTokenForRole(UserRole.User, userId: userId, tenantId: _tenantId);
+        return AuthenticatedClient(token);
+    }
+
+    private HttpClient AuthenticatedClient(string token)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", _tenantId.ToString());
+        return client;
+    }
+
+    private static string FromDate(int offsetDays)
+    {
+        return DateOnly.FromDateTime(DateTime.UtcNow.AddDays(offsetDays)).ToString("yyyy-MM-dd");
+    }
+
+    private static async Task<Dictionary<string, JsonElement>> ReadBodyAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    }
+}

--- a/tests/NextTurn.IntegrationTests/Queue/StaffQueueDashboardIntegrationTests.cs
+++ b/tests/NextTurn.IntegrationTests/Queue/StaffQueueDashboardIntegrationTests.cs
@@ -291,6 +291,61 @@ public sealed class StaffQueueDashboardIntegrationTests
         audit.Reason.Should().Be("Citizen did not arrive");
     }
 
+    [Fact]
+    public async Task ServeNext_WhenNextUserWithinThreshold_WritesNotificationAuditLog()
+    {
+        await JoinQueueAsync(UserAId);
+        await JoinQueueAsync(UserBId);
+
+        var serveResponse = await StaffClient().PostAsync($"/api/queues/{_queueId}/serve-next", null);
+        serveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var waitingEntryForUserB = await db.QueueEntries
+            .IgnoreQueryFilters()
+            .FirstAsync(e => e.QueueId == _queueId && e.UserId == UserBId);
+
+        var notificationAudit = await db.QueueTurnNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a =>
+                a.QueueId == _queueId &&
+                a.QueueEntryId == waitingEntryForUserB.Id &&
+                a.UserId == UserBId &&
+                a.DeliveryStatus == "Sent");
+
+        notificationAudit.Should().NotBeNull();
+        notificationAudit!.PositionInQueue.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ServeNext_WhenUserPreferenceDisabled_DoesNotWriteNotificationAuditLog()
+    {
+        await using (var setupScope = _factory.Services.CreateAsyncScope())
+        {
+            var db = setupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var userB = await db.Users.IgnoreQueryFilters().FirstAsync(u => u.Id == UserBId);
+            userB.SetQueueTurnApproachingNotificationsEnabled(false);
+            await db.SaveChangesAsync();
+        }
+
+        await JoinQueueAsync(UserAId);
+        await JoinQueueAsync(UserBId);
+
+        var serveResponse = await StaffClient().PostAsync($"/api/queues/{_queueId}/serve-next", null);
+        serveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var assertScope = _factory.Services.CreateAsyncScope();
+        var assertDb = assertScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var exists = await assertDb.QueueTurnNotificationAuditLogs
+            .IgnoreQueryFilters()
+            .AnyAsync(a => a.QueueId == _queueId && a.UserId == UserBId);
+
+        exists.Should().BeFalse();
+    }
+
     private Task<HttpResponseMessage> JoinQueueAsync(Guid userId)
     {
         return UserClient(userId).PostAsync($"/api/queues/{_queueId}/join", null);

--- a/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationHandlersTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationHandlersTests.cs
@@ -1,0 +1,64 @@
+using MediatR;
+using Moq;
+using NextTurn.Application.Appointment.Commands.BookAppointment;
+using NextTurn.Application.Appointment.Commands.CancelAppointment;
+using NextTurn.Application.Appointment.Commands.RescheduleAppointment;
+using NextTurn.Application.Appointment.Notifications;
+
+namespace NextTurn.UnitTests.Application.Appointment;
+
+public sealed class AppointmentNotificationHandlersTests
+{
+    private readonly Mock<IAppointmentNotificationService> _notificationServiceMock = new();
+
+    [Fact]
+    public async Task AppointmentBookedNotificationHandler_DelegatesToService()
+    {
+        var appointmentId = Guid.NewGuid();
+        var handler = new AppointmentBookedNotificationHandler(_notificationServiceMock.Object);
+
+        await handler.Handle(new AppointmentBookedNotification(appointmentId), CancellationToken.None);
+
+        _notificationServiceMock.Verify(s => s.SendBookingConfirmationAsync(appointmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AppointmentRescheduledNotificationHandler_DelegatesToService()
+    {
+        var appointmentId = Guid.NewGuid();
+        var handler = new AppointmentRescheduledNotificationHandler(_notificationServiceMock.Object);
+
+        await handler.Handle(
+            new AppointmentRescheduledNotification(
+                Guid.NewGuid(),
+                appointmentId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddMinutes(30),
+                DateTimeOffset.UtcNow.AddDays(1),
+                DateTimeOffset.UtcNow.AddDays(1).AddMinutes(30)),
+            CancellationToken.None);
+
+        _notificationServiceMock.Verify(s => s.SendRescheduleUpdateAsync(appointmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AppointmentCancelledNotificationHandler_DelegatesToService()
+    {
+        var appointmentId = Guid.NewGuid();
+        var handler = new AppointmentCancelledNotificationHandler(_notificationServiceMock.Object);
+
+        await handler.Handle(
+            new AppointmentCancelledNotification(
+                appointmentId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddMinutes(30),
+                false),
+            CancellationToken.None);
+
+        _notificationServiceMock.Verify(s => s.SendCancellationUpdateAsync(appointmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationServiceTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/AppointmentNotificationServiceTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NextTurn.Application.Appointment.Notifications;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Appointment.Entities;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Organisation.Enums;
+using NextTurn.Domain.Organisation.ValueObjects;
+using NextTurn.UnitTests.Helpers;
+using AppointmentEntity = NextTurn.Domain.Appointment.Entities.Appointment;
+using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
+
+namespace NextTurn.UnitTests.Application.Appointment;
+
+public sealed class AppointmentNotificationServiceTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+    private readonly Mock<ILogger<AppointmentNotificationService>> _loggerMock = new();
+
+    [Fact]
+    public async Task SendBookingConfirmationAsync_WhenEnabled_SendsEmailAndWritesSentAudit()
+    {
+        var setup = BuildSetup();
+        var addedLogs = new List<AppointmentNotificationAuditLog>();
+
+        var auditDbSetMock = AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentNotificationAuditLog>());
+        auditDbSetMock
+            .Setup(s => s.Add(It.IsAny<AppointmentNotificationAuditLog>()))
+            .Callback<AppointmentNotificationAuditLog>(log => addedLogs.Add(log));
+
+        _contextMock.Setup(c => c.Appointments).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Appointment }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.User }).Object);
+        _contextMock.Setup(c => c.AppointmentProfiles).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Profile }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Organisation }).Object);
+        _contextMock.Setup(c => c.AppointmentNotificationAuditLogs).Returns(auditDbSetMock.Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendBookingConfirmationAsync(setup.Appointment.Id, CancellationToken.None);
+
+        _emailServiceMock.Verify(
+            e => e.SendAppointmentStatusEmailAsync(
+                setup.User.Email.Value,
+                setup.User.Name,
+                "Booked",
+                setup.Appointment.SlotStart,
+                setup.Appointment.SlotEnd,
+                setup.Organisation.Name,
+                setup.Profile.Name,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        addedLogs.Should().ContainSingle();
+        addedLogs[0].DeliveryStatus.Should().Be("Sent");
+        addedLogs[0].NotificationType.Should().Be("Booked");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendBookingConfirmationAsync_WhenPreferenceDisabled_SkipsDeliveryAndAudit()
+    {
+        var setup = BuildSetup();
+        setup.User.SetAppointmentNotificationPreferences(false, true, true);
+
+        _contextMock.Setup(c => c.Appointments).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Appointment }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.User }).Object);
+        _contextMock.Setup(c => c.AppointmentProfiles).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Profile }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Organisation }).Object);
+        _contextMock.Setup(c => c.AppointmentNotificationAuditLogs)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentNotificationAuditLog>()).Object);
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendBookingConfirmationAsync(setup.Appointment.Id, CancellationToken.None);
+
+        _emailServiceMock.Verify(
+            e => e.SendAppointmentStatusEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendRescheduleUpdateAsync_WhenEmailFails_WritesFailedAudit()
+    {
+        var setup = BuildSetup();
+        var addedLogs = new List<AppointmentNotificationAuditLog>();
+
+        var auditDbSetMock = AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentNotificationAuditLog>());
+        auditDbSetMock
+            .Setup(s => s.Add(It.IsAny<AppointmentNotificationAuditLog>()))
+            .Callback<AppointmentNotificationAuditLog>(log => addedLogs.Add(log));
+
+        _contextMock.Setup(c => c.Appointments).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Appointment }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.User }).Object);
+        _contextMock.Setup(c => c.AppointmentProfiles).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Profile }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { setup.Organisation }).Object);
+        _contextMock.Setup(c => c.AppointmentNotificationAuditLogs).Returns(auditDbSetMock.Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        _emailServiceMock
+            .Setup(e => e.SendAppointmentStatusEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("smtp down"));
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendRescheduleUpdateAsync(setup.Appointment.Id, CancellationToken.None);
+
+        addedLogs.Should().ContainSingle();
+        addedLogs[0].DeliveryStatus.Should().Be("Failed");
+        addedLogs[0].NotificationType.Should().Be("Rescheduled");
+        addedLogs[0].ErrorMessage.Should().Contain("smtp down");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCancellationUpdateAsync_WhenAppointmentMissing_DoesNothing()
+    {
+        _contextMock.Setup(c => c.Appointments)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<AppointmentEntity>()).Object);
+
+        var service = new AppointmentNotificationService(_contextMock.Object, _emailServiceMock.Object, _loggerMock.Object);
+
+        await service.SendCancellationUpdateAsync(Guid.NewGuid(), CancellationToken.None);
+
+        _emailServiceMock.Verify(
+            e => e.SendAppointmentStatusEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static (AppointmentEntity Appointment, User User, AppointmentProfile Profile, OrganisationEntity Organisation) BuildSetup()
+    {
+        var organisation = OrganisationEntity.Create(
+            "City Office",
+            "city-office",
+            new Address("1 Main", "Colombo", "10000", "LK"),
+            OrganisationType.Government,
+            new EmailAddress("admin@city.gov"));
+
+        var user = User.Create(organisation.Id, "Alice", new EmailAddress("alice@example.com"), null, "hash");
+        var profile = AppointmentProfile.Create(organisation.Id, "Passport Service");
+
+        var appointment = AppointmentEntity.Create(
+            organisation.Id,
+            profile.Id,
+            user.Id,
+            DateTimeOffset.UtcNow.AddDays(2),
+            DateTimeOffset.UtcNow.AddDays(2).AddMinutes(30));
+
+        return (appointment, user, profile, organisation);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Appointment/BookAppointmentCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Appointment/BookAppointmentCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using NextTurn.Application.Appointment.Commands.BookAppointment;
@@ -13,6 +14,7 @@ public sealed class BookAppointmentCommandHandlerTests
 {
     private readonly Mock<IAppointmentRepository> _appointmentRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<IPublisher> _publisherMock = new();
 
     private readonly BookAppointmentCommandHandler _handler;
 
@@ -45,7 +47,14 @@ public sealed class BookAppointmentCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        _handler = new BookAppointmentCommandHandler(_appointmentRepositoryMock.Object, _contextMock.Object);
+        _publisherMock
+            .Setup(p => p.Publish(It.IsAny<AppointmentBookedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new BookAppointmentCommandHandler(
+            _appointmentRepositoryMock.Object,
+            _contextMock.Object,
+            _publisherMock.Object);
     }
 
     [Fact]
@@ -73,6 +82,9 @@ public sealed class BookAppointmentCommandHandlerTests
             Times.Once);
 
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AppointmentBookedNotification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -89,6 +101,9 @@ public sealed class BookAppointmentCommandHandlerTests
 
         _appointmentRepositoryMock.Verify(r => r.AddAsync(It.IsAny<AppointmentEntity>(), It.IsAny<CancellationToken>()), Times.Never);
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AppointmentBookedNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Application/Auth/GetAppointmentNotificationPreferencesQueryHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Auth/GetAppointmentNotificationPreferencesQueryHandlerTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Auth.Queries.GetAppointmentNotificationPreferences;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.UnitTests.Helpers;
+
+namespace NextTurn.UnitTests.Application.Auth;
+
+public sealed class GetAppointmentNotificationPreferencesQueryHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenUserExists_ReturnsPreferences()
+    {
+        var user = User.Create(Guid.NewGuid(), "Member", new EmailAddress("member@example.com"), null, "hash");
+        user.SetAppointmentNotificationPreferences(false, true, false);
+
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { user }).Object);
+
+        var handler = new GetAppointmentNotificationPreferencesQueryHandler(_contextMock.Object);
+        var result = await handler.Handle(new GetAppointmentNotificationPreferencesQuery(user.Id), CancellationToken.None);
+
+        result.AppointmentBookedNotificationsEnabled.Should().BeFalse();
+        result.AppointmentRescheduledNotificationsEnabled.Should().BeTrue();
+        result.AppointmentCancelledNotificationsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<User>()).Object);
+
+        var handler = new GetAppointmentNotificationPreferencesQueryHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(new GetAppointmentNotificationPreferencesQuery(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("User not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Auth/GetQueueNotificationPreferenceQueryHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Auth/GetQueueNotificationPreferenceQueryHandlerTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Auth.Queries.GetQueueNotificationPreference;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.UnitTests.Helpers;
+
+namespace NextTurn.UnitTests.Application.Auth;
+
+public sealed class GetQueueNotificationPreferenceQueryHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenUserExists_ReturnsPreference()
+    {
+        var tenantId = Guid.NewGuid();
+        var user = User.Create(tenantId, "Member", new EmailAddress("member@example.com"), null, "hash");
+        user.SetQueueTurnApproachingNotificationsEnabled(false);
+
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { user }).Object);
+
+        var handler = new GetQueueNotificationPreferenceQueryHandler(_contextMock.Object);
+        var result = await handler.Handle(new GetQueueNotificationPreferenceQuery(user.Id), CancellationToken.None);
+
+        result.QueueTurnApproachingNotificationsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<User>()).Object);
+
+        var handler = new GetQueueNotificationPreferenceQueryHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(new GetQueueNotificationPreferenceQuery(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("User not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Auth/UpdateAppointmentNotificationPreferencesCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Auth/UpdateAppointmentNotificationPreferencesCommandHandlerTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using MediatR;
+using Moq;
+using NextTurn.Application.Auth.Commands.UpdateAppointmentNotificationPreferences;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.UnitTests.Helpers;
+
+namespace NextTurn.UnitTests.Application.Auth;
+
+public sealed class UpdateAppointmentNotificationPreferencesCommandHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenUserExists_UpdatesPreferencesAndSaves()
+    {
+        var user = User.Create(Guid.NewGuid(), "Member", new EmailAddress("member@example.com"), null, "hash");
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { user }).Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = new UpdateAppointmentNotificationPreferencesCommandHandler(_contextMock.Object);
+
+        var result = await handler.Handle(
+            new UpdateAppointmentNotificationPreferencesCommand(user.Id, false, false, true),
+            CancellationToken.None);
+
+        result.Should().Be(Unit.Value);
+        user.AppointmentBookedNotificationsEnabled.Should().BeFalse();
+        user.AppointmentRescheduledNotificationsEnabled.Should().BeFalse();
+        user.AppointmentCancelledNotificationsEnabled.Should().BeTrue();
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<User>()).Object);
+
+        var handler = new UpdateAppointmentNotificationPreferencesCommandHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(
+            new UpdateAppointmentNotificationPreferencesCommand(Guid.NewGuid(), true, true, true),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("User not found.");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Auth/UpdateQueueNotificationPreferenceCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Auth/UpdateQueueNotificationPreferenceCommandHandlerTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using MediatR;
+using Moq;
+using NextTurn.Application.Auth.Commands.UpdateQueueNotificationPreference;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.UnitTests.Helpers;
+
+namespace NextTurn.UnitTests.Application.Auth;
+
+public sealed class UpdateQueueNotificationPreferenceCommandHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenUserExists_UpdatesPreferenceAndSaves()
+    {
+        var tenantId = Guid.NewGuid();
+        var user = User.Create(tenantId, "Member", new EmailAddress("member@example.com"), null, "hash");
+
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { user }).Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = new UpdateQueueNotificationPreferenceCommandHandler(_contextMock.Object);
+
+        var result = await handler.Handle(
+            new UpdateQueueNotificationPreferenceCommand(user.Id, false),
+            CancellationToken.None);
+
+        result.Should().Be(Unit.Value);
+        user.QueueTurnApproachingNotificationsEnabled.Should().BeFalse();
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<User>()).Object);
+
+        var handler = new UpdateQueueNotificationPreferenceCommandHandler(_contextMock.Object);
+
+        var act = async () => await handler.Handle(
+            new UpdateQueueNotificationPreferenceCommand(Guid.NewGuid(), true),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("User not found.");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Organisation/GetQueueNotificationThresholdQueryHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Organisation/GetQueueNotificationThresholdQueryHandlerTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Organisation.Queries.GetQueueNotificationThreshold;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Organisation.Enums;
+using NextTurn.Domain.Organisation.ValueObjects;
+using NextTurn.UnitTests.Helpers;
+using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
+
+namespace NextTurn.UnitTests.Application.Organisation;
+
+public sealed class GetQueueNotificationThresholdQueryHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenOrganisationExists_ReturnsThreshold()
+    {
+        var organisation = OrganisationEntity.Create(
+            "Town Office",
+            "town-office",
+            new Address("2 Main", "Kandy", "20000", "LK"),
+            OrganisationType.Government,
+            new EmailAddress("admin@town.gov"));
+        organisation.SetQueueNotificationThreshold(6);
+
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { organisation }).Object);
+
+        var handler = new GetQueueNotificationThresholdQueryHandler(_contextMock.Object);
+        var result = await handler.Handle(new GetQueueNotificationThresholdQuery(organisation.Id), CancellationToken.None);
+
+        result.QueueNotificationThreshold.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOrganisationMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Organisations)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<OrganisationEntity>()).Object);
+
+        var handler = new GetQueueNotificationThresholdQueryHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(new GetQueueNotificationThresholdQuery(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("Organisation not found.");
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Organisation/UpdateQueueNotificationThresholdCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Organisation/UpdateQueueNotificationThresholdCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using MediatR;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Organisation.Commands.UpdateQueueNotificationThreshold;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Organisation.Enums;
+using NextTurn.Domain.Organisation.ValueObjects;
+using NextTurn.UnitTests.Helpers;
+using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
+
+namespace NextTurn.UnitTests.Application.Organisation;
+
+public sealed class UpdateQueueNotificationThresholdCommandHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+
+    [Fact]
+    public async Task Handle_WhenOrganisationExists_UpdatesThresholdAndSaves()
+    {
+        var organisation = OrganisationEntity.Create(
+            "City Council",
+            "city-council",
+            new Address("1 Main", "Colombo", "10000", "LK"),
+            OrganisationType.Government,
+            new EmailAddress("admin@city.gov"));
+
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { organisation }).Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = new UpdateQueueNotificationThresholdCommandHandler(_contextMock.Object);
+
+        var result = await handler.Handle(
+            new UpdateQueueNotificationThresholdCommand(organisation.Id, 5),
+            CancellationToken.None);
+
+        result.Should().Be(Unit.Value);
+        organisation.QueueNotificationThreshold.Should().Be(5);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOrganisationMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Organisations)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<OrganisationEntity>()).Object);
+
+        var handler = new UpdateQueueNotificationThresholdCommandHandler(_contextMock.Object);
+        var act = async () => await handler.Handle(
+            new UpdateQueueNotificationThresholdCommand(Guid.NewGuid(), 4),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("Organisation not found.");
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/CallNextCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/CallNextCommandHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using MediatR;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.CallNext;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
 using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
@@ -13,6 +15,7 @@ public sealed class CallNextCommandHandlerTests
 {
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<ISender> _senderMock = new();
 
     private readonly CallNextCommandHandler _handler;
 
@@ -38,7 +41,11 @@ public sealed class CallNextCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        _handler = new CallNextCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
+
+        _handler = new CallNextCommandHandler(_queueRepositoryMock.Object, _contextMock.Object, _senderMock.Object);
     }
 
     [Fact]
@@ -50,6 +57,7 @@ public sealed class CallNextCommandHandlerTests
         result.Status.Should().Be("Serving");
 
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _senderMock.Verify(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Application/Queue/DailyQueueSummaryCalculatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/DailyQueueSummaryCalculatorTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using NextTurn.Application.Queue.DailySummary;
+using NextTurn.Domain.Queue.Enums;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class DailyQueueSummaryCalculatorTests
+{
+    private readonly DailyQueueSummaryCalculator _calculator = new();
+
+    private static readonly Guid OfficeA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid ServiceA = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public void Calculate_WithNoData_ReturnsEmptySummary()
+    {
+        var date = new DateOnly(2026, 4, 10);
+
+        var result = _calculator.Calculate(date, Array.Empty<DailyQueueSummaryAggregationPoint>());
+
+        result.TotalServed.Should().Be(0);
+        result.TotalSkipped.Should().Be(0);
+        result.TotalNoShows.Should().Be(0);
+        result.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Calculate_ComputesRowMetricsAndTrends()
+    {
+        var date = new DateOnly(2026, 4, 10);
+        var points = new List<DailyQueueSummaryAggregationPoint>
+        {
+            Point(date, QueueActionType.Serve, 5),
+            Point(date, QueueActionType.Skip, 2),
+            Point(date, QueueActionType.NoShow, 1),
+
+            Point(date.AddDays(-1), QueueActionType.Serve, 3),
+            Point(date.AddDays(-1), QueueActionType.Skip, 1),
+            Point(date.AddDays(-1), QueueActionType.NoShow, 0),
+
+            Point(date.AddDays(-7), QueueActionType.Serve, 6),
+            Point(date.AddDays(-7), QueueActionType.Skip, 0),
+            Point(date.AddDays(-7), QueueActionType.NoShow, 1),
+        };
+
+        var result = _calculator.Calculate(date, points);
+        var row = result.Rows.Should().ContainSingle().Subject;
+
+        row.Served.Should().Be(5);
+        row.Skipped.Should().Be(2);
+        row.NoShows.Should().Be(1);
+
+        row.ServedTrend.DeltaFromPreviousDay.Should().Be(2);
+        row.ServedTrend.DeltaFromPreviousWeek.Should().Be(-1);
+        row.SkippedTrend.DeltaFromPreviousDay.Should().Be(1);
+        row.NoShowsTrend.DeltaFromPreviousWeek.Should().Be(0);
+    }
+
+    [Fact]
+    public void Calculate_ComputesTotalTrendsAcrossRows()
+    {
+        var date = new DateOnly(2026, 4, 10);
+        var officeB = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var serviceB = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+        var points = new List<DailyQueueSummaryAggregationPoint>
+        {
+            Point(date, QueueActionType.Serve, 2),
+            new(date, officeB, "Office B", serviceB, "Service B", QueueActionType.Serve, 3),
+
+            Point(date.AddDays(-1), QueueActionType.Serve, 1),
+            new(date.AddDays(-1), officeB, "Office B", serviceB, "Service B", QueueActionType.Serve, 1),
+
+            Point(date.AddDays(-7), QueueActionType.Serve, 4),
+            new(date.AddDays(-7), officeB, "Office B", serviceB, "Service B", QueueActionType.Serve, 1),
+        };
+
+        var result = _calculator.Calculate(date, points);
+
+        result.TotalServed.Should().Be(5);
+        result.TotalServedTrend.DeltaFromPreviousDay.Should().Be(3);
+        result.TotalServedTrend.DeltaFromPreviousWeek.Should().Be(0);
+    }
+
+    [Fact]
+    public void Calculate_UsesHundredPercentWhenBaselineIsZero()
+    {
+        var date = new DateOnly(2026, 4, 10);
+        var points = new List<DailyQueueSummaryAggregationPoint>
+        {
+            Point(date, QueueActionType.NoShow, 2),
+        };
+
+        var result = _calculator.Calculate(date, points);
+
+        result.TotalNoShowsTrend.PreviousDay.Should().Be(0);
+        result.TotalNoShowsTrend.ChangePercentFromPreviousDay.Should().Be(100);
+    }
+
+    private static DailyQueueSummaryAggregationPoint Point(DateOnly date, QueueActionType actionType, int count)
+    {
+        return new DailyQueueSummaryAggregationPoint(
+            Date: date,
+            OfficeId: OfficeA,
+            OfficeName: "Main Office",
+            ServiceId: ServiceA,
+            ServiceName: "Citizen Service",
+            ActionType: actionType,
+            Count: count);
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/LeaveQueueCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/LeaveQueueCommandHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using MediatR;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.LeaveQueue;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
 
@@ -25,6 +27,7 @@ public sealed class LeaveQueueCommandHandlerTests
 
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<ISender> _senderMock = new();
 
     private readonly LeaveQueueCommandHandler _handler;
 
@@ -43,9 +46,14 @@ public sealed class LeaveQueueCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
+
         _handler = new LeaveQueueCommandHandler(
             _queueRepositoryMock.Object,
-            _contextMock.Object);
+            _contextMock.Object,
+            _senderMock.Object);
     }
 
     // ── Happy path ────────────────────────────────────────────────────────────
@@ -75,6 +83,10 @@ public sealed class LeaveQueueCommandHandlerTests
 
         _contextMock.Verify(
             c => c.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/tests/NextTurn.UnitTests/Application/Queue/MarkNoShowCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/MarkNoShowCommandHandlerTests.cs
@@ -1,10 +1,13 @@
 using FluentAssertions;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.MarkNoShow;
 using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Domain.Common;
+using NextTurn.Domain.Queue.Entities;
+using NextTurn.Domain.Queue.Enums;
 using NextTurn.Domain.Queue.Repositories;
 using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
 using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
@@ -16,12 +19,14 @@ public sealed class MarkNoShowCommandHandlerTests
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
     private readonly Mock<ISender> _senderMock = new();
+    private readonly Mock<DbSet<QueueActionAuditLog>> _auditLogSetMock = new();
 
     private readonly MarkNoShowCommandHandler _handler;
 
     private static readonly Guid QueueId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static readonly Guid OrgId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
     private static readonly Guid UserId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static readonly Guid StaffId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
 
     public MarkNoShowCommandHandlerTests()
     {
@@ -40,6 +45,10 @@ public sealed class MarkNoShowCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
+        _contextMock
+            .Setup(c => c.QueueActionAuditLogs)
+            .Returns(_auditLogSetMock.Object);
+
         _senderMock
             .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
@@ -50,10 +59,15 @@ public sealed class MarkNoShowCommandHandlerTests
     [Fact]
     public async Task Handle_WithServingEntry_MarksAsNoShow()
     {
-        var result = await _handler.Handle(new MarkNoShowCommand(QueueId), CancellationToken.None);
+        var result = await _handler.Handle(new MarkNoShowCommand(QueueId, StaffId), CancellationToken.None);
 
         result.Status.Should().Be("NoShow");
         result.TicketNumber.Should().Be(4);
+        _auditLogSetMock.Verify(
+            s => s.Add(It.Is<QueueActionAuditLog>(
+                a => a.ActionType == QueueActionType.NoShow
+                     && a.PerformedByUserId == StaffId)),
+            Times.Once);
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
         _senderMock.Verify(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -65,7 +79,7 @@ public sealed class MarkNoShowCommandHandlerTests
             .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((QueueEntity?)null);
 
-        var act = async () => await _handler.Handle(new MarkNoShowCommand(QueueId), CancellationToken.None);
+        var act = async () => await _handler.Handle(new MarkNoShowCommand(QueueId, StaffId), CancellationToken.None);
 
         await act.Should().ThrowAsync<DomainException>()
             .WithMessage("Queue not found.");
@@ -78,7 +92,7 @@ public sealed class MarkNoShowCommandHandlerTests
             .Setup(r => r.GetCurrentServingEntryAsync(QueueId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((QueueEntry?)null);
 
-        var act = async () => await _handler.Handle(new MarkNoShowCommand(QueueId), CancellationToken.None);
+        var act = async () => await _handler.Handle(new MarkNoShowCommand(QueueId, StaffId), CancellationToken.None);
 
         await act.Should().ThrowAsync<DomainException>()
             .WithMessage("No entry is currently being served.");

--- a/tests/NextTurn.UnitTests/Application/Queue/MarkNoShowCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/MarkNoShowCommandHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using MediatR;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.MarkNoShow;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
 using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
@@ -13,6 +15,7 @@ public sealed class MarkNoShowCommandHandlerTests
 {
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<ISender> _senderMock = new();
 
     private readonly MarkNoShowCommandHandler _handler;
 
@@ -37,7 +40,11 @@ public sealed class MarkNoShowCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        _handler = new MarkNoShowCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
+
+        _handler = new MarkNoShowCommandHandler(_queueRepositoryMock.Object, _contextMock.Object, _senderMock.Object);
     }
 
     [Fact]
@@ -48,6 +55,7 @@ public sealed class MarkNoShowCommandHandlerTests
         result.Status.Should().Be("NoShow");
         result.TicketNumber.Should().Be(4);
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _senderMock.Verify(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Application/Queue/MarkServedCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/MarkServedCommandHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using MediatR;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
 using NextTurn.Application.Queue.Commands.MarkServed;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Repositories;
 using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
@@ -13,6 +15,7 @@ public sealed class MarkServedCommandHandlerTests
 {
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<ISender> _senderMock = new();
 
     private readonly MarkServedCommandHandler _handler;
 
@@ -37,7 +40,11 @@ public sealed class MarkServedCommandHandlerTests
             .Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
-        _handler = new MarkServedCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
+
+        _handler = new MarkServedCommandHandler(_queueRepositoryMock.Object, _contextMock.Object, _senderMock.Object);
     }
 
     [Fact]
@@ -48,6 +55,7 @@ public sealed class MarkServedCommandHandlerTests
         result.Status.Should().Be("Served");
         result.TicketNumber.Should().Be(4);
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _senderMock.Verify(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Application/Queue/NotifyApproachingTurnCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/NotifyApproachingTurnCommandHandlerTests.cs
@@ -1,0 +1,191 @@
+using FluentAssertions;
+using Moq;
+using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
+using NextTurn.Domain.Auth.Entities;
+using NextTurn.Domain.Auth.ValueObjects;
+using NextTurn.Domain.Common;
+using NextTurn.Domain.Organisation.Enums;
+using NextTurn.Domain.Organisation.ValueObjects;
+using NextTurn.Domain.Queue.Enums;
+using NextTurn.UnitTests.Helpers;
+using OrganisationEntity = NextTurn.Domain.Organisation.Entities.Organisation;
+using QueueEntity = NextTurn.Domain.Queue.Entities.Queue;
+using QueueEntry = NextTurn.Domain.Queue.Entities.QueueEntry;
+using QueueTurnNotificationAuditLog = NextTurn.Domain.Queue.Entities.QueueTurnNotificationAuditLog;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class NotifyApproachingTurnCommandHandlerTests
+{
+    private readonly Mock<IApplicationDbContext> _contextMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+
+    [Fact]
+    public async Task Handle_WhenQueueMissing_ThrowsDomainException()
+    {
+        _contextMock.Setup(c => c.Queues).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<QueueEntity>()).Object);
+
+        var handler = new NotifyApproachingTurnCommandHandler(_contextMock.Object, _emailServiceMock.Object);
+        var act = async () => await handler.Handle(new NotifyApproachingTurnCommand(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("Queue not found.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenOrganisationMissing_ThrowsDomainException()
+    {
+        var queue = QueueEntity.Create(Guid.NewGuid(), "Main Queue", 100, 120);
+
+        _contextMock.Setup(c => c.Queues).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { queue }).Object);
+        _contextMock.Setup(c => c.Organisations)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<OrganisationEntity>()).Object);
+
+        var handler = new NotifyApproachingTurnCommandHandler(_contextMock.Object, _emailServiceMock.Object);
+        var act = async () => await handler.Handle(new NotifyApproachingTurnCommand(queue.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("Organisation not found.");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoWaitingEntries_ReturnsZeroAndDoesNotSave()
+    {
+        var organisation = BuildOrganisation();
+        var queue = QueueEntity.Create(organisation.Id, "Main Queue", 100, 120);
+
+        _contextMock.Setup(c => c.Queues).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { queue }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { organisation }).Object);
+        _contextMock.Setup(c => c.QueueEntries).Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<QueueEntry>()).Object);
+
+        var handler = new NotifyApproachingTurnCommandHandler(_contextMock.Object, _emailServiceMock.Object);
+        var result = await handler.Handle(new NotifyApproachingTurnCommand(queue.Id), CancellationToken.None);
+
+        result.NotificationsSent.Should().Be(0);
+        result.NotificationsFailed.Should().Be(0);
+        _emailServiceMock.Verify(
+            s => s.SendQueueTurnApproachingEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenMixOfAlreadySentSuccessAndFailure_StoresAuditsAndSaves()
+    {
+        var organisation = BuildOrganisation();
+        organisation.SetQueueNotificationThreshold(3);
+        var queue = QueueEntity.Create(organisation.Id, "Counter Queue", 100, 120);
+
+        var userAlreadySent = User.Create(organisation.Id, "Already Sent", new EmailAddress("sent@example.com"), null, "hash");
+        var userSuccess = User.Create(organisation.Id, "Success", new EmailAddress("success@example.com"), null, "hash");
+        var userFailure = User.Create(organisation.Id, "Failure", new EmailAddress("fail@example.com"), null, "hash");
+
+        var entryAlreadySent = QueueEntry.Create(queue.Id, userAlreadySent.Id, 1);
+        var entrySuccess = QueueEntry.Create(queue.Id, userSuccess.Id, 2);
+        var entryFailure = QueueEntry.Create(queue.Id, userFailure.Id, 3);
+
+        var existingAudit = QueueTurnNotificationAuditLog.Sent(
+            organisation.Id,
+            queue.Id,
+            entryAlreadySent.Id,
+            userAlreadySent.Id,
+            positionInQueue: 1,
+            threshold: 3);
+
+        var addedLogs = new List<QueueTurnNotificationAuditLog>();
+        var auditDbSetMock = AsyncQueryableHelper.BuildMockDbSet(new[] { existingAudit });
+        auditDbSetMock
+            .Setup(s => s.Add(It.IsAny<QueueTurnNotificationAuditLog>()))
+            .Callback<QueueTurnNotificationAuditLog>(log => addedLogs.Add(log));
+
+        _contextMock.Setup(c => c.Queues).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { queue }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { organisation }).Object);
+        _contextMock.Setup(c => c.QueueEntries)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { entryAlreadySent, entrySuccess, entryFailure }).Object);
+        _contextMock.Setup(c => c.Users)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { userAlreadySent, userSuccess, userFailure }).Object);
+        _contextMock.Setup(c => c.QueueTurnNotificationAuditLogs).Returns(auditDbSetMock.Object);
+        _contextMock.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        _emailServiceMock
+            .Setup(s => s.SendQueueTurnApproachingEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, string, int, int, CancellationToken>((_, _, ticket, _, _) =>
+                ticket == 3
+                    ? Task.FromException(new InvalidOperationException("smtp unavailable"))
+                    : Task.CompletedTask);
+
+        var handler = new NotifyApproachingTurnCommandHandler(_contextMock.Object, _emailServiceMock.Object);
+        var result = await handler.Handle(new NotifyApproachingTurnCommand(queue.Id), CancellationToken.None);
+
+        result.NotificationsSent.Should().Be(1);
+        result.NotificationsFailed.Should().Be(1);
+
+        addedLogs.Should().HaveCount(2);
+        addedLogs.Should().Contain(l => l.DeliveryStatus == "Sent" && l.QueueEntryId == entrySuccess.Id);
+        addedLogs.Should().Contain(l => l.DeliveryStatus == "Failed" && l.QueueEntryId == entryFailure.Id);
+
+        _emailServiceMock.Verify(
+            s => s.SendQueueTurnApproachingEmailAsync(
+                It.IsAny<string>(),
+                queue.Name,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserIneligible_SkipsAndDoesNotSave()
+    {
+        var organisation = BuildOrganisation();
+        organisation.SetQueueNotificationThreshold(3);
+        var queue = QueueEntity.Create(organisation.Id, "Counter Queue", 100, 120);
+
+        var disabledUser = User.Create(organisation.Id, "Disabled", new EmailAddress("disabled@example.com"), null, "hash");
+        disabledUser.SetQueueTurnApproachingNotificationsEnabled(false);
+
+        var entry = QueueEntry.Create(queue.Id, disabledUser.Id, 1);
+
+        _contextMock.Setup(c => c.Queues).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { queue }).Object);
+        _contextMock.Setup(c => c.Organisations).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { organisation }).Object);
+        _contextMock.Setup(c => c.QueueEntries).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { entry }).Object);
+        _contextMock.Setup(c => c.Users).Returns(AsyncQueryableHelper.BuildMockDbSet(new[] { disabledUser }).Object);
+        _contextMock.Setup(c => c.QueueTurnNotificationAuditLogs)
+            .Returns(AsyncQueryableHelper.BuildMockDbSet(Array.Empty<QueueTurnNotificationAuditLog>()).Object);
+
+        var handler = new NotifyApproachingTurnCommandHandler(_contextMock.Object, _emailServiceMock.Object);
+        var result = await handler.Handle(new NotifyApproachingTurnCommand(queue.Id), CancellationToken.None);
+
+        result.NotificationsSent.Should().Be(0);
+        result.NotificationsFailed.Should().Be(0);
+        _emailServiceMock.Verify(
+            s => s.SendQueueTurnApproachingEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static OrganisationEntity BuildOrganisation()
+    {
+        return OrganisationEntity.Create(
+            "City Council",
+            "city-council",
+            new Address("1 Main", "Colombo", "10000", "LK"),
+            OrganisationType.Government,
+            new EmailAddress("admin@city.gov"));
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/QueuePerformanceCalculatorTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/QueuePerformanceCalculatorTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using NextTurn.Application.Queue.Reports;
+
+namespace NextTurn.UnitTests.Application.Queue;
+
+public sealed class QueuePerformanceCalculatorTests
+{
+    private static readonly Guid OrganisationId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private readonly QueuePerformanceCalculator _calculator = new();
+
+    [Fact]
+    public void Calculate_WithNoDataPoints_ReturnsZeroSummary()
+    {
+        var filter = new QueuePerformanceFilter(
+            OrganisationId,
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 3, 2),
+            ServiceId: null,
+            OfficeId: null);
+
+        var result = _calculator.Calculate(filter, Array.Empty<QueuePerformanceDataPoint>());
+
+        result.TotalServed.Should().Be(0);
+        result.AverageWaitMinutes.Should().Be(0);
+        result.PeakHours.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Calculate_ComputesAverageWaitMinutes_ToTwoDecimals()
+    {
+        var filter = new QueuePerformanceFilter(
+            OrganisationId,
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 3, 2),
+            ServiceId: null,
+            OfficeId: null);
+
+        var data = new[]
+        {
+            new QueuePerformanceDataPoint(
+                new DateTimeOffset(2026, 3, 1, 9, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 3, 1, 9, 10, 0, TimeSpan.Zero),
+                HourOfDay: 9),
+            new QueuePerformanceDataPoint(
+                new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 3, 1, 10, 20, 0, TimeSpan.Zero),
+                HourOfDay: 10),
+            // Invalid negative wait values are clamped to zero.
+            new QueuePerformanceDataPoint(
+                new DateTimeOffset(2026, 3, 1, 11, 30, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 3, 1, 11, 20, 0, TimeSpan.Zero),
+                HourOfDay: 11),
+        };
+
+        var result = _calculator.Calculate(filter, data);
+
+        result.TotalServed.Should().Be(3);
+        result.AverageWaitMinutes.Should().Be(10);
+    }
+
+    [Fact]
+    public void Calculate_ReturnsTopThreePeakHours_OrderedByCountThenHour()
+    {
+        var filter = new QueuePerformanceFilter(
+            OrganisationId,
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 3, 2),
+            ServiceId: null,
+            OfficeId: null);
+
+        var points = new List<QueuePerformanceDataPoint>();
+
+        points.AddRange(CreatePoints(hour: 10, count: 4));
+        points.AddRange(CreatePoints(hour: 14, count: 3));
+        points.AddRange(CreatePoints(hour: 9, count: 3));
+        points.AddRange(CreatePoints(hour: 8, count: 2));
+
+        var result = _calculator.Calculate(filter, points);
+
+        result.PeakHours.Should().HaveCount(3);
+        result.PeakHours[0].HourOfDay.Should().Be(10);
+        result.PeakHours[0].ServedCount.Should().Be(4);
+        result.PeakHours[1].HourOfDay.Should().Be(9);
+        result.PeakHours[1].ServedCount.Should().Be(3);
+        result.PeakHours[2].HourOfDay.Should().Be(14);
+        result.PeakHours[2].ServedCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void Calculate_PreservesRequestedFilterMetadata()
+    {
+        var serviceId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var officeId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+        var filter = new QueuePerformanceFilter(
+            OrganisationId,
+            new DateOnly(2026, 3, 10),
+            new DateOnly(2026, 3, 31),
+            serviceId,
+            officeId);
+
+        var result = _calculator.Calculate(filter, CreatePoints(hour: 13, count: 1));
+
+        result.StartDate.Should().Be(new DateOnly(2026, 3, 10));
+        result.EndDate.Should().Be(new DateOnly(2026, 3, 31));
+        result.ServiceId.Should().Be(serviceId);
+        result.OfficeId.Should().Be(officeId);
+    }
+
+    private static IReadOnlyList<QueuePerformanceDataPoint> CreatePoints(int hour, int count)
+    {
+        var result = new List<QueuePerformanceDataPoint>();
+
+        for (var i = 0; i < count; i++)
+        {
+            var joined = new DateTimeOffset(2026, 3, 1, hour, 0, 0, TimeSpan.Zero).AddMinutes(i);
+            var served = joined.AddMinutes(5);
+            result.Add(new QueuePerformanceDataPoint(joined, served, hour));
+        }
+
+        return result;
+    }
+}

--- a/tests/NextTurn.UnitTests/Application/Queue/ServeNextCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/ServeNextCommandHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands.ServeNext;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Entities;
@@ -17,6 +19,7 @@ public sealed class ServeNextCommandHandlerTests
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
     private readonly Mock<DbSet<QueueActionAuditLog>> _auditLogSetMock = new();
+    private readonly Mock<ISender> _senderMock = new();
 
     private readonly ServeNextCommandHandler _handler;
 
@@ -39,7 +42,11 @@ public sealed class ServeNextCommandHandlerTests
             .Setup(r => r.GetByIdAsync(QueueId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(BuildQueue());
 
-        _handler = new ServeNextCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
+
+        _handler = new ServeNextCommandHandler(_queueRepositoryMock.Object, _contextMock.Object, _senderMock.Object);
     }
 
     [Fact]
@@ -66,6 +73,7 @@ public sealed class ServeNextCommandHandlerTests
             Times.Once);
 
         _contextMock.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _senderMock.Verify(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Application/Queue/SkipCommandHandlerTests.cs
+++ b/tests/NextTurn.UnitTests/Application/Queue/SkipCommandHandlerTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using NextTurn.Application.Common.Interfaces;
+using NextTurn.Application.Queue.Commands.NotifyApproachingTurn;
 using NextTurn.Application.Queue.Commands.Skip;
 using NextTurn.Domain.Common;
 using NextTurn.Domain.Queue.Entities;
@@ -17,6 +19,7 @@ public sealed class SkipCommandHandlerTests
     private readonly Mock<IQueueRepository> _queueRepositoryMock = new();
     private readonly Mock<IApplicationDbContext> _contextMock = new();
     private readonly Mock<DbSet<QueueActionAuditLog>> _auditLogSetMock = new();
+    private readonly Mock<ISender> _senderMock = new();
 
     private readonly SkipCommandHandler _handler;
 
@@ -39,7 +42,11 @@ public sealed class SkipCommandHandlerTests
             .Setup(r => r.GetByIdAsync(QueueId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(BuildQueue());
 
-        _handler = new SkipCommandHandler(_queueRepositoryMock.Object, _contextMock.Object);
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotifyApproachingTurnResult(0, 0));
+
+        _handler = new SkipCommandHandler(_queueRepositoryMock.Object, _contextMock.Object, _senderMock.Object);
     }
 
     [Fact]
@@ -65,6 +72,8 @@ public sealed class SkipCommandHandlerTests
                 a.PerformedByUserId == PerformedByUserId &&
                 a.Reason == "Citizen did not arrive")),
             Times.Once);
+
+        _senderMock.Verify(s => s.Send(It.IsAny<NotifyApproachingTurnCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Domain/Appointment/AppointmentNotificationAuditLogTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Appointment/AppointmentNotificationAuditLogTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NextTurn.Domain.Appointment.Entities;
+
+namespace NextTurn.UnitTests.Domain.Appointment;
+
+public sealed class AppointmentNotificationAuditLogTests
+{
+    [Fact]
+    public void Sent_CreatesSuccessfulAuditRecord()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var log = AppointmentNotificationAuditLog.Sent(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Booked",
+            "user@example.com",
+            DateTimeOffset.UtcNow.AddDays(1),
+            DateTimeOffset.UtcNow.AddDays(1).AddMinutes(30),
+            "City Office",
+            "Passport Service");
+
+        var after = DateTimeOffset.UtcNow;
+
+        log.Id.Should().NotBeEmpty();
+        log.DeliveryStatus.Should().Be("Sent");
+        log.NotificationType.Should().Be("Booked");
+        log.ErrorMessage.Should().BeNull();
+        log.CreatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public void Failed_NormalizesAndTruncatesErrorMessage()
+    {
+        var longMessage = " " + new string('x', 600) + " ";
+
+        var log = AppointmentNotificationAuditLog.Failed(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Cancelled",
+            "user@example.com",
+            DateTimeOffset.UtcNow.AddDays(1),
+            DateTimeOffset.UtcNow.AddDays(1).AddMinutes(30),
+            "City Office",
+            "Passport Service",
+            longMessage);
+
+        log.DeliveryStatus.Should().Be("Failed");
+        log.NotificationType.Should().Be("Cancelled");
+        log.ErrorMessage.Should().NotBeNull();
+        log.ErrorMessage!.Length.Should().Be(500);
+    }
+}

--- a/tests/NextTurn.UnitTests/Domain/Auth/UserTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Auth/UserTests.cs
@@ -178,6 +178,24 @@ public sealed class UserTests
         user.MfaEnabled.Should().BeFalse();
     }
 
+    [Fact]
+    public void Create_SetsQueueTurnApproachingNotificationsEnabledToTrue()
+    {
+        var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
+
+        user.QueueTurnApproachingNotificationsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetQueueTurnApproachingNotificationsEnabled_UpdatesPreference()
+    {
+        var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
+
+        user.SetQueueTurnApproachingNotificationsEnabled(false);
+
+        user.QueueTurnApproachingNotificationsEnabled.Should().BeFalse();
+    }
+
     // ── RecordFailedLogin ─────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/NextTurn.UnitTests/Domain/Auth/UserTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Auth/UserTests.cs
@@ -187,6 +187,16 @@ public sealed class UserTests
     }
 
     [Fact]
+    public void Create_SetsAppointmentNotificationPreferencesToTrue()
+    {
+        var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
+
+        user.AppointmentBookedNotificationsEnabled.Should().BeTrue();
+        user.AppointmentRescheduledNotificationsEnabled.Should().BeTrue();
+        user.AppointmentCancelledNotificationsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
     public void SetQueueTurnApproachingNotificationsEnabled_UpdatesPreference()
     {
         var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
@@ -194,6 +204,18 @@ public sealed class UserTests
         user.SetQueueTurnApproachingNotificationsEnabled(false);
 
         user.QueueTurnApproachingNotificationsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetAppointmentNotificationPreferences_UpdatesAllAppointmentPreferences()
+    {
+        var user = User.Create(ValidTenantId, ValidName, ValidEmail, null, ValidPasswordHash);
+
+        user.SetAppointmentNotificationPreferences(false, true, false);
+
+        user.AppointmentBookedNotificationsEnabled.Should().BeFalse();
+        user.AppointmentRescheduledNotificationsEnabled.Should().BeTrue();
+        user.AppointmentCancelledNotificationsEnabled.Should().BeFalse();
     }
 
     // ── RecordFailedLogin ─────────────────────────────────────────────────────

--- a/tests/NextTurn.UnitTests/Domain/Organisation/OrganisationTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Organisation/OrganisationTests.cs
@@ -148,6 +148,49 @@ public sealed class OrganisationTests
         org.Slug.Length.Should().BeGreaterThanOrEqualTo(3);
     }
 
+    [Fact]
+    public void Create_SetsDefaultQueueNotificationThresholdToThree()
+    {
+        var org = OrganisationEntity.Create(
+            ValidName,
+            ValidAddress,
+            OrganisationType.Healthcare,
+            ValidAdminEmail);
+
+        org.QueueNotificationThreshold.Should().Be(3);
+    }
+
+    [Fact]
+    public void SetQueueNotificationThreshold_WithValidValue_UpdatesThreshold()
+    {
+        var org = OrganisationEntity.Create(
+            ValidName,
+            ValidAddress,
+            OrganisationType.Healthcare,
+            ValidAdminEmail);
+
+        org.SetQueueNotificationThreshold(5);
+
+        org.QueueNotificationThreshold.Should().Be(5);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(51)]
+    public void SetQueueNotificationThreshold_OutOfRange_ThrowsDomainException(int threshold)
+    {
+        var org = OrganisationEntity.Create(
+            ValidName,
+            ValidAddress,
+            OrganisationType.Healthcare,
+            ValidAdminEmail);
+
+        var act = () => org.SetQueueNotificationThreshold(threshold);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Queue notification threshold must be between 1 and 50.");
+    }
+
     // ── Organisation.Create — validation failures ─────────────────────────────
 
     [Theory]

--- a/tests/NextTurn.UnitTests/Domain/Queue/QueueTurnNotificationAuditLogTests.cs
+++ b/tests/NextTurn.UnitTests/Domain/Queue/QueueTurnNotificationAuditLogTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using NextTurn.Domain.Queue.Entities;
+
+namespace NextTurn.UnitTests.Domain.Queue;
+
+public sealed class QueueTurnNotificationAuditLogTests
+{
+    [Fact]
+    public void Sent_CreatesSuccessfulAuditRecord()
+    {
+        var organisationId = Guid.NewGuid();
+        var queueId = Guid.NewGuid();
+        var queueEntryId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var before = DateTimeOffset.UtcNow;
+
+        var log = QueueTurnNotificationAuditLog.Sent(
+            organisationId,
+            queueId,
+            queueEntryId,
+            userId,
+            positionInQueue: 2,
+            threshold: 3);
+
+        var after = DateTimeOffset.UtcNow;
+
+        log.Id.Should().NotBeEmpty();
+        log.OrganisationId.Should().Be(organisationId);
+        log.QueueId.Should().Be(queueId);
+        log.QueueEntryId.Should().Be(queueEntryId);
+        log.UserId.Should().Be(userId);
+        log.PositionInQueue.Should().Be(2);
+        log.Threshold.Should().Be(3);
+        log.DeliveryStatus.Should().Be("Sent");
+        log.ErrorMessage.Should().BeNull();
+        log.CreatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public void Failed_WithWhitespaceMessage_UsesDefaultMessage()
+    {
+        var log = QueueTurnNotificationAuditLog.Failed(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            positionInQueue: 4,
+            threshold: 5,
+            errorMessage: "   ");
+
+        log.DeliveryStatus.Should().Be("Failed");
+        log.ErrorMessage.Should().Be("Notification delivery failed.");
+    }
+
+    [Fact]
+    public void Failed_TrimsAndTruncatesErrorMessageTo500Characters()
+    {
+        var longMessage = " " + new string('x', 600) + " ";
+
+        var log = QueueTurnNotificationAuditLog.Failed(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            positionInQueue: 1,
+            threshold: 3,
+            errorMessage: longMessage);
+
+        log.DeliveryStatus.Should().Be("Failed");
+        log.ErrorMessage.Should().NotBeNull();
+        log.ErrorMessage!.Length.Should().Be(500);
+        log.ErrorMessage.Should().Be(new string('x', 500));
+    }
+}

--- a/tests/NextTurn.UnitTests/Infrastructure/Queue/QueuePerformanceExportServiceTests.cs
+++ b/tests/NextTurn.UnitTests/Infrastructure/Queue/QueuePerformanceExportServiceTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using FluentAssertions;
+using NextTurn.Application.Queue.Reports;
+using NextTurn.Infrastructure.Queue;
+
+namespace NextTurn.UnitTests.Infrastructure.Queue;
+
+public sealed class QueuePerformanceExportServiceTests
+{
+    private readonly QueuePerformanceExportService _service = new();
+
+    [Fact]
+    public void ExportCsv_IncludesSummaryFieldsAndPeakHours()
+    {
+        var report = new QueuePerformanceReportResult(
+            StartDate: new DateOnly(2026, 3, 1),
+            EndDate: new DateOnly(2026, 3, 31),
+            ServiceId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            OfficeId: null,
+            TotalServed: 27,
+            AverageWaitMinutes: 8.42,
+            PeakHours: new[]
+            {
+                new PeakHourSummary(9, 12),
+                new PeakHourSummary(10, 8),
+            });
+
+        var csvBytes = _service.ExportCsv(report);
+        var csv = Encoding.UTF8.GetString(csvBytes);
+
+        csv.Should().Contain("Metric,Value");
+        csv.Should().Contain("StartDate,2026-03-01");
+        csv.Should().Contain("EndDate,2026-03-31");
+        csv.Should().Contain("TotalServed,27");
+        csv.Should().Contain("AverageWaitMinutes,8.42");
+        csv.Should().Contain("PeakHour,ServedCount");
+        csv.Should().Contain("09:00-09:59,12");
+        csv.Should().Contain("10:00-10:59,8");
+    }
+
+    [Fact]
+    public void ExportCsv_WhenNoOptionalFilters_WritesAllMarker()
+    {
+        var report = new QueuePerformanceReportResult(
+            StartDate: new DateOnly(2026, 3, 1),
+            EndDate: new DateOnly(2026, 3, 31),
+            ServiceId: null,
+            OfficeId: null,
+            TotalServed: 0,
+            AverageWaitMinutes: 0,
+            PeakHours: Array.Empty<PeakHourSummary>());
+
+        var csvBytes = _service.ExportCsv(report);
+        var csv = Encoding.UTF8.GetString(csvBytes);
+
+        csv.Should().Contain("ServiceId,All");
+        csv.Should().Contain("OfficeId,All");
+    }
+}


### PR DESCRIPTION
## Summary
This PR delivers the NT-28 story by introducing an on-demand daily queue summary report for admin users.  
It adds backend query/aggregation logic, trend computation against previous day and previous week, secured API exposure, a React dashboard for generating and viewing the report, and supporting unit/integration tests.

## Problem Solved
Admins can now generate a daily operational snapshot that shows:
- Served count
- Skipped count
- No-show count  
for each office/service combination, plus trend deltas versus:
- Previous day
- Previous week

This supports faster monitoring and better staffing/service decisions.

## Scope of Changes

### 1. Application Layer
Added a full daily summary reporting slice:
- Query contract, handler, validator
- Daily summary domain contracts and result models
- Trend calculator for day/week comparisons
- Service interface for report generation

Also extended no-show command shape to support explicit audit attribution for accurate reporting.

### 2. Infrastructure Layer
Implemented daily summary aggregation service:
- Aggregates audit events by date, office, and service
- Computes served/skipped/no-show metrics
- Feeds trend calculator with current, previous day, and previous week buckets
- Wired through DI

### 3. Domain + Accuracy Fix
Extended queue action audit enum to include explicit no-show action, and updated no-show command handler to write a no-show audit record.  
This ensures no-show totals are measurable and reliable in reports.

### 4. API Layer
Added secured endpoint for on-demand daily summary generation:
- `GET /api/queues/reports/daily-summary`
- Access: OrgAdmin/SystemAdmin
- Accepts optional date (defaults to current UTC date)
- Returns totals, trends, and detailed office/service rows

### 5. Frontend (React)
Added Daily Queue Summary dashboard:
- Date picker + on-demand generate button
- Summary cards for totals with trend indicators
- Detailed table by office/service with trend context
- Admin navigation wiring and route setup
- API client contracts and request function for daily summary endpoint

### 6. Tests
Added/updated tests for correctness and regression safety:
- Unit tests for daily trend calculator behavior
- Unit test updates for no-show audit logging behavior
- Integration tests for endpoint data accuracy and role authorization

## Acceptance Criteria Mapping
- Report displays served, skipped, no-shows per office/service: 
- Shows trends compared to previous day/week: 
- Can be generated on-demand: 

## Definition of Done Mapping
- Implemented as scheduled or on-demand query:  (on-demand query delivered)
- Unit tests ≥80% coverage:  (targeted new logic covered; measured at 100% for new calculator/updated handler paths in targeted run)
- Integration tests for data accuracy:  (tests added)
- React UI to view summary: 
- Code reviewed and merged:  pending review/merge process
- Demo in sprint review:  pending process step
- Confluence updated:  pending process step
- No open bugs:  pending QA verification

## Validation Performed
- Solution build (`dotnet build`): Passed
- Frontend build (`npm run build`): Passed
- Targeted unit tests for NT-28 logic: Passed
- Integration test run: Test project compiles; execution in this environment is blocked by missing Docker/Testcontainers runtime

## Risk / Impact
- Low-to-medium risk, mostly additive feature work
- Main behavioral change outside reporting: explicit no-show action auditing
- Existing queue operations remain intact; reporting is admin-only and read-focused